### PR TITLE
Another proposal for the begin/rescue block refactoring :)

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -96,12 +96,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Boolean] `true` if successfully unstarred
       def unstar(repo, options={})
-        begin
-          request :delete, "user/starred/#{Repository.new repo}", options
-          return true
-        rescue Octokit::NotFound
-          return false
-        end
+        !request_throws? Octokit::NotFound, :delete, "user/starred/#{Repository.new repo}", options
       end
 
       # Watch a repository

--- a/lib/octokit/request.rb
+++ b/lib/octokit/request.rb
@@ -35,6 +35,14 @@ module Octokit
 
     private
 
+    def request_throws?(expected_exception, method, path, options={})
+      request(method, path, options)
+      false
+    rescue Exception => e
+      raise e if !e.is_a? expected_exception
+      true
+    end
+
     def request(method, path, options={})
       path.sub(%r{^/}, '') #leading slash in path fails in github:enterprise
 


### PR DESCRIPTION
Another attempt to refactor the 

```
begin
    #code
    true
rescue Octokit::NotFound
    false
end
```

blocks. Just replaced one example for now.

RSpec: :white_check_mark: 
