### PR TITLE
Bump hashie dependency to 2.x

### DIFF
--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.2'
   spec.add_dependency 'faraday', '~> 0.8'
   spec.add_dependency 'faraday_middleware', '~> 0.9'
-  spec.add_dependency 'hashie', '~> 1.2'
+  spec.add_dependency 'hashie', '~> 2.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'netrc', '~> 0.7.7'
   spec.authors = ["Wynn Netherland", "Erik Michaels-Ober", "Clint Shryock"]


### PR DESCRIPTION
I'm working on building an internal gem that depends on octokit and [ridley](https://github.com/reset/ridley). ridley depends on [chozo](https://github.com/reset/chozo), which depends on hashie ~> 2.0. When trying to build and install my gem, shit gets weird because of the conflicting dependencies. After bumping the dependency in octokit and bundling, all specs still pass and octokit doesn't require any more changes that I can see.
