### PR TITLE
make delete work

### DIFF
--- a/lib/octopussy/client.rb
+++ b/lib/octopussy/client.rb
@@ -203,7 +203,7 @@ module Octopussy
     def delete(repo, delete_token={})
       repo = Repo.new(repo)
       response = self.class.post("/repos/delete/#{repo.name}", :query => auth_params, :body => {:delete_token => delete_token})
-      Hashie::Mash.new(response).repository
+      Hashie::Mash.new(response)
     end
     
     def confirm_delete(repo, delete_token)


### PR DESCRIPTION
This is the change I had to make octopussy's delete work.  Here's the working monkeypatch from my script:

   http://github.com/vim-scripts/vim-scraper/blob/793d749251465e7f2334a7358f5f327b7342a47e/delete-repos
