### PR TITLE
Feature/accept oauth token rspec

### DIFF
--- a/lib/octokit/client/authentication.rb
+++ b/lib/octokit/client/authentication.rb
@@ -14,6 +14,10 @@ module Octokit
       def authenticated?
         !authentication.empty?
       end
+      
+      def oauthed?
+        !oauth_token.nil?
+      end
     end
   end
 end

--- a/lib/octokit/client/connection.rb
+++ b/lib/octokit/client/connection.rb
@@ -14,6 +14,8 @@ module Octokit
           :url => endpoint,
         }
 
+        options.merge!(:params => { :access_token => oauth_token }) if oauthed? && !authenticated?
+
         Faraday::Connection.new(options) do |connection|
           connection.adapter(adapter)
           connection.basic_auth authentication[:login], authentication[:password] if authenticate and authenticated?

--- a/lib/octokit/configuration.rb
+++ b/lib/octokit/configuration.rb
@@ -3,18 +3,19 @@ require File.expand_path('../version', __FILE__)
 
 module Octokit
   module Configuration
-    VALID_OPTIONS_KEYS = [:adapter, :endpoint, :format, :login, :password, :proxy, :token, :user_agent, :version].freeze
+    VALID_OPTIONS_KEYS = [:adapter, :endpoint, :format, :login, :password, :proxy, :token, :oauth_token, :user_agent, :version].freeze
     VALID_FORMATS      = [:json, :xml, :yaml].freeze
 
-    DEFAULT_ADAPTER    = Faraday.default_adapter.freeze
-    DEFAULT_ENDPOINT   = 'https://github.com/'.freeze
-    DEFAULT_FORMAT     = :json.freeze
-    DEFAULT_LOGIN      = nil.freeze
-    DEFAULT_PASSWORD   = nil.freeze
-    DEFAULT_PROXY      = nil.freeze
-    DEFAULT_TOKEN      = nil.freeze
-    DEFAULT_USER_AGENT = "Octokit Ruby Gem #{Octokit::VERSION}".freeze
-    DEFAULT_VERSION    = 2
+    DEFAULT_ADAPTER     = Faraday.default_adapter.freeze
+    DEFAULT_ENDPOINT    = 'https://github.com/'.freeze
+    DEFAULT_FORMAT      = :json.freeze
+    DEFAULT_LOGIN       = nil.freeze
+    DEFAULT_PASSWORD    = nil.freeze
+    DEFAULT_PROXY       = nil.freeze
+    DEFAULT_TOKEN       = nil.freeze
+    DEFAULT_OAUTH_TOKEN = nil.freeze
+    DEFAULT_USER_AGENT  = "Octokit Ruby Gem #{Octokit::VERSION}".freeze
+    DEFAULT_VERSION     = 2
 
     attr_accessor *VALID_OPTIONS_KEYS
 
@@ -31,15 +32,16 @@ module Octokit
     end
 
     def reset
-      self.adapter    = DEFAULT_ADAPTER
-      self.endpoint   = DEFAULT_ENDPOINT
-      self.format     = DEFAULT_FORMAT
-      self.login      = DEFAULT_LOGIN
-      self.password   = DEFAULT_PASSWORD
-      self.proxy      = DEFAULT_PROXY
-      self.token      = DEFAULT_TOKEN
-      self.user_agent = DEFAULT_USER_AGENT
-      self.version    = DEFAULT_VERSION
+      self.adapter     = DEFAULT_ADAPTER
+      self.endpoint    = DEFAULT_ENDPOINT
+      self.format      = DEFAULT_FORMAT
+      self.login       = DEFAULT_LOGIN
+      self.password    = DEFAULT_PASSWORD
+      self.proxy       = DEFAULT_PROXY
+      self.token       = DEFAULT_TOKEN
+      self.oauth_token = DEFAULT_OAUTH_TOKEN
+      self.user_agent  = DEFAULT_USER_AGENT
+      self.version     = DEFAULT_VERSION
     end
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -58,6 +58,8 @@ def github_url(url)
     url
   elsif @client && @client.authenticated?
     "https://pengwynn%2Ftoken:OU812@github.com/api/v#{Octokit.version}/#{Octokit.format}/#{url}"
+  elsif @client && @client.oauthed?
+    "https://github.com/api/v#{Octokit.version}/#{Octokit.format}/#{url}?access_token=#{@client.oauth_token}"
   else
     "https://github.com/api/v#{Octokit.version}/#{Octokit.format}/#{url}"
   end


### PR DESCRIPTION
Feature for `rspec` branch.

Allows use of an OAuth access token for authenticated API requests.

**Usage:** `Octokit::Client.new(:login => 'login', :oauth_token => 'oauth_token')`

Feature for `master` here: https://github.com/pengwynn/octokit/pull/12
