### PR TITLE
Update `update_milestone` method to use `HTTP PATCH`

### DIFF
--- a/lib/octokit/client/milestones.rb
+++ b/lib/octokit/client/milestones.rb
@@ -65,7 +65,7 @@ module Octokit
       # @example Update a milestone for a repository
       #   Octokit.update_milestone("pengwynn/octokit", 1, {:description => 'Add support for v3 of Github API'})
       def update_milestone(repository, number, options={})
-        post("/repos/#{Repository.new(repository)}/milestones/#{number}", options, 3)
+        patch("/repos/#{Repository.new(repository)}/milestones/#{number}", options, 3)
       end
       alias :edit_milestone :update_milestone
 

--- a/lib/octokit/client/request.rb
+++ b/lib/octokit/client/request.rb
@@ -9,6 +9,10 @@ module Octokit
         request(:post, path, options, version, authenticate, raw)
       end
 
+      def patch(path, options={}, version=api_version, authenticate=true, raw=false)
+        request(:patch, path, options, version, authenticate, raw)
+      end
+
       def put(path, options={}, version=api_version, authenticate=true, raw=false)
         request(:put, path, options, version, authenticate, raw)
       end
@@ -24,7 +28,7 @@ module Octokit
           case method
           when :get, :delete
             request.url(path, options)
-          when :post, :put
+          when :post, :patch, :put
             request.path = path
             if version >= 3
               request.body = options.to_json unless options.empty?

--- a/spec/octokit/client/milestones_spec.rb
+++ b/spec/octokit/client/milestones_spec.rb
@@ -46,7 +46,7 @@ describe Octokit::Client::Milestones do
   describe ".update_milestone" do
 
     it "should update a milestone" do
-       stub_request(:post, "https://api.github.com/repos/pengwynn/octokit/milestones/1").
+       stub_request(:patch, "https://api.github.com/repos/pengwynn/octokit/milestones/1").
          with(:body => "{\"description\":\"Add support for API v3\"}", 
               :headers => {'Accept'=>'*/*', 'Content-Type'=>'application/json'}).
          to_return(:status => 200, :body => fixture('v3/milestone.json'))


### PR DESCRIPTION
Update `Milestone::update_milestone` to use `:patch` method, instead of `:post`

**Note:** Faraday is a runtime dependency (~0.6.0), so Faraday itself needs a new release to be able to grab the update mentioned below

See Faraday update here:
https://github.com/technoweenie/faraday/commit/2343a4e98fdbce3f95e0968083f7bbe92c52b9f6

Discussion here:
https://github.com/pengwynn/octokit/pull/35
