### PR TITLE
Exclude test specs from gemspec

### DIFF
--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -17,6 +17,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_rubygems_version = '>= 1.3.5'
   spec.summary = "Ruby toolkit for working with the GitHub API"
-  spec.test_files = Dir.glob("spec/**/*")
   spec.version = Octokit::VERSION.dup
 end


### PR DESCRIPTION
Additional line still causing specs to be included and the gem failing to install. Removed and tested, gem installs fine on windows after removal.
