### PR TITLE
Adds ratelimit functions to client.

### DIFF
--- a/lib/octokit/request.rb
+++ b/lib/octokit/request.rb
@@ -22,10 +22,6 @@ module Octokit
       request(:put, path, options, version, authenticate, raw, force_urlencoded)
     end
 
-    def head(path, options={}, version=api_version, authenticate=true, raw=true, force_urlencoded=false)
-      request(:head, path, options, version, authenticate, raw, force_urlencoded)
-    end
-
     def ratelimit
       # TODO: Switch over to head once github doesn't decrement counter on HEAD requests.
       headers = get("/rate_limit",{}, api_version, true, true).headers
@@ -59,9 +55,7 @@ module Octokit
         end
       end
 
-      if method == :head
-        response.headers
-      elsif raw
+      if raw
         response
       elsif auto_traversal && ( next_url = links(response)["next"] )
         response.body + request(method, next_url, options, version, authenticate, raw, force_urlencoded)


### PR DESCRIPTION
I feel like this is a nice simple thing missing from the client interface.

Example of code:

```
1.9.3-p194 :001 > require 'octokit'
 => true 
1.9.3-p194 :002 > Octokit.ratelimit_remaining
 => 4990 
1.9.3-p194 :003 > Octokit.ratelimit
 => 5000 
```

I'm not sure, but I think my implementation might return the wrong numbers when dealing with authentication. Anyways, I'd love your guys input and maybe even a pull.
