### PR TITLE
Don't require title and body when updating an issue

### DIFF
--- a/lib/octokit/client/issues.rb
+++ b/lib/octokit/client/issues.rb
@@ -149,8 +149,8 @@ module Octokit
       #
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param number [String] Number ID of the issue
-      # @param title [String] Updated title for the issue
-      # @param body [String] Updated body of the issue
+      # @param title [String] Optional Updated title for the issue
+      # @param body [String] Optional Updated body of the issue
       # @param options [Hash] A customizable set of options.
       # @option options [String] :assignee User login.
       # @option options [Integer] :milestone Milestone number.
@@ -159,8 +159,15 @@ module Octokit
       # @see http://developer.github.com/v3/issues/#edit-an-issue
       # @example Change the title of Issue #25
       #   Octokit.update_issue("pengwynn/octokit", "25", "A new title", "the same body"")
-      def update_issue(repo, number, title, body, options={})
-        patch("repos/#{Repository.new(repo)}/issues/#{number}", options.merge({:title => title, :body => body}))
+      def update_issue(*args)
+        options = args.last.is_a?(Hash) ? args.pop : {}
+        repo    = args.shift
+        number  = args.shift
+        title   = args.shift
+        body    = args.shift
+        options[:title] = title unless title.nil?
+        options[:body]  = body  unless body.nil?
+        patch("repos/#{Repository.new(repo)}/issues/#{number}", options)
       end
 
       # Get all comments attached to issues for the repository

--- a/spec/octokit/client/issues_spec.rb
+++ b/spec/octokit/client/issues_spec.rb
@@ -133,6 +133,15 @@ describe Octokit::Client::Issues do
       expect(issue.number).to eq(12)
     end
 
+    it "doesn't require a title and a body" do
+      stub_patch("/repos/ctshryock/octokit/issues/12").
+        with(:body => {"labels" => %w(bug)},
+             :headers => {'Content-Type'=>'application/json'}).
+        to_return(json_response("issue.json"))
+      issue = @client.update_issue("ctshryock/octokit", 12, :labels => %w(bug))
+      expect(issue.number).to eq(12)
+    end
+
   end
 
   describe ".repository_issues_comments" do


### PR DESCRIPTION
Discovered this when working on Octonaut. @sferik is there a more Ruby-ish way to do this without the benefit of `extract_options!`?
