### PR TITLE
Allow endpoint to be set with options[:endpoint]

### DIFF
--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -11,7 +11,7 @@ module Octokit
         :authenticate     => true,
         :force_urlencoded => false,
         :raw              => false,
-        :url              => api_endpoint
+        :ssl              => { :verify => false }
       }.merge(options)
 
       if !proxy.nil?

--- a/lib/octokit/request.rb
+++ b/lib/octokit/request.rb
@@ -53,9 +53,12 @@ module Octokit
 
       force_urlencoded = options.delete(:force_urlencoded) || false
 
+      url = options.delete(:endpoint) || api_endpoint
+
       conn_options = {
         :authenticate => token.nil?,
-        :force_urlencoded => force_urlencoded
+        :force_urlencoded => force_urlencoded,
+        :url => url
       }
 
       response = connection(conn_options).send(method) do |request|

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -212,6 +212,24 @@ describe Octokit::Client do
     end
   end
 
+  describe "endpoint url" do
+
+    it "defaults to api.github.com" do
+      stub_request(:get, 'https://api.github.com').
+        to_return(:body => 'octocat')
+      response = Octokit.get '/'
+      expect(response).to eq('octocat')
+    end
+
+    it "can be set in the options" do
+      stub_request(:get, 'http://wynnnetherland.com').
+        to_return(:body => 'pengwynn')
+      response = Octokit.get '/', {:endpoint => 'http://wynnnetherland.com'}
+      expect(response).to eq('pengwynn')
+    end
+
+  end
+
   describe "error handling" do
 
     it "displays validation errors" do


### PR DESCRIPTION
In the case of exchanging a code for an oauth token in the oauth process we
need to be able to point octokit to github.com instead of api.github.com.
Instead of jumping through hoops, this commit simplifies the process by
allowing the endpoint to be passed as an option.

Currently
  Octokit.get '/'
  => GET https://api.github.com/

This Commit
  Octokit.get '/', {:endpoint => Octokit.web_endpoint}
  => GET https://github.com/
