### PR TITLE
Fixed some spec describes

### DIFF
--- a/spec/octokit/client/commits_spec.rb
+++ b/spec/octokit/client/commits_spec.rb
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 require 'helper'
 
-describe Octokit::Client::Pulls do
+describe Octokit::Client::Commits do
 
   before do
     @client = Octokit::Client.new(:login => 'sferik')

--- a/spec/octokit/client/timelines_spec.rb
+++ b/spec/octokit/client/timelines_spec.rb
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 require 'helper'
 
-describe Octokit::Client::Users do
+describe Octokit::Client::Timelines do
 
   describe ".timeline" do
 


### PR DESCRIPTION
`commits_spec.rb` and `timelines_spec.rb` had the wrong module names in their `describe`s.
