### PR TITLE
Ensure file content is properly Base64 encoded

### DIFF
--- a/lib/octokit/client/contents.rb
+++ b/lib/octokit/client/contents.rb
@@ -68,7 +68,7 @@ module Octokit
           end
         end
         raise ArgumentError.new "content or :file option required" if content.nil?
-        options[:content] = Base64.encode64(content)
+        options[:content] = Base64.encode64(content).delete("\r\n")
         options[:message] = message
         url = "repos/#{Repository.new repo}/contents/#{path}"
         put(url, options)

--- a/spec/octokit/client/contents_spec.rb
+++ b/spec/octokit/client/contents_spec.rb
@@ -51,7 +51,7 @@ describe Octokit::Client::Contents do
   describe ".create_contents" do
     it "creates repository contents at a path" do
       stub_put("/repos/pengwynn/api-sandbox/contents/foo/bar/baz.txt").
-        with({:body => {:message => "I am commit-ing", :content => "SGVyZSBiZSB0aGUgY29udGVudA==\n"}}).
+        with({:body => {:message => "I am commit-ing", :content => "SGVyZSBiZSB0aGUgY29udGVudA=="}}).
         to_return(json_response("create_content.json"))
 
       response = @client.create_contents("pengwynn/api-sandbox",
@@ -62,7 +62,7 @@ describe Octokit::Client::Contents do
     end
     it "creates contents from file path" do
       stub_put("/repos/pengwynn/api-sandbox/contents/foo/bar/baz.txt").
-        with({:body => {:message => "I am commit-ing", :content => "SGVyZSBiZSB0aGUgY29udGVudAo=\n"}}).
+        with({:body => {:message => "I am commit-ing", :content => "SGVyZSBiZSB0aGUgY29udGVudAo="}}).
         to_return(json_response("create_content.json"))
 
       response = @client.create_contents("pengwynn/api-sandbox",
@@ -73,7 +73,7 @@ describe Octokit::Client::Contents do
     end
     it "creates contents from File object" do
       stub_put("/repos/pengwynn/api-sandbox/contents/foo/bar/baz.txt").
-        with({:body => {:message => "I am commit-ing", :content => "SGVyZSBiZSB0aGUgY29udGVudAo=\n"}}).
+        with({:body => {:message => "I am commit-ing", :content => "SGVyZSBiZSB0aGUgY29udGVudAo="}}).
         to_return(json_response("create_content.json"))
 
       file = File.new "spec/fixtures/new_file.txt", "r"
@@ -91,7 +91,7 @@ describe Octokit::Client::Contents do
         with({:body => {
                 :sha => "4d149b826e7305659006eb64cfecd3be68d0f2f0",
                 :message => "I am commit-ing",
-                :content => "SGVyZSBiZSBtb2FyIGNvbnRlbnQ=\n"
+                :content => "SGVyZSBiZSBtb2FyIGNvbnRlbnQ="
         }}).
         to_return(json_response("update_content.json"))
 
@@ -107,7 +107,7 @@ describe Octokit::Client::Contents do
         with({:body => {
                 :sha => "4d149b826e7305659006eb64cfecd3be68d0f2f0",
                 :message => "I am commit-ing",
-                :content => "SGVyZSBiZSBtb2FyIGNvbnRlbnQK\n"
+                :content => "SGVyZSBiZSBtb2FyIGNvbnRlbnQK"
         }}).
         to_return(json_response("update_content.json"))
 
@@ -123,7 +123,7 @@ describe Octokit::Client::Contents do
         with({:body => {
                 :sha => "4d149b826e7305659006eb64cfecd3be68d0f2f0",
                 :message => "I am commit-ing",
-                :content => "SGVyZSBiZSBtb2FyIGNvbnRlbnQK\n"
+                :content => "SGVyZSBiZSBtb2FyIGNvbnRlbnQK"
         }}).
         to_return(json_response("update_content.json"))
 


### PR DESCRIPTION
When making a call to the `create_contents` method, the Base64-encoding is causing
Octokit to throw an `UnprocessableEntity` exception, complaining that the content
is not valid Base64.

See the error below:

``` ruby
Octokit::UnprocessableEntity: PUT https://api.github.com/repos/Sage/sageone_help_uk/contents/_help/bbb.textile: 422: content is not valid Base64
from /usr/local/opt/rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/bundler/gems/octokit-50c53ea2579f/lib/faraday/response/raise_octokit_error.rb:22:in `on_complete'
```

It's because of this issue documented here:

http://stackoverflow.com/questions/2620975/strange-n-in-base64-encoded-string-in-ruby

Where the call to Base64 encoding is happening, I've added a small piece of logic
to mimic Ruby 1.9s `strict_encode64` functionality, ensuring we're backward compatible
to Ruby 1.8.7.

See #244
