### PR TITLE
Reset Octokit before and after Authorization and Client specs

### DIFF
--- a/spec/octokit/client/authorizations_spec.rb
+++ b/spec/octokit/client/authorizations_spec.rb
@@ -7,6 +7,10 @@ describe Octokit::Client::Authorizations do
     @client = basic_auth_client
   end
 
+  after do
+    Octokit.reset!
+  end
+
   describe ".create_authorization", :vcr do
     context 'without :idempotent => true' do
       it "creates an API authorization" do

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -3,6 +3,14 @@ require 'json'
 
 describe Octokit::Client do
 
+  before do
+    Octokit.reset!
+  end
+
+  after do
+    Octokit.reset!
+  end
+
   describe "module configuration" do
 
     before do


### PR DESCRIPTION
Added `Octokit.reset!` calls to before and after in the top level of the
Authorizations and Client specs.

Fixes cases such as https://travis-ci.org/octokit/octokit.rb/jobs/16294010
where the modified client leaked between test cases causing seemingly
random VCR request match failures.

I'm not sure how to run select specs in a certain order so I brute forced
my way to reproducing the issue with the following:

``` bash
$ while clear; script/test; do :; done
```
