### PR TITLE
Spelling error

### DIFF
--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -11,7 +11,7 @@ class RepoTest < Test::Unit::TestCase
       @repo.username.should == "pengwynn"
     end
 
-    should "repond to user and repo" do
+    should "respond to user and repo" do
       @repo.repo.should == "linkedin"
       @repo.user.should == "pengwynn"
     end


### PR DESCRIPTION
Just a spelling error. I was browsing through the specs (the documentation link is broken) and found this typo.
