### PR TITLE
Fix missing addressable dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'jruby-openssl', :platforms => :jruby
 gem 'rake'
+gem 'addressable', '~> 2.3.5'
 
 group :development do
   gem 'awesome_print', :require => 'ap'

--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -5,6 +5,7 @@ require 'octokit/version'
 
 Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.add_dependency 'addressable', '~> 2.3.5'
   spec.add_dependency 'sawyer', '~> 0.1.0'
   spec.authors = ["Wynn Netherland", "Erik Michaels-Ober", "Clint Shryock"]
   spec.description = %q{Simple wrapper for the GitHub API}


### PR DESCRIPTION
Without it, a Rails 4 app complains about a missing dependency when requiring `addressable/uri`.
