### PR TITLE
Add test to cover `client.delete_repository!`

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -47,14 +47,14 @@ module Octokit
         if response.respond_to?(:delete_token)
           response['delete_token']
         else
-          response['repository']
+          response
         end
       end
       alias :delete_repo :delete_repository
 
       def delete_repository!(repo, options={})
-        response = post("api/v2/json/repos/delete/#{Repository.new(repo)}", options)
-        post("api/v2/json/repos/delete/#{Repository.new(repo)}", options.merge(:delete_token => response['delete_token']))['repository']
+        delete_token = post("api/v2/json/repos/delete/#{Repository.new(repo)}", options)
+        post("api/v2/json/repos/delete/#{Repository.new(repo)}", options.merge(:delete_token => delete_token))
       end
       alias :delete_repo! :delete_repository!
 

--- a/spec/fixtures/delete_failure.json
+++ b/spec/fixtures/delete_failure.json
@@ -1,0 +1,1 @@
+{"error":"sferik/rails_admin_failure Repository not found"}

--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -124,13 +124,26 @@ describe Octokit::Client::Repositories do
 
   end
 
-  describe ".delete_repository" do
+  describe ".delete_repository!" do
 
     it "should delete a repository" do
       stub_post("repos/delete/sferik/rails_admin").
-        to_return(:body => fixture("repository.json"))
-      repository = @client.delete_repository("sferik/rails_admin")
-      repository.name.should == "rails_admin"
+        to_return(:body => fixture("delete_token.json"))
+      stub_post("repos/delete/sferik/rails_admin").
+        with(:delete_token => "uhihwkkkzu").
+        to_return(:status => 204)
+      @client.delete_repo!("sferik/rails_admin")
+    end
+
+  end
+
+  describe ".delete_repository" do
+
+    it "should return an error for non-existant repo" do
+      stub_post("repos/delete/sferik/rails_admin_failure").
+        to_return(:body => fixture("delete_failure.json"))
+      response = @client.delete_repository("sferik/rails_admin_failure")
+      response.error.should == "sferik/rails_admin_failure Repository not found"
     end
 
   end


### PR DESCRIPTION
Refactor to return error as part of response
Add fixture file

Test coverage up to 99.7%
