### PR TITLE
Modify method signature for Pub Sub Hubbub methods

### DIFF
--- a/lib/octokit/client/pub_sub_hubbub/service_hooks.rb
+++ b/lib/octokit/client/pub_sub_hubbub/service_hooks.rb
@@ -13,8 +13,8 @@ module Octokit
         # @example Subscribe to push events to one of your repositories to Travis-CI
         #    client = Octokit::Client.new(:oauth_token = "token")
         #    client.subscribe_service_hook('joshk', 'device_imapable', 'Travis', { :token => "test", :domain => "domain", :user => "user" })
-        def subscribe_service_hook(owner, repository, service_name, service_arguments = {})
-          topic = "https://github.com/#{owner}/#{repository}/events/push"
+        def subscribe_service_hook(repo, service_name, service_arguments = {})
+          topic = "https://github.com/#{Repository.new(repo)}/events/push"
           callback = "github://#{service_name}?#{service_arguments.collect{ |k,v| [ k,v ].join("=") }.join("&") }"
           subscribe(topic, callback)
           true
@@ -29,8 +29,8 @@ module Octokit
         # @example Subscribe to push events to one of your repositories to Travis-CI
         #    client = Octokit::Client.new(:oauth_token = "token")
         #    client.unsubscribe_service_hook('joshk', 'device_imapable', 'Travis')
-        def unsubscribe_service_hook(owner, repository, service_name)
-          topic = "https://github.com/#{owner}/#{repository}/events/push"
+        def unsubscribe_service_hook(repo, service_name)
+          topic = "https://github.com/#{Repository.new(repo)}/events/push"
           callback = "github://#{service_name}"
           unsubscribe(topic, callback)
           true

--- a/spec/octokit/client/pub_sub_hubbub/service_hooks_spec.rb
+++ b/spec/octokit/client/pub_sub_hubbub/service_hooks_spec.rb
@@ -18,7 +18,7 @@ describe Octokit::Client::PubSubHubbub::ServiceHooks do
         with(subscribe_request_body).
         to_return(:body => nil)
 
-      client.subscribe_service_hook("joshk", "completeness-fu", "Travis", { :token => 'travistoken' }).should == true
+      client.subscribe_service_hook("joshk/completeness-fu", "Travis", { :token => 'travistoken' }).should == true
       assert_requested :post, "https://api.github.com/hub?access_token=myfaketoken", :body => subscribe_request_body, :times => 1
     end
   end
@@ -37,7 +37,7 @@ describe Octokit::Client::PubSubHubbub::ServiceHooks do
         with(unsubscribe_request_body).
         to_return(:body => nil)
 
-      client.unsubscribe_service_hook("joshk", "completeness-fu", "Travis").should == true
+      client.unsubscribe_service_hook("joshk/completeness-fu", "Travis").should == true
       assert_requested :post, "https://api.github.com/hub?access_token=myfaketoken", :body => unsubscribe_request_body, :times => 1
     end
   end


### PR DESCRIPTION
Convert `subscribe_service_hook`, `unsubscribe_service_hook` to accept a single `Repository` parameter, instead of seperate `user`, `repository` parameters

See [this thread](https://github.com/pengwynn/octokit/commit/babb695e46eb000db90c72803b4ac6e39b16deae#commitcomment-454083)
