### PR TITLE
Fixed incorrect example usage of update_user()

### DIFF
--- a/lib/octokit/client/users.rb
+++ b/lib/octokit/client/users.rb
@@ -85,7 +85,7 @@ module Octokit
       # @return [Sawyer::Resource]
       # @see http://developer.github.com/v3/users/#update-the-authenticated-user
       # @example
-      #   Octokit.user(:name => "Erik Michaels-Ober", :email => "sferik@gmail.com", :company => "Code for America", :location => "San Francisco", :hireable => false)
+      #   Octokit.update_user(:name => "Erik Michaels-Ober", :email => "sferik@gmail.com", :company => "Code for America", :location => "San Francisco", :hireable => false)
       def update_user(options)
         patch "user", options
       end


### PR DESCRIPTION
Also would recommend that the the :bio option not be shown as this is a essentially deprecated feature.  Its not shown on GitHub.com UI and has been mentioned to be deprecated: https://github.com/github/github-services/issues/503#issuecomment-12654988

If you are good with removing :bio i will send another request
