### PR TITLE
Feature/accept oauth token

### DIFF
--- a/lib/octokit/client/authentication.rb
+++ b/lib/octokit/client/authentication.rb
@@ -14,6 +14,10 @@ module Octokit
       def authenticated?
         !authentication.empty?
       end
+
+      def oauthed?
+        !oauth_token.nil?
+      end
     end
   end
 end

--- a/lib/octokit/client/connection.rb
+++ b/lib/octokit/client/connection.rb
@@ -14,6 +14,8 @@ module Octokit
           :url => endpoint,
         }
 
+        options.merge!(:params => { :access_token => oauth_token }) if oauthed? && !authenticated?
+
         Faraday::Connection.new(options) do |connection|
           connection.adapter(adapter)
           connection.basic_auth authentication[:login], authentication[:password] if authenticated?

--- a/lib/octokit/configuration.rb
+++ b/lib/octokit/configuration.rb
@@ -3,18 +3,19 @@ require File.expand_path('../version', __FILE__)
 
 module Octokit
   module Configuration
-    VALID_OPTIONS_KEYS = [:adapter, :endpoint, :format, :login, :password, :proxy, :token, :user_agent, :version].freeze
+    VALID_OPTIONS_KEYS = [:adapter, :endpoint, :format, :login, :password, :proxy, :token, :oauth_token, :user_agent, :version].freeze
     VALID_FORMATS      = [:json, :xml, :yaml].freeze
 
-    DEFAULT_ADAPTER    = Faraday.default_adapter.freeze
-    DEFAULT_ENDPOINT   = 'https://github.com/'.freeze
-    DEFAULT_FORMAT     = :json.freeze
-    DEFAULT_LOGIN      = nil.freeze
-    DEFAULT_PASSWORD   = nil.freeze
-    DEFAULT_PROXY      = nil.freeze
-    DEFAULT_TOKEN      = nil.freeze
-    DEFAULT_USER_AGENT = "Octokit Ruby Gem #{Octokit::VERSION}".freeze
-    DEFAULT_VERSION    = 2
+    DEFAULT_ADAPTER     = Faraday.default_adapter.freeze
+    DEFAULT_ENDPOINT    = 'https://github.com/'.freeze
+    DEFAULT_FORMAT      = :json.freeze
+    DEFAULT_LOGIN       = nil.freeze
+    DEFAULT_PASSWORD    = nil.freeze
+    DEFAULT_PROXY       = nil.freeze
+    DEFAULT_TOKEN       = nil.freeze
+    DEFAULT_OAUTH_TOKEN = nil.freeze
+    DEFAULT_USER_AGENT  = "Octokit Ruby Gem #{Octokit::VERSION}".freeze
+    DEFAULT_VERSION     = 2
 
     attr_accessor *VALID_OPTIONS_KEYS
 
@@ -31,15 +32,16 @@ module Octokit
     end
 
     def reset
-      self.adapter    = DEFAULT_ADAPTER
-      self.endpoint   = DEFAULT_ENDPOINT
-      self.format     = DEFAULT_FORMAT
-      self.login      = DEFAULT_LOGIN
-      self.password   = DEFAULT_PASSWORD
-      self.proxy      = DEFAULT_PROXY
-      self.token      = DEFAULT_TOKEN
-      self.user_agent = DEFAULT_USER_AGENT
-      self.version    = DEFAULT_VERSION
+      self.adapter     = DEFAULT_ADAPTER
+      self.endpoint    = DEFAULT_ENDPOINT
+      self.format      = DEFAULT_FORMAT
+      self.login       = DEFAULT_LOGIN
+      self.password    = DEFAULT_PASSWORD
+      self.proxy       = DEFAULT_PROXY
+      self.token       = DEFAULT_TOKEN
+      self.oauth_token = DEFAULT_OAUTH_TOKEN
+      self.user_agent  = DEFAULT_USER_AGENT
+      self.version     = DEFAULT_VERSION
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -26,6 +26,8 @@ def github_url(url)
     url
   elsif @client && @client.authenticated?
     "https://pengwynn%2Ftoken:OU812@github.com/api/v#{Octokit.version}/#{Octokit.format}/#{url}"
+  elsif @client && @client.oauthed?
+    "https://github.com/api/v#{Octokit.version}/#{Octokit.format}/#{url}?access_token=#{@client.oauth_token}"
   else
     "https://github.com/api/v#{Octokit.version}/#{Octokit.format}/#{url}"
   end

--- a/test/octokit_test.rb
+++ b/test/octokit_test.rb
@@ -2,6 +2,18 @@ require File.expand_path(File.dirname(__FILE__) + '/helper')
 
 class OctokitTest < Test::Unit::TestCase
 
+  context "when oauthed" do
+    setup do
+      @client = Octokit::Client.new(:login => 'pengwynn', :oauth_token => 'OU812')
+    end
+    should "return full user info for the authenticated user" do
+      stub_get("user/show", "full_user.json")
+      user = @client.user
+      user.plan.name.should == 'free'
+      user.plan.space.should == 307200
+    end
+  end
+
   context "when authenticated" do
     setup do
       @client = Octokit::Client.new(:login => 'pengwynn', :token => 'OU812')


### PR DESCRIPTION
Allows use of an OAuth access token for authenticated API requests.

Usage: Octokit::Client.new(:login => 'login', :oauth_token => 'oauth_token')

Includes one simple test. I figure these will be clobbered by the 'rspec' branch soon.
