### PR TITLE
Performance improvement for Repository#slug

### DIFF
--- a/lib/octokit/repository.rb
+++ b/lib/octokit/repository.rb
@@ -22,7 +22,7 @@ module Octokit
     end
 
     def slug
-      [@username, @name].compact.join('/')
+      "#{@username}/#{@name}"
     end
 
     def to_s


### PR DESCRIPTION
The impact is most likely minimal, but why not squeeze a few milliseconds out of it.

Benchmark:

``` ruby
require 'benchmark'

@username = 'koraktor'
@name = 'metior'

Benchmark.bmbm do |bm|
  bm.report { 1000000.times { [@username, @name].compact.join('/') } }
  bm.report { 1000000.times { "#{@username}/#{@name}" } }
end
```

Result (Ruby 1.9.2):

```
Rehearsal ------------------------------------
   0.940000   0.000000   0.940000 (  0.939449)
   0.420000   0.000000   0.420000 (  0.413283)
--------------------------- total: 1.360000sec

       user     system      total        real
   0.950000   0.000000   0.950000 (  0.958496)
   0.410000   0.000000   0.410000 (  0.418962)
```
