### PR TITLE
Add spec test for creating a repo for an organization

### DIFF
--- a/spec/fixtures/v3/organization-repository.json
+++ b/spec/fixtures/v3/organization-repository.json
@@ -1,0 +1,42 @@
+{
+  "integrate_branch": null,
+  "created_at": "2011-10-31T15:14:28Z",
+  "forks": 1,
+  "has_issues": true,
+  "svn_url": "https://svn.github.com/CoMoRichWebGroup/demo",
+  "homepage": null,
+  "git_url": "git://github.com/CoMoRichWebGroup/demo.git",
+  "open_issues": 0,
+  "language": null,
+  "mirror_url": null,
+  "has_downloads": true,
+  "fork": false,
+  "watchers": 1,
+  "private": false,
+  "clone_url": "https://github.com/CoMoRichWebGroup/demo.git",
+  "size": 0,
+  "updated_at": "2011-10-31T15:14:28Z",
+  "master_branch": null,
+  "pushed_at": null,
+  "owner": {
+    "url": "https://api.github.com/users/CoMoRichWebGroup",
+    "login": "CoMoRichWebGroup",
+    "id": 570695,
+    "gravatar_id": "073de5791bd35c95a6eb211ba244df0e",
+    "avatar_url": "https://secure.gravatar.com/avatar/073de5791bd35c95a6eb211ba244df0e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-orgs.png"
+  },
+  "name": "demo",
+  "url": "https://api.github.com/repos/CoMoRichWebGroup/demo",
+  "has_wiki": true,
+  "organization": {
+    "url": "https://api.github.com/users/CoMoRichWebGroup",
+    "login": "CoMoRichWebGroup",
+    "id": 570695,
+    "gravatar_id": "073de5791bd35c95a6eb211ba244df0e",
+    "avatar_url": "https://secure.gravatar.com/avatar/073de5791bd35c95a6eb211ba244df0e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-orgs.png"
+  },
+  "ssh_url": "git@github.com:CoMoRichWebGroup/demo.git",
+  "description": null,
+  "id": 2681446,
+  "html_url": "https://github.com/CoMoRichWebGroup/demo"
+}

--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -109,6 +109,15 @@ describe Octokit::Client::Repositories do
       repository.name.should == "rails_admin"
     end
 
+    it "should create a repository for an organization" do
+      stub_post("/orgs/comorichwebgroup/repos").
+        with(:name => "demo").
+        to_return(:body => fixture("v3/organization-repository.json"))
+      repository = @client.create_repository("demo", {:organization => 'comorichwebgroup'})
+      repository.name.should == "demo"
+      repository.organization.login.should == "CoMoRichWebGroup"
+    end
+
   end
 
   describe ".delete_repository" do


### PR DESCRIPTION
Adding a test to cover the case where creating a repo for an organization, instead of a normal user. Added a new fixture, which has the `organization` section you get in return.

Test coverage from 99.76% to 99.84%, hooray! 
