### PR TITLE
Update client/gist_spec to pass on 1.8.7

### DIFF
--- a/spec/octokit/client/gists_spec.rb
+++ b/spec/octokit/client/gists_spec.rb
@@ -72,7 +72,7 @@ describe Octokit::Client::Gists do
     it "should edit an existing gist" do
       gist_content = JSON.parse(fixture("v3/gist.json").read)
       gist_id = gist_content['id']
-      updated_gist = gist_content.merge(:description => 'updated')
+      updated_gist = gist_content.merge('description' => 'updated')
 
       stub_patch("/gists/#{gist_id}").
         to_return(:body => updated_gist)


### PR DESCRIPTION
I think there's an issue with 1.8.7 and our Hashie/Mash stuff. Here when we loaded the fixture and merged `:description` it was either not replacing the existing `'description'` on 1.8.7, or the Hashie/Mash was favoring this new symbol instead, where as on 1.8.7 it favored the existing `'description'`.

By merging the string version instead, specs should be passing again on 1.8.7 and rbx-18mode
