### PR TITLE
Add test repository setup and teardown helpers.

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -48,6 +48,9 @@ VCR.configure do |c|
   }
   c.cassette_library_dir = 'spec/cassettes'
   c.hook_into :webmock
+  c.after_http_request(:real?, lambda { |req| req.uri =~ /user\/repos/ }) do
+    sleep 5
+  end
 end
 
 def test_github_login


### PR DESCRIPTION
Added `test_repo` test helper method to generate a unique-enough
repository name and filter it from VCR cassettes as
`<GITHUB_TEST_REPOSITORY>`.

Added `setup_test_repo` test helper method to create a new repository on
GitHub to test against. Method returns the newly created repository.

Added `teardown_test_repo` test helper method to delete a test repository
from GitHub. Method takes a full repository name.

These methods will remove the need for hardcoded test repository names which cause headaches for anyone working on existing tests or adding new methods instead of a group of tests that utilize any type of setup in a `before` block. Example usage can be seen in https://github.com/octokit/octokit.rb/pull/403#issue-25510917.
