### PR TITLE
Add methods for GitHub:status api endpoints.

### DIFF
--- a/lib/octokit/client/statuses.rb
+++ b/lib/octokit/client/statuses.rb
@@ -24,6 +24,31 @@ module Octokit
         options.merge!(:state => state)
         post("repos/#{Repository.new(repo)}/statuses/#{sha}", options)
       end
+
+      # Returns the current system status
+      #
+      # @return [Hash] GitHub status
+      # @see https://status.github.com/api#api-current-status
+      def github_status
+        get('status.json', {:endpoint => Octokit.status_api_endpoint})
+      end
+
+      # Returns the last human communication, status, and timestamp.
+      #
+      # @return [Hash] GitHub status last message
+      # @see https://status.github.com/api#api-last-message
+      def github_status_last_message
+        get('last-message.json', {:endpoint => Octokit.status_api_endpoint})
+      end
+
+      # Returns the most recent human communications with status and timestamp.
+      #
+      # @return [Array<Hash>] GitHub status messages
+      # @see https://status.github.com/api#api-recent-messages
+      def github_status_messages
+        get('messages.json', {:endpoint => Octokit.status_api_endpoint})
+      end
+
     end
   end
 end

--- a/lib/octokit/configuration.rb
+++ b/lib/octokit/configuration.rb
@@ -9,6 +9,7 @@ module Octokit
       :api_version,
       :api_endpoint,
       :web_endpoint,
+      :status_api_endpoint,
       :login,
       :password,
       :proxy,
@@ -21,12 +22,13 @@ module Octokit
       :auto_traversal,
       :per_page].freeze
 
-    DEFAULT_ADAPTER        = Faraday.default_adapter
-    DEFAULT_API_VERSION    = 3
-    DEFAULT_API_ENDPOINT   = ENV['OCTOKIT_API_ENDPOINT'] || 'https://api.github.com/'
-    DEFAULT_WEB_ENDPOINT   = ENV['OCTOKIT_WEB_ENDPOINT'] || 'https://github.com/'
-    DEFAULT_USER_AGENT     = "Octokit Ruby Gem #{Octokit::VERSION}".freeze
-    DEFAULT_AUTO_TRAVERSAL = false
+    DEFAULT_ADAPTER             = Faraday.default_adapter
+    DEFAULT_API_VERSION         = 3
+    DEFAULT_API_ENDPOINT        = ENV['OCTOKIT_API_ENDPOINT'] || 'https://api.github.com/'
+    DEFAULT_WEB_ENDPOINT        = ENV['OCTOKIT_WEB_ENDPOINT'] || 'https://github.com/'
+    DEFAULT_STATUS_API_ENDPOINT = ENV['OCTOKIT_STATUS_API_ENDPOINT'] || 'https://status.github.com/api/'
+    DEFAULT_USER_AGENT          = "Octokit Ruby Gem #{Octokit::VERSION}".freeze
+    DEFAULT_AUTO_TRAVERSAL      = false
 
     attr_accessor(*VALID_OPTIONS_KEYS)
 
@@ -55,20 +57,21 @@ module Octokit
     end
 
     def reset
-      self.adapter        = DEFAULT_ADAPTER
-      self.api_version    = DEFAULT_API_VERSION
-      self.api_endpoint   = DEFAULT_API_ENDPOINT
-      self.web_endpoint   = DEFAULT_WEB_ENDPOINT
-      self.login          = nil
-      self.password       = nil
-      self.proxy          = nil
-      self.oauth_token    = nil
-      self.client_id      = nil
-      self.client_secret  = nil
-      self.request_host   = nil
-      self.netrc          = false
-      self.user_agent     = DEFAULT_USER_AGENT
-      self.auto_traversal = DEFAULT_AUTO_TRAVERSAL
+      self.adapter             = DEFAULT_ADAPTER
+      self.api_version         = DEFAULT_API_VERSION
+      self.api_endpoint        = DEFAULT_API_ENDPOINT
+      self.web_endpoint        = DEFAULT_WEB_ENDPOINT
+      self.status_api_endpoint = DEFAULT_STATUS_API_ENDPOINT
+      self.login               = nil
+      self.password            = nil
+      self.proxy               = nil
+      self.oauth_token         = nil
+      self.client_id           = nil
+      self.client_secret       = nil
+      self.request_host        = nil
+      self.netrc               = false
+      self.user_agent          = DEFAULT_USER_AGENT
+      self.auto_traversal      = DEFAULT_AUTO_TRAVERSAL
     end
   end
 end

--- a/spec/fixtures/github_status.json
+++ b/spec/fixtures/github_status.json
@@ -1,0 +1,4 @@
+{
+  "status": "good",
+  "last_updated": "2013-02-01T23:05:27Z"
+}

--- a/spec/fixtures/github_status_last_message.json
+++ b/spec/fixtures/github_status_last_message.json
@@ -1,0 +1,5 @@
+{
+  "status": "good",
+  "body": "Everything operating normally.",
+  "created_on": "2013-01-31T23:57:09Z"
+}

--- a/spec/fixtures/github_status_messages.json
+++ b/spec/fixtures/github_status_messages.json
@@ -1,0 +1,12 @@
+[
+  {
+    "status": "minor",
+    "body": "I'm seeing, like, unicorns man.",
+    "created_on":"2013-01-31T23:38:28Z"
+  },
+  {
+    "status": "good",
+    "body": "Everything operating normally.",
+    "created_on": "2013-01-31T23:57:09Z"
+  }
+]

--- a/spec/octokit/client/statuses_spec.rb
+++ b/spec/octokit/client/statuses_spec.rb
@@ -32,4 +32,37 @@ describe Octokit::Client::Statuses do
 
   end
 
+  describe ".github_status" do
+
+    it "returns the current system status" do
+      stub_get('https://status.github.com/api/status.json').
+        to_return(json_response('github_status.json'))
+      github_status = @client.github_status
+      expect(github_status.status).to eq('good')
+    end
+
+  end
+
+  describe ".github_status_last_message" do
+
+    it "returns the last human communication, status, and timestamp" do
+      stub_get('https://status.github.com/api/last-message.json').
+        to_return(json_response('github_status_last_message.json'))
+      last_message = @client.github_status_last_message
+      expect(last_message.body).to eq('Everything operating normally.')
+    end
+
+  end
+
+  describe ".github_status_messages" do
+
+    it "returns the most recent human communications" do
+      stub_get('https://status.github.com/api/messages.json').
+        to_return(json_response('github_status_messages.json'))
+      status_messages = @client.github_status_messages
+      expect(status_messages.first.body).to eq("I'm seeing, like, unicorns man.")
+    end
+
+  end
+
 end


### PR DESCRIPTION
Methods added:

`.github_status`
`.github_status_messages`
`.github_status_last_message`

Re: #209
