### PR TITLE
Fix Client#contributors method

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -111,7 +111,7 @@ module Octokit
       alias :repo_teams :repository_teams
       alias :teams :repository_teams
 
-      def contributors(repo, anon=false, options={})
+      def contributors(repo, anon=nil, options={})
         get "repos/#{Repository.new repo}/contributors", options.merge(:anon => anon), 3
       end
       alias :contribs :contributors

--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -270,7 +270,7 @@ describe Octokit::Client::Repositories do
     context "without anonymous users" do
 
       it "should return all repository contributors" do
-        stub_get("/repos/sferik/rails_admin/contributors?anon=false").
+        stub_get("/repos/sferik/rails_admin/contributors?anon").
           to_return(:body => fixture("v3/contributors.json"))
         contributors = @client.contributors("sferik/rails_admin")
         contributors.first.login.should == "sferik"


### PR DESCRIPTION
Currently github api returns anonymous users if we specify anything in anon parameter. 

Eg, `curl -L https://api.github.com/repos/rails/rails/contributors?anon=false` will return anonymous users.

But if we specify empty string, space or just omit value of anon parameter `Octokat.contributors('rais/rails')` will return expected users.

This pull request changes `#contributors` query from `?anon=false` to `?anon` so method will return expected result.

If you wish we can clean up query from anon parameter in this case completely.
