### PR TITLE
Change to use maximum number of items per page during autotraversal

### DIFF
--- a/lib/octokit/configuration.rb
+++ b/lib/octokit/configuration.rb
@@ -11,7 +11,8 @@ module Octokit
       :proxy,
       :oauth_token,
       :user_agent,
-      :auto_traversal].freeze
+      :auto_traversal,
+      :per_page].freeze
 
     DEFAULT_ADAPTER        = Faraday.default_adapter
     DEFAULT_API_VERSION    = 3

--- a/lib/octokit/request.rb
+++ b/lib/octokit/request.rb
@@ -28,6 +28,10 @@ module Octokit
       response = connection(authenticate, raw, version, force_urlencoded).send(method) do |request|
         case method
         when :delete, :get
+          if auto_traversal && per_page.nil?
+            self.per_page = 100
+          end
+          options.merge!(:per_page => per_page) if per_page
           request.url(path, options)
         when :patch, :post, :put
           request.path = path

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -10,19 +10,37 @@ describe Octokit::Client do
     }.should_not raise_exception
   end
 
-  it "should traverse a paginated response if auto_traversal is on" do
-    stub_get("https://api.github.com/foo/bar").
-      to_return(:status => 200, :body => %q{["stuff"]}, :headers => 
-        { 'Link' => %q{<https://api.github.com/foo/bar?page=2>; rel="next", <https://api.github.com/foo/bar?page=3>; rel="last"} })
 
-    stub_get("https://api.github.com/foo/bar?page=2").
-      to_return(:status => 200, :body => %q{["even more stuff"]}, :headers => 
-        { 'Link' => %q{<https://api.github.com/foo/bar?page=3>; rel="next", <https://api.github.com/foo/bar?page=3>; rel="last", <https://api.github.com/foo/bar?page=1>; rel="prev", <https://api.github.com/foo/bar?page=1>; rel="first"} })
+  describe "auto_traversal" do
 
-    stub_get("https://api.github.com/foo/bar?page=3").
-      to_return(:status => 200, :body => %q{["stuffapalooza"]}, :headers => 
-        { 'Link' => %q{<https://api.github.com/foo/bar?page=2>; rel="prev", <https://api.github.com/foo/bar?page=1>; rel="first"} })
+    it "should traverse a paginated response using the maximum allowed number of items per page" do
+      stub_get("https://api.github.com/foo/bar?per_page=100").
+        to_return(:status => 200, :body => %q{["stuff"]}, :headers =>
+          { 'Link' => %q{<https://api.github.com/foo/bar?page=2>; rel="next", <https://api.github.com/foo/bar?page=3>; rel="last"} })
 
-    Octokit::Client.new(:auto_traversal => true).get("https://api.github.com/foo/bar", {}, 3).should == ['stuff', 'even more stuff', 'stuffapalooza']
+      stub_get("https://api.github.com/foo/bar?page=2&per_page=100").
+        to_return(:status => 200, :body => %q{["even more stuff"]}, :headers =>
+          { 'Link' => %q{<https://api.github.com/foo/bar?page=3>; rel="next", <https://api.github.com/foo/bar?page=3>; rel="last", <https://api.github.com/foo/bar?page=1>; rel="prev", <https://api.github.com/foo/bar?page=1>; rel="first"} })
+
+      stub_get("https://api.github.com/foo/bar?page=3&per_page=100").
+        to_return(:status => 200, :body => %q{["stuffapalooza"]}, :headers =>
+          { 'Link' => %q{<https://api.github.com/foo/bar?page=2>; rel="prev", <https://api.github.com/foo/bar?page=1>; rel="first"} })
+
+      Octokit::Client.new(:auto_traversal => true).get("https://api.github.com/foo/bar", {}, 3).should == ['stuff', 'even more stuff', 'stuffapalooza']
+    end
+
+    it "should use the number set in the per_page configuration option when present" do
+      stub_get("https://api.github.com/foo/bar?per_page=50").
+        to_return(:status => 200, :body => %q{["stuff"]}, :headers =>
+          { 'Link' => %q{<https://api.github.com/foo/bar?page=2>; rel="next", <https://api.github.com/foo/bar?page=3>; rel="last"} })
+
+      stub_get("https://api.github.com/foo/bar?page=2&per_page=50").
+        to_return(:status => 200, :body => %q{["even more stuff"]}, :headers =>
+          { 'Link' => %q{<https://api.github.com/foo/bar?page=3>; rel="last", <https://api.github.com/foo/bar?page=1>; rel="prev", <https://api.github.com/foo/bar?page=1>; rel="first"} })
+
+      Octokit::Client.new(:auto_traversal => true, :per_page => 50).get("https://api.github.com/foo/bar", {}, 3).should
+    end
+
   end
+
 end


### PR DESCRIPTION
Added a per_page configuration option to allow overriding of default
setting of 30 items per_page. Autotraversal also defaults to using the
maximum allowed setting of 100 for API v3. This should speed up requests
while autotraversing and give better control to the client.
