### PR TITLE
Rescue from NoMethodError when trying to load missing netrc

### DIFF
--- a/lib/octokit/authentication.rb
+++ b/lib/octokit/authentication.rb
@@ -58,8 +58,13 @@ module Octokit
       info = Netrc.read netrc_file
       netrc_host = URI.parse(api_endpoint).host
       creds = info[netrc_host]
-      self.login = creds.shift
-      self.password = creds.shift
+      if creds.nil?
+        # creds will be nil if there is no netrc for this end point
+        warn "Error loading credentials from netrc file for #{api_endpoint}"
+      else
+        self.login = creds.shift
+        self.password = creds.shift
+      end
     rescue LoadError
       warn "Please install netrc gem for .netrc support"
     end


### PR DESCRIPTION
If you try to authenticate with `netrc` credentials and there's no entry in the `netrc` file for the given api endpoint, Octokit throws an unhelpful error:

``` ruby
>> c = Octokit::Client.new netrc: true
NoMethodError: undefined method `shift' for nil:NilClass
    from /Users/clint/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/octokit-2.6.1/lib/octokit/authentication.rb:61:in `login_from_netrc'
    from /Users/clint/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/octokit-2.6.1/lib/octokit/client.rb:91:in `initialize'
    from (irb):4:in `new'
    from (irb):4
    from /Users/clint/.rbenv/versions/2.0.0-p247/bin/irb:12:in `<main>'
```

With this patch, output changed to this:

``` ruby
>> c = Octokit::Client.new netrc: true
Error loading credentials from netrc file for https://api.github.com/
#<Octokit::Client:0x007f94052d1478 @access_token=nil, @api_endpoint="https://api.github.com"
```

This adds a simple `rescue NoMethodError` with a `warn` to the user. I'm all for suggestions on handling this better than the `NoMethodError` catch, or the wording in the `warn` output.
