### PR TITLE
Allow overriding Host header

### DIFF
--- a/lib/octokit/configuration.rb
+++ b/lib/octokit/configuration.rb
@@ -15,6 +15,7 @@ module Octokit
       :client_id,
       :client_secret,
       :user_agent,
+      :request_host,
       :auto_traversal,
       :per_page].freeze
 
@@ -58,6 +59,7 @@ module Octokit
       self.oauth_token    = nil
       self.client_id      = nil
       self.client_secret  = nil
+      self.request_host   = nil
       self.user_agent     = DEFAULT_USER_AGENT
       self.auto_traversal = DEFAULT_AUTO_TRAVERSAL
     end

--- a/lib/octokit/request.rb
+++ b/lib/octokit/request.rb
@@ -54,6 +54,8 @@ module Octokit
             request.body = options unless options.empty?
           end
         end
+
+        request.headers['Host'] = Octokit.request_host if Octokit.request_host
       end
 
       if raw

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -106,5 +106,38 @@ describe Octokit::Client do
     end
   end
 
+  describe "request_host" do
+    after(:each) { Octokit.reset }
+
+    it "should default to nil" do
+      client = Octokit::Client.new
+      client.request_host.should be_nil
+    end
+
+    it "should be settable" do
+      Octokit.request_host = 'github.company.com'
+      client = Octokit::Client.new
+      client.request_host.should == 'github.company.com'
+    end
+
+    it "does not change the Host header when not set" do
+      Octokit.api_endpoint = 'http://github.internal'
+
+      stub_request(:any, /.*/)
+      req = stub_request(:get, 'http://github.internal/users/me').with(:headers => { 'Host' => /.*/})
+      Octokit.user "me"
+      req.should_not have_been_requested
+    end
+
+    it "changes the Host header when set" do
+      Octokit.api_endpoint = 'http://github.internal'
+      Octokit.request_host = 'github.company.com'
+
+      req = stub_request(:get, 'http://github.internal/users/me').with(:headers => { 'Host' => 'github.company.com' })
+      Octokit.user "me"
+      req.should have_been_requested
+    end
+  end
+
 
 end


### PR DESCRIPTION
This supports scenarios where the GHE instance is behind a proxy that
interferes with normal API functionality (e.g. authenticates with
OAuth).

In order to use the API when GHE is behind a proxy like that, you need
to hit it using a different (internal) hostname. However, as of version
11.10.280, GHE redirects all non-canonical hostname requests to the
canonical version. This breaks using a different hostname for API
requests.

This commit enables access using a different hostname by overriding the
Host header so that GHE does not perform the redirect.
