### PR TITLE
Respect superclass's initializer arity in Error

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -1,7 +1,7 @@
 module Octokit
   # Custom error class for rescuing from all GitHub errors
   class Error < StandardError
-    def initialize(response)
+    def initialize(response=nil)
       @response = response
       super(build_error_message)
     end
@@ -22,6 +22,8 @@ module Octokit
     private
 
     def build_error_message
+      return nil  if @response.nil?
+
       message = if response_body
         ": #{response_body[:error] || response_body[:message] || ''}"
       else


### PR DESCRIPTION
This fixes rspec-mocks and probably other mocking libs that create instances of
error classes without arguments.

E.g. in rspec-mocks `api.stub(:foobar).and_raise(Octokit::NotFound)` would cause
an error because of the missing response argument in Octokit::Error#initializer.
