### PR TITLE
Use PATCH instead of POST when updating things

### DIFF
--- a/lib/octokit/client/issues.rb
+++ b/lib/octokit/client/issues.rb
@@ -80,7 +80,7 @@ module Octokit
       # @example Close Issue #25 from pengwynn/octokit
       #   Octokit.close_issue("pengwynn/octokit", "25")
       def close_issue(repo, number, options={})
-        post("repos/#{Repository.new(repo)}/issues/#{number}", options.merge({:state => "closed"}))
+        patch("repos/#{Repository.new(repo)}/issues/#{number}", options.merge({:state => "closed"}))
       end
 
       # Reopen an issue
@@ -94,7 +94,7 @@ module Octokit
       # @example Reopen Issue #25 from pengwynn/octokit
       #   Octokit.reopen_issue("pengwynn/octokit", "25")
       def reopen_issue(repo, number, options={})
-        post("repos/#{Repository.new(repo)}/issues/#{number}", options.merge({:state => "open"}))
+        patch("repos/#{Repository.new(repo)}/issues/#{number}", options.merge({:state => "open"}))
       end
 
       # Update an issue
@@ -110,7 +110,7 @@ module Octokit
       # @example Change the title of Issue #25
       #   Octokit.update_issue("pengwynn/octokit", "25", "A new title", "the same body"")
       def update_issue(repo, number, title, body, options={})
-        post("repos/#{Repository.new(repo)}/issues/#{number}", options.merge({:title => title, :body => body}))
+        patch("repos/#{Repository.new(repo)}/issues/#{number}", options.merge({:title => title, :body => body}))
       end
 
       # Get all comments attached to issues for the repository
@@ -189,7 +189,7 @@ module Octokit
       # @example Update the comment "I've started this on my 25-issue-comments-v3 fork" on Issue #25 on pengwynn/octokit
       #   Octokit.update_comment("pengwynn/octokit", 25, "Almost to v1, added this on my fork")
       def update_comment(repo, number, comment, options={})
-        post("repos/#{Repository.new(repo)}/issues/comments/#{number}", options.merge({:body => comment}))
+        patch("repos/#{Repository.new(repo)}/issues/comments/#{number}", options.merge({:body => comment}))
       end
 
       # Delete a single comment

--- a/lib/octokit/client/labels.rb
+++ b/lib/octokit/client/labels.rb
@@ -52,7 +52,7 @@ module Octokit
       # @example Update the label "Version 1.0" with new color "#cceeaa"
       #   Octokit.update_label("pengwynn/octokit", "Version 1.0", {:color => "cceeaa"})
       def update_label(repo, label, options={})
-        post("repos/#{Repository.new(repo)}/labels/#{CGI.escape(label)}", options)
+        patch("repos/#{Repository.new(repo)}/labels/#{CGI.escape(label)}", options)
       end
 
       # Delete a label from a repository.

--- a/lib/octokit/client/milestones.rb
+++ b/lib/octokit/client/milestones.rb
@@ -65,7 +65,7 @@ module Octokit
       # @example Update a milestone for a repository
       #   Octokit.update_milestone("pengwynn/octokit", 1, {:description => 'Add support for v3 of Github API'})
       def update_milestone(repository, number, options={})
-        post("repos/#{Repository.new(repository)}/milestones/#{number}", options)
+        patch("repos/#{Repository.new(repository)}/milestones/#{number}", options)
       end
       alias :edit_milestone :update_milestone
 

--- a/lib/octokit/client/pulls.rb
+++ b/lib/octokit/client/pulls.rb
@@ -90,7 +90,7 @@ module Octokit
           :state => state
         })
         options.reject! { |_, value| value.nil? }
-        post("repos/#{Repository.new repo}/pulls/#{id}", options)
+        patch("repos/#{Repository.new repo}/pulls/#{id}", options)
       end
 
 

--- a/spec/octokit/client/issues_spec.rb
+++ b/spec/octokit/client/issues_spec.rb
@@ -74,7 +74,7 @@ describe Octokit::Client::Issues do
   describe ".close_issue" do
 
     it "closes an issue" do
-      stub_post("/repos/ctshryock/octokit/issues/12").
+      stub_patch("/repos/ctshryock/octokit/issues/12").
         with(:body => {"state" => "closed"},
              :headers => {'Content-Type'=>'application/json'}).
         to_return(json_response("issue_closed.json"))
@@ -89,7 +89,7 @@ describe Octokit::Client::Issues do
   describe ".reopen_issue" do
 
     it "reopens an issue" do
-      stub_post("/repos/ctshryock/octokit/issues/12").
+      stub_patch("/repos/ctshryock/octokit/issues/12").
         with(:body => {"state" => "open"},
              :headers => {'Content-Type'=>'application/json'}).
         to_return(json_response("issue.json"))
@@ -103,7 +103,7 @@ describe Octokit::Client::Issues do
   describe ".update_issue" do
 
     it "updates an issue" do
-      stub_post("/repos/ctshryock/octokit/issues/12").
+      stub_patch("/repos/ctshryock/octokit/issues/12").
         with(:body => {"title" => "Use all the v3 api!", "body" => ""},
              :headers => {'Content-Type'=>'application/json'}).
         to_return(json_response("issue.json"))
@@ -162,7 +162,7 @@ describe Octokit::Client::Issues do
   describe ".update_comment" do
 
     it "updates an existing comment" do
-      stub_post("/repos/pengwynn/octokit/issues/comments/1194549").
+      stub_patch("/repos/pengwynn/octokit/issues/comments/1194549").
         with(:body => {"body" => "A test comment update"}).
         to_return(json_response('comment.json'))
       comment = @client.update_comment("pengwynn/octokit", 1194549, "A test comment update")

--- a/spec/octokit/client/labels_spec.rb
+++ b/spec/octokit/client/labels_spec.rb
@@ -54,7 +54,7 @@ describe Octokit::Client::Labels do
   describe ".update_label" do
 
     it "updates a label with a new color" do
-      stub_post("/repos/pengwynn/octokit/labels/V3+Addition").
+      stub_patch("/repos/pengwynn/octokit/labels/V3+Addition").
         with(:body => {"color" => "ededed"},
             :headers => {'Content-Type'=>'application/json'}).
         to_return(json_response('label.json'))

--- a/spec/octokit/client/milestones_spec.rb
+++ b/spec/octokit/client/milestones_spec.rb
@@ -44,7 +44,7 @@ describe Octokit::Client::Milestones do
   describe ".update_milestone" do
 
     it "updates a milestone" do
-      stub_post("/repos/pengwynn/octokit/milestones/1").
+      stub_patch("/repos/pengwynn/octokit/milestones/1").
         with(:body => {"description" => "Add support for API v3"}).
         to_return(json_response('milestone.json'))
       milestone = @client.update_milestone("pengwynn/octokit", 1, {:description => "Add support for API v3"})

--- a/spec/octokit/client/pulls_spec.rb
+++ b/spec/octokit/client/pulls_spec.rb
@@ -23,7 +23,7 @@ describe Octokit::Client::Pulls do
   describe ".update_pull_request" do
 
     it "updates a pull request" do
-      stub_post("https://api.github.com/repos/pengwynn/octokit/pulls/67").
+      stub_patch("https://api.github.com/repos/pengwynn/octokit/pulls/67").
         with(:pull => { :title => "New title", :body => "Updated body", :state => "closed"}).
           to_return(json_response('pull_update.json'))
       pull = @client.update_pull_request('pengwynn/octokit', 67, 'New title', 'Updated body', 'closed')


### PR DESCRIPTION
Brings all updates inline with the GitHub documentation.
