### PR TITLE
POST and PUT failures

### DIFF
--- a/lib/octokit/client/connection.rb
+++ b/lib/octokit/client/connection.rb
@@ -17,6 +17,7 @@ module Octokit
         options.merge!(:params => { :access_token => oauth_token }) if oauthed? && !authenticated?
 
         con = Faraday::Connection.new(options) do |connection|
+          connection.use Faraday::Request::UrlEncoded
           connection.use Faraday::Response::RaiseError
           unless raw
             connection.use Faraday::Response::Rashify


### PR DESCRIPTION
It looks like POSTs and PUTs with bodies are failing because we're not URL-encoding the hash parameters beforehand. So Faraday is asking for things like `bytesize` from the parameter hash.

The simple addition of Faraday's URL-encoding middleware seems to have fixed it right up. I'm unsure of the best way to test this, as it seems webmock is a jumping in a tad early and not letting requests make their way through the middleware. I'm not sure on that though.

At any rate, "real world" testing is working for me. Namely the `add_keys` method. Hope that helps!
