### PR TITLE
Suppress ruby warnings

### DIFF
--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -19,7 +19,7 @@ require 'octokit/client/users'
 
 module Octokit
   class Client
-    attr_accessor *Configuration::VALID_OPTIONS_KEYS
+    attr_accessor(*Configuration::VALID_OPTIONS_KEYS)
 
     def initialize(options={})
       options = Octokit.options.merge(options)

--- a/lib/octokit/configuration.rb
+++ b/lib/octokit/configuration.rb
@@ -22,7 +22,7 @@ module Octokit
     DEFAULT_OAUTH_TOKEN = nil
     DEFAULT_USER_AGENT  = "Octokit Ruby Gem #{Octokit::VERSION}".freeze
 
-    attr_accessor *VALID_OPTIONS_KEYS
+    attr_accessor(*VALID_OPTIONS_KEYS)
 
     def self.extended(base)
       base.reset


### PR DESCRIPTION
This pull request avoids the following warnings from being logged, which happens whenever the octokit library is used in your own ruby script:

```
.../lib/octokit/configuration.rb:25: warning: `*' interpreted as argument prefix
.../lib/octokit/client.rb:22: warning: `*' interpreted as argument prefix
```

This is done by helping out the ruby interpreter with some parentheses.

**Please note:** as this isn't a functional fix or enhancement, there is no new spec for this pull request... however, all existing specs _(obviously)_ still run.
