### PR TITLE
delete_repository! doesn't work

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -52,7 +52,7 @@ module Octokit
       alias :delete_repo :delete_repository
 
       def delete_repository!(repo, options={})
-        delete_token = post("/api/v2/json/repos/delete/#{Repository.new(repo)}", options)
+        delete_token = delete_repository(repo, options)
         post("/api/v2/json/repos/delete/#{Repository.new(repo)}", options.merge(:delete_token => delete_token))
       end
       alias :delete_repo! :delete_repository!


### PR DESCRIPTION
The delete_repository! method doesn't seem to work. The delete_repository works okay.

On /lib/octokit/client/repositories.rb the following line

```
    delete_token = post("api/v2/json/repos/delete/#{Repository.new(repo)}", options)
```

should probably assign the :delete_token item of the hash, not the entire hash to the delete_token value. See how delete_repository method works.
