### PR TITLE
Stricter base64 encoding on content creation and update

### DIFF
--- a/lib/octokit/client/contents.rb
+++ b/lib/octokit/client/contents.rb
@@ -73,7 +73,7 @@ module Octokit
           end
         end
         raise ArgumentError.new "content or :file option required" if content.nil?
-        options[:content] = Base64.encode64(content)
+        options[:content] = Base64.encode64(content).delete("\n")
         options[:message] = message
         url = "repos/#{Repository.new repo}/contents/#{path}"
         put url, options


### PR DESCRIPTION
Long time listener, first time caller. Per https://github.com/octokit/octokit.rb/commit/c9ac24618bc326b5ab1f46d233addc2bfefb652c#commitcomment-4152077, re-implement https://github.com/octokit/octokit.rb/commit/f105b3c.

The merge in c9ac24618bc326b5ab1f46d233addc2bfefb652c appears to break `update_content` requests to files over a certain length. 

This commit trims any trailing new lines in the encoded content ensuring it's properly parsed and the update succeeds.

Discovered while working on https://github.com/benbalter/github-forms and [tested via this fork](https://github.com/benbalter/github-forms/blob/master/Gemfile), which seem to resolve the issue fully.

/cc @damian, #244, #245
