### PR TITLE
Make script/test portable

### DIFF
--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Because `/bin/sh` isn't always bash, `script/test` might fail.

Ubuntu specifically, uses dash as `/bin/sh`, which does not support the double bracket builtin in `script/test`.

http://stackoverflow.com/questions/9666102/bash-double-bracket-issue
https://wiki.ubuntu.com/DashAsBinSh
http://askubuntu.com/questions/141928/what-is-difference-between-bin-sh-and-bin-bash
