### PR TITLE
Add 'issue' parameter to `Pull::create_pull_request`

### DIFF
--- a/lib/octokit/client/pulls.rb
+++ b/lib/octokit/client/pulls.rb
@@ -11,6 +11,15 @@ module Octokit
         post("api/v2/json/pulls/#{Repository.new(repo)}", options.merge({:pull => pull}))['pulls']
       end
 
+      def create_pull_request_for_issue(repo, base, head, issue, options={})
+        pull = {
+          :base  => base,
+          :head  => head,
+          :issue => issue
+        }
+        post("api/v2/json/pulls/#{Repository.new(repo)}", options.merge({:pull => pull}))['pulls']
+      end
+
       def pull_requests(repo, state='open', options={})
         get("api/v2/json/pulls/#{Repository.new(repo)}/#{state}", options)['pulls']
       end

--- a/spec/octokit/client/pulls_spec.rb
+++ b/spec/octokit/client/pulls_spec.rb
@@ -19,6 +19,18 @@ describe Octokit::Client::Pulls do
 
   end
 
+  describe ".create_pull_request_for_issue" do
+
+    it "should create a pull request and attach it to an existing issue" do
+      stub_post("pulls/pengwynn/octokit").
+        with(:pull => {:base => "master", :head => "pengwynn:master", :issue => "34"}).
+        to_return(:body => fixture("v2/pulls.json"))
+      issues = @client.create_pull_request_for_issue("pengwynn/octokit", "master", "pengwynn:master", "34")
+      issues.first.number.should == 251
+    end
+
+  end
+
   describe ".pull_requests" do
 
     it "should return all pull requests" do


### PR DESCRIPTION
You can associate a pull request with an pre-existing issue via the [API](http://develop.github.com/p/pulls.html).  It should be used **in place of** `title` and `body` ( at least that's my interpretation )   

[Example from StackOverflow](http://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github/4529172#4529172)
