### PR TITLE
response[:body] was returning a Hashie::Mash on line 30 in lib/faraday/raise_error.rb I just added an inspect to it. Not the prettiest thing, but I needed a fix this very second. Thaanks for your great effort on this wonderful gem.

### DIFF
--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -27,7 +27,7 @@ module Faraday
     end
 
     def error_message(response)
-      "#{response[:method].to_s.upcase} #{response[:url].to_s}: #{response[:status]}#{(': ' + response[:body]) if response[:body]}"
+      "#{response[:method].to_s.upcase} #{response[:url].to_s}: #{response[:status]}#{(': ' + response[:body].inspect) if response[:body]}"
     end
   end
 end

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -27,7 +27,7 @@ describe Faraday::Response do
       it "should raise #{exception.name} error" do
         lambda do
           @client.user('sferik')
-        end.should raise_error(exception)
+        end.should raise_error(exception,/.*/)
       end
     end
   end


### PR DESCRIPTION
failed: can't convert Hashie::Mash into String
 /home/xn/.rvm/gems/ruby-1.8.7-p302@clutch/gems/octokit-0.6.1/lib/faraday/raise_error.rb:30:in `+'
/home/xn/.rvm/gems/ruby-1.8.7-p302@clutch/gems/octokit-0.6.1/lib/faraday/raise_error.rb:30:in`error_message'
/home/xn/.rvm/gems/ruby-1.8.7-p302@clutch/gems/octokit-0.6.1/lib/faraday/raise_error.rb:13:in `on_complete'
/home/xn/.rvm/gems/ruby-1.8.7-p302@clutch/gems/faraday-0.6.0/lib/faraday/response.rb:9:in`call'
/home/xn/.rvm/gems/ruby-1.8.7-p302@clutch/gems/faraday-0.6.0/lib/faraday/response.rb:62:in `on_complete'

response[:body] was returning a Hashie::Mash
