### PR TITLE
Support case where Github returns an array in the response error.

### DIFF
--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -27,7 +27,11 @@ module Faraday
     end
 
     def error_message(response)
-      "#{response[:method].to_s.upcase} #{response[:url].to_s}: #{response[:status]}#{(': ' + response[:body][:error]) if response[:body]}"
+      error = if response[:body]
+        error = response[:body][:error]
+        error = error.join(", ") if error.is_a?(Array)
+      end
+      "#{response[:method].to_s.upcase} #{response[:url].to_s}: #{response[:status]}#{(': ' + error) if error}"
     end
   end
 end

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -31,4 +31,32 @@ describe Faraday::Response do
       end
     end
   end
+
+  context "when response[:body][:error] is a string" do
+
+    before do
+      stub_get('user/show/sferik').
+        to_return(:status => 403, :body=>"{\"error\":\"error\"}")
+    end
+
+    it "should raise exception without error" do
+      lambda do
+        @client.user('sferik')
+      end.should raise_error(Octokit::Forbidden)
+    end
+  end
+
+  context "when response[:body][:error] is an array" do
+
+    before do
+      stub_get('user/show/sferik').
+        to_return(:status => 403, :body=>"{\"error\":[\"a\",\"v\"]}")
+    end
+
+    it "should raise exception without error" do
+      lambda do
+        @client.user('sferik')
+      end.should raise_error(Octokit::Forbidden)
+    end
+  end
 end


### PR DESCRIPTION
Hi Guys,

Github seems to return an array now (didn't use to?) on the API Rate Limit error response, maybe others. This was causing an exception in Octokits' Faraday::Response::Response#error_message method, which was expecting the response[:body][:error] value to support #to_s.

I have created a patch with tests that supports arrays in the response error value from Github.  Please review my patch and consider merging into master.

Cheers,
Bill

ps.  @pengwynn - We met at SXSW at the Gingerman through Adam Michela.  I didn't make it to Oklahoma after all and thus missed the Red Dirt Ruby conf.  Hope it was a huge success!
