### PR TITLE
Refactor date parsing in Octokit::Commits

### DIFF
--- a/lib/octokit/client/commits.rb
+++ b/lib/octokit/client/commits.rb
@@ -178,13 +178,7 @@ module Octokit
       # @example
       #   Octokit.commits_since('pengwynn/octokit', '2012-10-01')
       def commits_since(repo, date, sha_or_branch="master", options={})
-        begin
-          date = DateTime.parse(date)
-        rescue ArgumentError
-          raise ArgumentError, "#{date} is not a valid date"
-        end
-
-        params = {:since => iso8601(date) }
+        params = {:since => iso8601(parse_date(date))}
         commits(repo, sha_or_branch, params.merge(options))
       end
 
@@ -198,12 +192,7 @@ module Octokit
       # @example
       #   Octokit.commits_before('pengwynn/octokit', '2012-10-01')
       def commits_before(repo, date, sha_or_branch="master", options={})
-        begin
-          date = DateTime.parse(date)
-        rescue ArgumentError
-          raise ArgumentError, "#{date} is not a valid date"
-        end
-        params = {:until => iso8601(date)}
+        params = {:until => iso8601(parse_date(date))}
         commits(repo, sha_or_branch, params.merge(options))
       end
 
@@ -272,6 +261,18 @@ module Octokit
         end
       end
 
+      # Parses the given string representation of a date, throwing a meaningful exception
+      # (containing the date that failed to parse) in case of failure.
+      #
+      # @param [String] String representation of a date
+      # @return [DateTime]
+      def parse_date(date)
+        begin
+          date = DateTime.parse(date)
+        rescue ArgumentError
+          raise ArgumentError, "#{date} is not a valid date"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Splitting #184 into smaller pull requests. 

The only logical explanation for the existence of the begin/rescue block around the date parsing for me is that it provides a more meaningful exception message than default ruby, so I added that as a comment. Or is there something I'm missing?

Spec: :white_check_mark:
Coverage: :white_check_mark:
