### PR TITLE
Fix "Faraday::Builder is now Faraday::RackBuilder" warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Often, it helps to know what Octokit is doing under the hood. Faraday makes it
 easy to peek into the underlying HTTP traffic:
 
 ```ruby
-stack = Faraday::Builder.new do |builder|
+stack = Faraday::RackBuilder.new do |builder|
   builder.response :logger
   builder.use Octokit::Response::RaiseError
   builder.adapter Faraday.default_adapter
@@ -417,7 +417,7 @@ Add the gem to your Gemfile
 Next, construct your own Faraday middleware:
 
 ```ruby
-stack = Faraday::Builder.new do |builder|
+stack = Faraday::RackBuilder.new do |builder|
   builder.use Faraday::HttpCache
   builder.use Octokit::Response::RaiseError
   builder.adapter Faraday.default_adapter

--- a/lib/octokit/configurable.rb
+++ b/lib/octokit/configurable.rb
@@ -26,7 +26,7 @@ module Octokit
     #   @return [String] GitHub username for Basic Authentication
     # @!attribute middleware
     #   @see https://github.com/lostisland/faraday
-    #   @return [Faraday::Builder] Configure middleware for Faraday
+    #   @return [Faraday::Builder or Faraday::RackBuilder] Configure middleware for Faraday
     # @!attribute netrc
     #   @return [Boolean] Instruct Octokit to get credentials from .netrc file
     # @!attribute netrc_file

--- a/lib/octokit/default.rb
+++ b/lib/octokit/default.rb
@@ -19,8 +19,11 @@ module Octokit
     # Default WEB endpoint
     WEB_ENDPOINT = "https://github.com".freeze
 
-    # Default Faraday middleware stack
-    MIDDLEWARE = Faraday::Builder.new do |builder|
+    # In Faraday 0.9, Faraday::Builder was renamed to Faraday::RackBuilder
+    RACK_BUILDER_CLASS = defined?(Faraday::RackBuilder) ? Faraday::RackBuilder : Faraday::Builder
+
+    # Default Faraday middleware stack    
+    MIDDLEWARE = RACK_BUILDER_CLASS.new do |builder|
       builder.use Octokit::Response::RaiseError
       builder.use Octokit::Response::FeedParser
       builder.adapter Faraday.default_adapter


### PR DESCRIPTION
In Faraday 0.9, Faraday::Builder was renamed to Faraday::RackBuilder. Support both versions of Faraday.

Fix #413
