### PR TITLE
Remove title and body params from .update_issue method.

### DIFF
--- a/lib/octokit/client/issues.rb
+++ b/lib/octokit/client/issues.rb
@@ -149,18 +149,18 @@ module Octokit
       #
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param number [String] Number ID of the issue
-      # @param title [String] Updated title for the issue
-      # @param body [String] Updated body of the issue
       # @param options [Hash] A customizable set of options.
+      # @option options [String] :title Updated title for the issue
+      # @option options [String] :body Updated body of the issue
       # @option options [String] :assignee User login.
       # @option options [Integer] :milestone Milestone number.
       # @option options [String] :labels List of comma separated Label names. Example: <tt>bug,ui,@high</tt>.
       # @return [Issue] The updated Issue
       # @see http://developer.github.com/v3/issues/#edit-an-issue
       # @example Change the title of Issue #25
-      #   Octokit.update_issue("pengwynn/octokit", "25", "A new title", "the same body"")
-      def update_issue(repo, number, title, body, options={})
-        patch("repos/#{Repository.new(repo)}/issues/#{number}", options.merge({:title => title, :body => body}))
+      #   Octokit.update_issue("pengwynn/octokit", "25", :title => "A new title")
+      def update_issue(repo, number, options={})
+        patch("repos/#{Repository.new(repo)}/issues/#{number}", options)
       end
 
       # Get all comments attached to issues for the repository

--- a/spec/octokit/client/issues_spec.rb
+++ b/spec/octokit/client/issues_spec.rb
@@ -126,11 +126,11 @@ describe Octokit::Client::Issues do
 
     it "updates an issue" do
       stub_patch("/repos/ctshryock/octokit/issues/12").
-        with(:body => {"title" => "Use all the v3 api!", "body" => ""},
+        with(:body => {"title" => "Migrate issues to v3"},
              :headers => {'Content-Type'=>'application/json'}).
         to_return(json_response("issue.json"))
-      issue = @client.update_issue("ctshryock/octokit", 12, "Use all the v3 api!", "")
-      expect(issue.number).to eq(12)
+      issue = @client.update_issue("ctshryock/octokit", 12, :title => "Migrate issues to v3")
+      expect(issue.title).to eq("Migrate issues to v3")
     end
 
   end


### PR DESCRIPTION
**Breaks the current api** to make the method handle optional parameters consistent with other methods in Octokit.

.update_issue now takes 3 parameters - repo, issue number and optional
parameters. body and title are removed from the method parameters and can be passed
in the optional arguments hash.
