### PR TITLE
Fixed generating error messages

### DIFF
--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -27,7 +27,7 @@ module Faraday
     end
 
     def error_message(response)
-      "#{response[:method].to_s.upcase} #{response[:url].to_s}: #{response[:status]}#{(': ' + response[:body]) if response[:body]}"
+      "#{response[:method].to_s.upcase} #{response[:url].to_s}: #{response[:status]}#{(': ' + response[:body][:error]) if response[:body]}"
     end
   end
 end


### PR DESCRIPTION
This is another fix for #17. A cleaner one in my opinion.

I don't know why this ever worked in the first place (I know it did), but GitHub returns errors like `{"error":"Not Found"}` &ndash; so this should be safe.

Sorry for the duplicate, though.
