### PR TITLE
Add `update_milestone` method for Milestones

### DIFF
--- a/lib/octokit/client/milestones.rb
+++ b/lib/octokit/client/milestones.rb
@@ -51,6 +51,24 @@ module Octokit
         post("/repos/#{Repository.new(repository)}/milestones", options.merge({:title => title}), 3)
       end
 
+      # Update a milestone for a repository
+      #
+      # @param repository [String, Repository, Hash] A GitHub repository.
+      # @param number [String, Integer] Number ID of a milestone
+      # @param options [Hash] A customizable set of options.
+      # @option options [String] :title A unique title.
+      # @option options [String] :state (open) State: <tt>open</tt> or <tt>closed</tt>.
+      # @option options [String] :description A meaningful description
+      # @option options [Time] :due_on Set if the milestone has a due date
+      # @return [Milestone] A single milestone object
+      # @see http://developer.github.com/v3/issues/milestones/#update-a-milestone
+      # @example Update a milestone for a repository
+      #   Octokit.update_milestone("pengwynn/octokit", 1, {:description => 'Add support for v3 of Github API'})
+      def update_milestone(repository, number, options={})
+        post("/repos/#{Repository.new(repository)}/milestones/#{number}", options, 3)
+      end
+      alias :edit_milestone :update_milestone
+
       # Delete a single milestone for a repository
       #
       # @param repository [String, Repository, Hash] A GitHub repository.

--- a/spec/octokit/client/milestones_spec.rb
+++ b/spec/octokit/client/milestones_spec.rb
@@ -43,6 +43,19 @@ describe Octokit::Client::Milestones do
 
   end
 
+  describe ".update_milestone" do
+
+    it "should update a milestone" do
+       stub_request(:post, "https://api.github.com/repos/pengwynn/octokit/milestones/1").
+         with(:body => "{\"description\":\"Add support for API v3\"}", 
+              :headers => {'Accept'=>'*/*', 'Content-Type'=>'application/json'}).
+         to_return(:status => 200, :body => fixture('v3/milestone.json'))
+      milestone = @client.update_milestone("pengwynn/octokit", 1, {:description => "Add support for API v3"})
+      milestone.description.should == "Add support for API v3"
+    end
+
+  end
+
   describe ".delete_milestone" do
 
     it "should delete a milestone from a repository" do


### PR DESCRIPTION
Note: Faraday doesn't support `PATCH`, at least not that I could see.

According to the documentation (
http://developer.github.com/v3/#http-verbs ), we can use `POST` instead.
