### PR TITLE
s/access_token/oauth_token/ in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ To use an access token with the Octokit client, just pass it in lieu of your
 username and password:
 
 ```ruby
-client = Octokit::Client.new :access_token => "<your 40 char token>"
+client = Octokit::Client.new :oauth_token => "<your 40 char token>"
 
 user = client.user
 user.login


### PR DESCRIPTION
The oauth token example in the readme used the `:access_token` symbol, but the gem expects an `:oauth_token`.

Let's not talk about how much time I spent over the past few days debugging just about everything else in the stack...
