### PR TITLE
Feature: Use defaults for environment variables

### DIFF
--- a/script/test
+++ b/script/test
@@ -10,7 +10,6 @@ do
   octokitvar="OCTOKIT_TEST_GITHUB_${testvar}"
   if [[ -z "${!octokitvar}" ]]; then
       echo "Please export ${octokitvar}";
-      exit 1;
   fi
 done
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -52,7 +52,7 @@ def test_github_login
 end
 
 def test_github_password
-  ENV.fetch 'OCTOKIT_TEST_GITHUB_PASSWORD', 'wow such password'
+  ENV.fetch 'OCTOKIT_TEST_GITHUB_PASSWORD', 'wow_such_password'
 end
 
 def test_github_token
@@ -128,6 +128,6 @@ def basic_auth_client(login = test_github_login, password = test_github_password
 end
 
 def oauth_client
-  Octokit::Client.new(:access_token => ENV.fetch('OCTOKIT_TEST_GITHUB_TOKEN'))
+  Octokit::Client.new(:access_token => test_github_token)
 end
 


### PR DESCRIPTION
I sort of discussed this with @joeyw on #377 but I wanted to display just how simple it is to get the tests to run with `./script/test`. 

This is a WIP and I will probably add to it so that user's can specify their own repository via an environment variable as well. We can then generalize the before/after blocks to use the specified environment variable for making requests and create a sensitive data filter for that with VCR. Ideally this will make future contributions less of a hassle for all.
