### PR TITLE
POST request to add deploy key API now correctly sends title and key in t

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -1,4 +1,4 @@
-,module Octokit
+module Octokit
   class Client
     module Repositories
       def search_repositories(q, options={})


### PR DESCRIPTION
POST request to add deploy key API now correctly sends title and key in the request body.  
