### PR TITLE
Deprecate and do not pass client_secret in .authorize_url

### DIFF
--- a/lib/octokit/client/authorizations.rb
+++ b/lib/octokit/client/authorizations.rb
@@ -130,7 +130,6 @@ module Octokit
     # Get the URL to authorize a user for an application via the web flow
     #
     # @param app_id [String] Client Id we received when our application was registered with GitHub.
-    # @param app_secret [String] Client Secret we received when our application was registered with GitHub.
     # @option options [String] :redirect_uri The url to redirect to after authorizing.
     # @option options [String] :scope The scopes to request from the user.
     # @option options [String] :state A random string to protect against CSRF.
@@ -138,10 +137,16 @@ module Octokit
     # @see Octokit::Client
     # @see http://developer.github.com/v3/oauth/#web-application-flow
     # @example
-    #   @client.authorize_url('xxxx', 'yyyy')
-    def authorize_url(app_id, app_secret, options = {})
+    #   @client.authorize_url('xxxx')
+    def authorize_url(*args)
+      arguments = Arguments.new(args)
+      options   = arguments.options
+      app_id = arguments.shift
+      if app_secret = arguments.shift
+        warn "client_secret is not required for this method"
+      end
       authorize_url = options.delete(:endpoint) || Octokit.web_endpoint
-      authorize_url += "login/oauth/authorize?client_id=" + app_id + "&client_secret=" + app_secret
+      authorize_url += "login/oauth/authorize?client_id=" + app_id
 
       options.each do |key, value|
         authorize_url += "&" + key.to_s + "=" + value

--- a/spec/octokit/client/authorizations_spec.rb
+++ b/spec/octokit/client/authorizations_spec.rb
@@ -110,8 +110,12 @@ describe Octokit::Client::Authorizations do
 
   describe '.authorize_url' do
     it "returns the authorize_url" do
+      url = Octokit.authorize_url('id_here')
+      expect(url).to eq('https://github.com/login/oauth/authorize?client_id=id_here')
+    end
+    it "does not choke on deprecated app_secret argument" do
       url = Octokit.authorize_url('id_here', 'secret_here')
-      expect(url).to eq('https://github.com/login/oauth/authorize?client_id=id_here&client_secret=secret_here')
+      expect(url).to eq('https://github.com/login/oauth/authorize?client_id=id_here')
     end
   end # .authorize_url
 


### PR DESCRIPTION
Fixes #331, for some reason we're requiring `client_secret` (and passing it in the querystring) for the `.authorize_url` when we shouldn't.

This change deprecates that argument until we change the method signature in the next major version.
