### PR TITLE
Fix warnings in configurable

### DIFF
--- a/lib/octokit/configurable.rb
+++ b/lib/octokit/configurable.rb
@@ -43,11 +43,11 @@ module Octokit
     # @!attribute web_endpoint
     #   @return [String] Base URL for web URLs. default: https://github.com/
 
-    attr_accessor :access_token, :api_endpoint, :auto_paginate, :client_id,
+    attr_accessor :access_token, :auto_paginate, :client_id,
                   :client_secret, :default_media_type, :connection_options,
-                  :login, :middleware, :netrc, :netrc_file,
-                  :per_page, :proxy, :user_agent, :web_endpoint
-    attr_writer :password
+                  :middleware, :netrc, :netrc_file,
+                  :per_page, :proxy, :user_agent
+    attr_writer :password, :web_endpoint, :api_endpoint, :login
 
     class << self
 


### PR DESCRIPTION
This fixes the following warnings:

```
octokit-2.6.2/lib/octokit/configurable.rb:92: warning: method redefined; discarding old api_endpoint
octokit-2.6.2/lib/octokit/configurable.rb:99: warning: method redefined; discarding old web_endpoint
octokit-2.6.2/lib/octokit/configurable.rb:103: warning: method redefined; discarding old login
```
