### PR TITLE
encode URI component in ServiceHooks.subscribe_service_hook

### DIFF
--- a/lib/octokit/client/pub_sub_hubbub/service_hooks.rb
+++ b/lib/octokit/client/pub_sub_hubbub/service_hooks.rb
@@ -1,3 +1,5 @@
+require "uri"
+
 module Octokit
   class Client
     module PubSubHubbub
@@ -14,7 +16,7 @@ module Octokit
         #    client.subscribe_service_hook('joshk/device_imapable', 'Travis', { :token => "test", :domain => "domain", :user => "user" })
         def subscribe_service_hook(repo, service_name, service_arguments = {})
           topic = "#{Octokit.web_endpoint}#{Repository.new(repo)}/events/push"
-          callback = "github://#{service_name}?#{service_arguments.collect{ |k,v| [ k,v ].join("=") }.join("&") }"
+          callback = "github://#{service_name}?#{service_arguments.collect{ |k,v| [ k,v ].map{ |p| URI.encode_www_form_component(p) }.join("=") }.join("&") }"
           subscribe(topic, callback)
         end
 

--- a/spec/octokit/client/pub_sub_hubbub/service_hooks_spec.rb
+++ b/spec/octokit/client/pub_sub_hubbub/service_hooks_spec.rb
@@ -13,6 +13,13 @@ describe Octokit::Client::PubSubHubbub::ServiceHooks do
         :"hub.topic" => 'https://github.com/joshk/completeness-fu/events/push'
       }
     }
+    let(:irc_request_body) {
+      {
+        :"hub.callback" => 'github://irc?server=chat.freenode.org&room=%23myproject',
+        :"hub.mode" => 'subscribe',
+        :"hub.topic" => 'https://github.com/joshk/completeness-fu/events/push'
+      }
+    }
     it "subscribes to pull events on specified topic" do
       stub_post("/hub").
         with(subscribe_request_body).
@@ -21,7 +28,13 @@ describe Octokit::Client::PubSubHubbub::ServiceHooks do
       expect(client.subscribe_service_hook("joshk/completeness-fu", "Travis", { :token => 'travistoken' })).to eq(true)
       assert_requested :post, "https://api.github.com/hub", :body => subscribe_request_body, :times => 1,
         :headers => {'Content-type' => 'application/x-www-form-urlencoded'}
-
+    end
+    it "encodes URL parameters" do
+      stub_post("/hub").
+        with(irc_request_body).
+        to_return(:status => 204)
+      expect(client.subscribe_service_hook("joshk/completeness-fu", "irc", { :server => "chat.freenode.org", :room => "#myproject"})).to eql(true)
+      assert_requested :post, "https://api.github.com/hub", :body => irc_request_body, :times => 1
     end
   end
 


### PR DESCRIPTION
The fix use URI.encode_www_form_component to escape both parameter name and value in the URL.
