### PR TITLE
Update pull-merged? method to reflect GET request from Github API docs

### DIFF
--- a/lib/octokit/client/pulls.rb
+++ b/lib/octokit/client/pulls.rb
@@ -236,7 +236,7 @@ module Octokit
       # @return [Boolean] True if the pull request has been merged
       def pull_merged?(repo, number, options={})
         begin
-          get("repos/#{Repository.new(repo)}/pulls/#{number}/merged", options)
+          get("repos/#{Repository.new(repo)}/pulls/#{number}/merge", options)
           return true
         rescue Octokit::NotFound
           return false

--- a/spec/octokit/client/pulls_spec.rb
+++ b/spec/octokit/client/pulls_spec.rb
@@ -189,7 +189,7 @@ describe Octokit::Client::Pulls do
   describe ".pull_merged?" do
 
     it "returns whether the pull request has been merged" do
-      stub_get("https://api.github.com/repos/pengwynn/octokit/pulls/67/merged").
+      stub_get("https://api.github.com/repos/pengwynn/octokit/pulls/67/merge").
         to_return(:status => 204)
       merged = @client.pull_merged?("pengwynn/octokit", 67)
       expect(merged).to be_true


### PR DESCRIPTION
I was getting a false response when checking if a pull request was merged. After looking at the Github API docs, I noticed the url ends in "/merge", not "/merged"

Thanks.
