### PR TITLE
Faraday::Builder#adapter takes multiple args

### DIFF
--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -32,7 +32,7 @@ module Octokit
           builder.use FaradayMiddleware::Mashify
           builder.use FaradayMiddleware::ParseJson
         end
-        builder.adapter(adapter)
+        builder.adapter *adapter
       end
       connection.basic_auth authentication[:login], authentication[:password] if authenticate and authenticated?
       connection


### PR DESCRIPTION
enables adapters that take multiple arguments, i.e. the rack adapter.
