### PR TITLE
Implement tag api. #145.

### DIFF
--- a/lib/octokit/client/objects.rb
+++ b/lib/octokit/client/objects.rb
@@ -75,6 +75,60 @@ module Octokit
         }
         post("repos/#{Repository.new(repo)}/git/blobs", options.merge(parameters), 3).sha
       end
+
+      # Get a tag
+      #
+      # @param repo [String, Hash, Repository] A GitHub repository.
+      # @param tag_sha [String] The SHA of the tag to fetch.
+      # @return [Hashie::Mash] Hash representing the tag.
+      # @see http://developer.github.com/v3/git/tags/#get-a-tag
+      # @example Fetch a tag
+      #   Octokit.tag('pengwynn/octokit', '23aad20633f4d2981b1c7209a800db3014774e96')
+      def tag(repo, tag_sha, options={})
+        get("repos/#{Repository.new repo}/git/tags/#{tag_sha}", options, 3)
+      end
+
+      # Create a tag
+      #
+      # Requires authenticated client.
+      #
+      # @param repo [String, Hash, Repository] A GitHub repository.
+      # @param tag [String] Tag string.
+      # @param message [String] Tag message.
+      # @param object_sha [String] SHA of the git object this is tagging.
+      # @param type [String] Type of the object we're tagging. Normally this is
+      #   a `commit` but it can also be a `tree` or a `blob`.
+      # @param tagger_name [String] Name of the author of the tag.
+      # @param tagger_email [String] Email of the author of the tag.
+      # @param tagger_date [string] Timestamp of when this object was tagged.
+      # @return [Hashie::Mash] Hash representing new tag.
+      # @see Octokit::Client
+      # @see http://developer.github.com/v3/git/tags/#create-a-tag-object
+      # @example
+      #   @client.create_tag(
+      #     "pengwynn/octokit",
+      #     "v9000.0.0",
+      #     "Version 9000\n",
+      #     "f4cdf6eb734f32343ce3f27670c17b35f54fd82e",
+      #     "commit",
+      #     "Wynn Netherland",
+      #     "wynn.netherland@gmail.com",
+      #     "2012-06-03T17:03:11-07:00"
+      #   )
+      def create_tag(repo, tag, message, object_sha, type, tagger_name, tagger_email, tagger_date, options={})
+        options.merge!(
+          :tag => tag,
+          :message => message,
+          :object => object_sha,
+          :type => type,
+          :tagger => {
+            :name => tagger_name,
+            :email => tagger_email,
+            :date => tagger_date
+          }
+        )
+        post("repos/#{Repository.new repo}/git/tags", options, 3)
+      end
     end
   end
 end

--- a/spec/fixtures/v3/tag.json
+++ b/spec/fixtures/v3/tag.json
@@ -1,0 +1,16 @@
+{
+  "tagger": {
+    "date": "2012-06-03T17:03:11-07:00",
+    "name": "Wynn Netherland",
+    "email": "wynn.netherland@gmail.com"
+  },
+  "message": "Version 1.4.0\n",
+  "object": {
+    "type": "commit",
+    "url": "https://api.github.com/repos/pengwynn/octokit/git/commits/f4cdf6eb734f32343ce3f27670c17b35f54fd82e",
+    "sha": "f4cdf6eb734f32343ce3f27670c17b35f54fd82e"
+  },
+  "url": "https://api.github.com/repos/pengwynn/octokit/git/tags/23aad20633f4d2981b1c7209a800db3014774e96",
+  "sha": "23aad20633f4d2981b1c7209a800db3014774e96",
+  "tag": "v1.4.0"
+}

--- a/spec/fixtures/v3/tag_create.json
+++ b/spec/fixtures/v3/tag_create.json
@@ -1,0 +1,16 @@
+{
+  "tagger": {
+    "date": "2012-06-03T17:03:11-07:00",
+    "name": "Wynn Netherland",
+    "email": "wynn.netherland@gmail.com"
+  },
+  "message": "Version 9000\n",
+  "object": {
+    "type": "commit",
+    "url": "https://api.github.com/repos/pengwynn/octokit/git/commits/f4cdf6eb734f32343ce3f27670c17b35f54fd82e",
+    "sha": "f4cdf6eb734f32343ce3f27670c17b35f54fd82e"
+  },
+  "url": "https://api.github.com/repos/pengwynn/octokit/git/tags/23aad20633f4d2981b1c7209a800db3014774e96",
+  "sha": "23aad20633f4d2981b1c7209a800db3014774e96",
+  "tag": "v9000.0.0"
+}

--- a/spec/octokit/client/objects_spec.rb
+++ b/spec/octokit/client/objects_spec.rb
@@ -58,4 +58,52 @@ describe Octokit::Client::Objects do
 
   end
 
+  describe ".tag" do
+
+    it "returns a tag" do
+      stub_get("/repos/pengwynn/octokit/git/tags/23aad20633f4d2981b1c7209a800db3014774e96").
+        to_return(:body => fixture("v3/tag.json"))
+      tag = @client.tag("pengwynn/octokit", "23aad20633f4d2981b1c7209a800db3014774e96")
+      expect(tag.sha).to eq("23aad20633f4d2981b1c7209a800db3014774e96")
+      expect(tag.message).to eq("Version 1.4.0\n")
+      expect(tag.tag).to eq("v1.4.0")
+    end
+
+  end
+
+  describe ".create_tag" do
+
+    it "creates a tag" do
+      stub_post("/repos/pengwynn/octokit/git/tags").
+        with(:body => {
+                :tag => "v9000.0.0",
+                :message => "Version 9000\n",
+                :object => "f4cdf6eb734f32343ce3f27670c17b35f54fd82e",
+                :type => "commit",
+                :tagger => {
+                  :name => "Wynn Netherland",
+                  :email => "wynn.netherland@gmail.com",
+                  :date => "2012-06-03T17:03:11-07:00"
+                }
+              },
+            :headers => { "Content-Type" => "application/json" }).
+              to_return(:body => fixture("v3/tag_create.json"))
+      tag = @client.create_tag(
+        "pengwynn/octokit",
+        "v9000.0.0",
+        "Version 9000\n",
+        "f4cdf6eb734f32343ce3f27670c17b35f54fd82e",
+        "commit",
+        "Wynn Netherland",
+        "wynn.netherland@gmail.com",
+        "2012-06-03T17:03:11-07:00"
+      )
+      expect(tag.tag).to eq("v9000.0.0")
+      expect(tag.message).to eq("Version 9000\n")
+      expect(tag.sha).to eq("23aad20633f4d2981b1c7209a800db3014774e96")
+    end
+
+  end
+
+
 end


### PR DESCRIPTION
Adds .tag and .create_tag methods.

The create method uses a lot of parameters, would a hash be better suited for this? I went with required fields as params since thats what it feels like the rest of octokit uses.

Also the tags created with this seem to be invisible. I created a tag on a private repo and I can retrieve the tag with the sha I get when creating it, but it doesn't show up anywhere and can't be used for anything I can see. The tags don't show up on the GitHub repo page. Pulling the repo from GitHub doesn't mention the creation of any new tags either.
