### PR TITLE
remove leading slashes in paths for enterprise use

### DIFF
--- a/lib/octokit/client/contents.rb
+++ b/lib/octokit/client/contents.rb
@@ -12,7 +12,7 @@ module Octokit
   # @example Get the readme file for a repo
   #   Octokit.readme("pengwynn/octokit")
   def readme(repo, options={})
-    get("/repos/#{Repository.new repo}/readme", options, 3)
+    get("repos/#{Repository.new repo}/readme", options, 3)
   end
 
   # Receive a listing of a repository folder or the contents of a file
@@ -26,7 +26,7 @@ module Octokit
   #   Octokit.contents("pengwynn/octokit", :path => 'lib/octokit.rb')
   def contents(repo, options={})
     repo_path = options.delete :path
-    url = "/repos/#{Repository.new repo}/contents/#{repo_path}"
+    url = "repos/#{Repository.new repo}/contents/#{repo_path}"
     get(url, options, 3)
   end
 
@@ -42,7 +42,7 @@ module Octokit
   def archive_link(repo, options={})
     repo_ref = options.delete :ref
     format = (options.delete :format) || 'tarball'
-    url = "/repos/#{Repository.new repo}/#{format}/#{repo_ref}"
+    url = "repos/#{Repository.new repo}/#{format}/#{repo_ref}"
     headers = get(url, options, 3, false, true).headers
     return headers['location']
   end

--- a/lib/octokit/client/markdown.rb
+++ b/lib/octokit/client/markdown.rb
@@ -14,7 +14,7 @@ module Octokit
       def markdown(text, options={})
         options[:text] = text
         options[:repo] = Repository.new(options[:repo]) if options[:repo]
-        post("/markdown", options, 3, true, true).body
+        post("markdown", options, 3, true, true).body
       end
 
     end

--- a/lib/octokit/request.rb
+++ b/lib/octokit/request.rb
@@ -23,13 +23,13 @@ module Octokit
     end
 
     def ratelimit
-      headers = get("/rate_limit",{}, api_version, true, true).headers
+      headers = get("rate_limit",{}, api_version, true, true).headers
       return headers["X-RateLimit-Limit"].to_i
     end
     alias rate_limit ratelimit
 
     def ratelimit_remaining
-      headers = get("/rate_limit",{}, api_version, true, true).headers
+      headers = get("rate_limit",{}, api_version, true, true).headers
       return headers["X-RateLimit-Remaining"].to_i
     end
     alias rate_limit_remaining ratelimit_remaining
@@ -37,6 +37,7 @@ module Octokit
     private
 
     def request(method, path, options, version, authenticate, raw, force_urlencoded)
+      path.sub(%r{^/}, '') #leading slash in path fails in github:enterprise
       response = connection(authenticate, raw, version, force_urlencoded).send(method) do |request|
         case method
         when :delete, :get


### PR DESCRIPTION
Main fix is in Request#request -- just strips the leading slash.
I also removed the leading slashes in existing calls.
I had considered doing this in spec/helper.rb, but couldn't get a
good error message.
module Octokit::Request
  alias :request_without_assert :request
  def request(method, path, options, version, authenticate, raw, force_urlencoded)
    path.start_with?('/').should == false #will fail in github:enterprise
    request_without_assert(method, path, options, version, authenticate, raw, force_urlencoded)
  end
end
