### PR TITLE
Use client_id and client_secret as default arguments in #authorize_url

### DIFF
--- a/lib/octokit/client/authorizations.rb
+++ b/lib/octokit/client/authorizations.rb
@@ -129,8 +129,8 @@ module Octokit
 
     # Get the URL to authorize a user for an application via the web flow
     #
-    # @param app_id [String] Client Id we received when our application was registered with GitHub.
-    # @param app_secret [String] Client Secret we received when our application was registered with GitHub.
+    # @param app_id [String] Client Id we received when our application was registered with GitHub. Defaults to the client_id.
+    # @param app_secret [String] Client Secret we received when our application was registered with GitHub. Defaults to the client_secret.
     # @option options [String] :redirect_uri The url to redirect to after authorizing.
     # @option options [String] :scope The scopes to request from the user.
     # @option options [String] :state A random string to protect against CSRF.
@@ -139,7 +139,7 @@ module Octokit
     # @see http://developer.github.com/v3/oauth/#web-application-flow
     # @example
     #   @client.authorize_url('xxxx', 'yyyy')
-    def authorize_url(app_id, app_secret, options = {})
+    def authorize_url(app_id = client_id, app_secret = client_secret, options = {})
       authorize_url = options.delete(:endpoint) || Octokit.web_endpoint
       authorize_url += "login/oauth/authorize?client_id=" + app_id + "&client_secret=" + app_secret
 

--- a/lib/octokit/configurable.rb
+++ b/lib/octokit/configurable.rb
@@ -44,10 +44,10 @@ module Octokit
     #   @return [String] Base URL for web URLs. default: https://github.com/
 
     attr_accessor :access_token, :api_endpoint, :auto_paginate, :client_id,
-                  :default_media_type, :connection_options,
+                  :client_secret, :default_media_type, :connection_options,
                   :login, :middleware, :netrc, :netrc_file,
                   :per_page, :proxy, :user_agent, :web_endpoint
-    attr_writer :client_secret, :password
+    attr_writer :password
 
     class << self
 

--- a/spec/octokit/client/authorizations_spec.rb
+++ b/spec/octokit/client/authorizations_spec.rb
@@ -108,10 +108,24 @@ describe Octokit::Client::Authorizations do
     end
   end # .delete_authorization
 
-  describe '.authorize_url' do
-    it "returns the authorize_url" do
-      url = Octokit.authorize_url('id_here', 'secret_here')
-      expect(url).to eq('https://github.com/login/oauth/authorize?client_id=id_here&client_secret=secret_here')
+  describe ".authorize_url" do
+    context "with preconfigured client credentials" do
+      it "returns the authorize_url" do
+        Octokit.configure do |c|
+          c.client_id = 'id_here'
+          c.client_secret = 'secret_here'
+        end
+
+        url = Octokit.authorize_url
+        expect(url).to eq('https://github.com/login/oauth/authorize?client_id=id_here&client_secret=secret_here')
+      end
+    end
+
+    context "with passed client credentials" do
+      it "returns the authorize_url" do
+        url = Octokit.authorize_url('id_here', 'secret_here')
+        expect(url).to eq('https://github.com/login/oauth/authorize?client_id=id_here&client_secret=secret_here')
+      end
     end
   end # .authorize_url
 


### PR DESCRIPTION
Allows you to use already defined `client_id` and `client_secret` to call `::Authorizations.authorize_url`.

``` ruby
Octokit.configure do |c|
  c.client_id = 'id'
  c.client_secret = 'secret'
end

Octokit.authorize_url # => https://github.com/login/oauth/authorize?client_id=id&client_secret=secret
```

See #328.
