### PR TITLE
Refactor connection to build once per class

### DIFF
--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -21,7 +21,10 @@ module Octokit
         options.merge!(:params => unauthed_rate_limit_params)
       end
 
-      # TODO: Don't build on every request
+      @connection ||= build_connection(options) 
+    end
+
+    def build_connection(options)
       connection = Faraday.new(options) do |builder|
 
         if options[:force_urlencoded]

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -242,5 +242,15 @@ describe Octokit::Client do
 
   end
 
+  describe "connection" do
+    it "reuses the same connection for multiple requests" do
+      Faraday.should_receive(:new).once.and_call_original
+      client = Octokit::Client.new
+      stub_request(:get, 'https://api.github.com').
+        to_return(:body => 'octocat')
+      3.times { client.get '/' }
+    end
+  end
+
 
 end


### PR DESCRIPTION
This change refactors how the Faraday connection is created so that it is created once and cached in an instance variable.

The connection module is included in the `Client` class, so the client will build the connection and store it off to an instance variable called connection.

This change also adds tests to ensure that Faraday only builds the connection once.  Since the connection is a private method, the tests try to get at the behavior that we want to avoid (building the connection more than once).

I really love octokit, I hope this change makes it a little more awesome.  I believe that I've followed the contribution guidelines, but if there is anything I can do to make this pull request even better let me know.
