### PR TITLE
Correct method description

### DIFF
--- a/lib/octokit/client/markdown.rb
+++ b/lib/octokit/client/markdown.rb
@@ -2,7 +2,7 @@ module Octokit
   class Client
     module Markdown
 
-      # Receive the default Readme for a repository
+      # Render an arbitrary Markdown document
       #
       # @param text [String] Markdown source
       # @option options [String] (optional) :mode (`markdown` or `gfm`)


### PR DESCRIPTION
Seems like a simple copy&past mistake. This fixes it.
