### PR TITLE
Fixes doc about /user/keys call.

### DIFF
--- a/lib/octokit/client/users.rb
+++ b/lib/octokit/client/users.rb
@@ -229,7 +229,7 @@ module Octokit
       #
       # @return [Array<Hashie::Mash>] Array of hashes representing public keys.
       # @see Octokit::Client
-      # @see http://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
+      # @see http://developer.github.com/v3/users/keys/#list-your-public-keys
       # @example
       #   @client.keys
       def keys(options={})


### PR DESCRIPTION
This library doesn't yet implement the API call that had been referenced: http://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
