### PR TITLE
Unset auth variables in ENV for testing.

### DIFF
--- a/script/test
+++ b/script/test
@@ -15,4 +15,4 @@ do
 done
 
 echo "===> Running specs..."
-bundle exec rspec-queue spec
+(unset OCTOKIT_LOGIN; unset OCTOKIT_ACCESS_TOKEN; bundle exec rspec-queue spec)


### PR DESCRIPTION
Normal access tokens are getting picked up by octokit in testing, causing tests to fail.
