### PR TITLE
Fixing wrong example in documentation for org_issues

### DIFF
--- a/Octokit/Client/Issues.html
+++ b/Octokit/Client/Issues.html
@@ -1855,11 +1855,11 @@ format: YYYY-MM-DDTHH:MM:SSZ</p>
     <p class="tag_title">Examples:</p>
     
       
-        <p class="example_title"><div class='inline'><p>List issues for the authenticted user across owned and member repositories</p>
+        <p class="example_title"><div class='inline'><p>List all issues for a given organization for the authenticated user</p>
 </div></p>
       
       <pre class="example code"><code><span class='ivar'>@client</span> <span class='op'>=</span> <span class='const'>Octokit</span><span class='op'>::</span><span class='const'>Client</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='symbol'>:login</span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>foo</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='symbol'>:password</span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>bar</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
-<span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_user_issues'>user_issues</span></code></pre>
+<span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_user_issues'>org_issues</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>octokit<span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span></code></pre>
     
   </div>
 <p class="tag_title">Parameters:</p>


### PR DESCRIPTION
There was a wrong example displayed for Client.org_issues. Instead of .org_issues, there was a .user_issues
This is a fix for it.
