### PR TITLE
Fix all_repository requests for Enterprise

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -75,7 +75,7 @@ module Octokit
       #
       # @return [Array] List of repositories.
       def all_repositories(options={})
-        get '/repositories', options
+        get 'repositories', options
       end
 
       # Star a repository


### PR DESCRIPTION
The leading slash here was causing the request to ignore the specified api endpoint, so it was being sent to `http(s)://[hostname]/repositories` rather than `http(s)://[hostname]/api/v3/repositories`.
