### PR TITLE
Change how users#follows? works

### DIFF
--- a/lib/octokit/client/users.rb
+++ b/lib/octokit/client/users.rb
@@ -120,12 +120,8 @@ module Octokit
       # @see http://developer.github.com/v3/users/followers/#check-if-you-are-following-a-user
       # @example
       #   @client.follows?('pengwynn')
-      def follows?(*args)
-        target = args.pop
-        user = args.first
-        user ||= login
-        return if user.nil?
-        boolean_from_response(:get, "user/following/#{target}")
+      def follows?(user)
+        boolean_from_response(:get, "user/following/#{user}")
       end
 
       # Follow a user.

--- a/spec/octokit/client/users_spec.rb
+++ b/spec/octokit/client/users_spec.rb
@@ -158,7 +158,7 @@ describe Octokit::Client::Users do
       it "returns true" do
         stub_get("https://api.github.com/user/following/puls").
           to_return(:status => 204, :body => "")
-        follows = @client.follows?("sferik", "puls")
+        follows = @client.follows?("puls")
         expect(follows).to eq(true)
       end
 
@@ -169,7 +169,7 @@ describe Octokit::Client::Users do
       it "returns false" do
         stub_get("https://api.github.com/user/following/dogbrainz").
           to_return(:status => 404, :body => "")
-        follows = @client.follows?("sferik", "dogbrainz")
+        follows = @client.follows?("dogbrainz")
         expect(follows).to be_false
       end
 


### PR DESCRIPTION
From what I can tell the API doesn't support "does user A follow user B" format
that this method implies it could. Simplfy this method to just take a single
user name.
- single parameter instead of array
- Refs #191
