### PR TITLE
Fix Octokit.organization_members returning nil

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -125,7 +125,11 @@ module Octokit
       # @example
       #   Octokit.org_members('github')
       def organization_members(org, options={})
-        get("orgs/#{org}/members", options, 3)
+        if authenticated?
+          get("orgs/#{org}/members", options, 3)
+        else
+          get("orgs/#{org}/public_members", options, 3)
+        end
       end
       alias :org_members :organization_members
 

--- a/spec/octokit/client/organizations_spec.rb
+++ b/spec/octokit/client/organizations_spec.rb
@@ -70,6 +70,14 @@ describe Octokit::Client::Organizations do
   describe ".organization_members" do
 
     it "returns all public members of an organization" do
+      stub_get("https://api.github.com/orgs/codeforamerica/public_members").
+        to_return(:body => fixture("v3/organization_members.json"))
+      users = @client.organization_members("codeforamerica")
+      expect(users.first.login).to eq("akit")
+    end
+
+    it "returns all public and private members of an organization" do
+      @client.stub(:authenticated?){true}
       stub_get("https://api.github.com/orgs/codeforamerica/members").
         to_return(:body => fixture("v3/organization_members.json"))
       users = @client.organization_members("codeforamerica")


### PR DESCRIPTION
Bugfix: https://github.com/pengwynn/octokit/issues/158
Depending if the we are authenticated or not we'll request a different URL

http://developer.github.com/changes/2012-10-17-org-members-redirection/
