### PR TITLE
Expose faraday config in Octokit.configure

### DIFF
--- a/lib/octokit/configuration.rb
+++ b/lib/octokit/configuration.rb
@@ -5,6 +5,7 @@ module Octokit
   module Configuration
     VALID_OPTIONS_KEYS = [
       :adapter,
+      :faraday_config_block,
       :api_version,
       :api_endpoint,
       :web_endpoint,
@@ -46,6 +47,10 @@ module Octokit
 
     def web_endpoint=(value)
       @web_endpoint = File.join(value, "")
+    end
+
+    def faraday_config(&block)
+      @faraday_config_block = block
     end
 
     def reset

--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -28,13 +28,19 @@ module Octokit
         else
           builder.request :url_encoded
         end
+
         builder.use Faraday::Response::RaiseOctokitError
+
         unless raw
           builder.use FaradayMiddleware::Mashify
           builder.use FaradayMiddleware::ParseJson
         end
+
+        faraday_config_block.call(builder) if faraday_config_block
+
         builder.adapter *adapter
       end
+
       connection.basic_auth authentication[:login], authentication[:password] if authenticate and authenticated?
       connection
     end

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -10,6 +10,19 @@ describe Octokit::Client do
     }.should_not raise_exception
   end
 
+  it 'should configure faraday from faraday_config_block' do
+    mw_evaluated = false
+    Octokit.configure do |c|
+      c.faraday_config { |f| mw_evaluated = true }
+    end
+    stub_request(:get, "https://api.github.com/rate_limit").
+      to_return(:status => 200, :body => '', :headers =>
+                { 'X-RateLimit-Limit' => 5000, 'X-RateLimit-Remaining' => 5000})
+    client = Octokit::Client.new()
+    client.rate_limit
+    mw_evaluated.should be_true
+  end
+
 
   describe "auto_traversal" do
 


### PR DESCRIPTION
I want to add things to the Faraday middleware (cache, instrumentation, logging) so expose the Faraday config in the Octokit config.

Also acceptable would be to expose all those things in Octokit explicitly, since it seems like it would be useful.
