### PR TITLE
Use rspec 3.0.0.beta2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'mime-types', '< 2.0.0'
   gem 'netrc', '~> 0.7.7'
   gem 'rb-fsevent', '~> 0.9'
-  gem 'rspec', '>= 2.14'
+  gem 'rspec', '~> 3.0.0.beta2'
   gem 'simplecov', :require => false
   gem 'test-queue', '>= 0.1.3'
   gem 'vcr', '~> 2.4'

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -15,7 +15,7 @@ require 'webmock/rspec'
 WebMock.disable_net_connect!(:allow => 'coveralls.io')
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.raise_errors_for_deprecations!
 end
 
 require 'vcr'
@@ -130,4 +130,3 @@ end
 def oauth_client
   Octokit::Client.new(:access_token => test_github_token)
 end
-

--- a/spec/octokit/rate_limit_spec.rb
+++ b/spec/octokit/rate_limit_spec.rb
@@ -5,7 +5,7 @@ describe Octokit::RateLimit do
 
   it "parses rate limit info from response headers" do
     response = double()
-    response.should_receive(:headers).
+    expect(response).to receive(:headers).
       at_least(:once).
       and_return({
         "X-RateLimit-Limit" => 60,


### PR DESCRIPTION
After @sferik work on the warnings (#434), we can now upgrade to latest rspec, and raise on rspec warnings. 
