### PR TITLE
Add Repositories.repository? to check if a repo exists.

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -12,6 +12,17 @@ module Octokit
       end
       alias :search_repos :search_repositories
 
+      # Check if a repository exists
+      #
+      # @see http://developer.github.com/v3/repos/#get
+      # @param repo [String, Hash, Repository] A GitHub repository
+      # @return [Hashie::Mash] if a repository exists, false otherwise
+      def repository?(repo, options = {})
+        repository(repo, options)
+      rescue Octokit::NotFound
+        false
+      end
+
       # Get a single repository
       #
       # @see http://developer.github.com/v3/repos/#get

--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -521,4 +521,23 @@ describe Octokit::Client::Repositories do
 
   end
 
+  describe ".repository?" do
+
+    it "returns true if the repository exists" do
+      stub_get("/repos/sferik/rails_admin").
+        to_return(json_response("repository.json"))
+
+      result = @client.repository?("sferik/rails_admin")
+      expect(result).to be_true
+    end
+
+    it "returns false if the repository doesn't exist" do
+      stub_get("/repos/pengwynn/octokit").
+        to_return(:status => 404)
+
+      result = @client.repository?("pengwynn/octokit")
+      expect(result).to be_false
+    end
+
+  end
 end


### PR DESCRIPTION
I've used this method in a couple of places and I thought it could be useful for other users. My main user case is to check if a repo exists before creating it, something like this:

``` ruby
client.create_repository('foo') unless client.repository?('calavera/foo')
```

Without `Repositories.repository?` I needed to capture the exception that `Repositories.repository` raises and the code was quite nasty.
