### PR TITLE
Be sure to symbolize keys from error responses

### DIFF
--- a/lib/faraday/response/raise_octokit_error.rb
+++ b/lib/faraday/response/raise_octokit_error.rb
@@ -31,7 +31,9 @@ module Faraday
 
     def error_message(response)
       message = if body = response[:body]
-        body = ::MultiJson.decode(body) if body.is_a? String
+        if body.is_a? String
+          body = ::MultiJson.decode body, :symbolize_keys => true
+        end
         ": #{body[:error] || body[:message] || ''}"
       else
         ''


### PR DESCRIPTION
As noted by @glenngillen in commit 4f8c13bd7d4ab5cf029f157e9ccdaaee29ea8462.
