### PR TITLE
Added delete_repository

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -54,11 +54,10 @@ module Octokit
       alias :create_repo :create_repository
       alias :create :create_repository
 
-      def delete_repository(name, options={})
-        delete "repos/user/#{Repository.new repo}"
+      def delete_repository(repo, options={})
+        delete "/repos/#{Repository.new repo}", options, 3
       end
-      alias :delete :delete_repository
-      alias :delete_repo, :delete_repository
+      alias :delete_repo :delete_repository
 
       def set_private(repo, options={})
         update_repository repo, options.merge({ :private => true })

--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -120,6 +120,17 @@ describe Octokit::Client::Repositories do
 
   end
 
+  describe ".delete_repository" do
+
+    it "should delete a repository" do
+      stub_delete("/repos/sferik/rails_admin").
+        to_return(:status => 204, :body => "")
+      result = @client.delete_repository("sferik/rails_admin")
+      result.should be_nil
+    end
+
+  end
+
   describe ".set_private" do
 
     it "should set a repository private" do


### PR DESCRIPTION
Added the delete repository as requested in pengwynn/octokit#101 

I've tested it with ruby versions 1.9.3 and 1.8.7 and all seemed well.
