### PR TITLE
Add RateLimit#exceeded?, Fix autopaginate for Enterprise.

### DIFF
--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -196,7 +196,7 @@ module Octokit
       data = request(:get, url, opts)
 
       if @auto_paginate
-        while @last_response.rels[:next] && !rate_limit.exceeded?
+        while @last_response.rels[:next] && !rate_limit.remaining.zero?
           @last_response = @last_response.rels[:next].get
           if block_given?
             yield(data, @last_response)

--- a/lib/octokit/rate_limit.rb
+++ b/lib/octokit/rate_limit.rb
@@ -21,8 +21,8 @@ module Octokit
     def self.from_response(response)
       info = new
       if response && !response.headers.nil?
-        info.limit = response.headers['X-RateLimit-Limit'].to_i
-        info.remaining = response.headers['X-RateLimit-Remaining'].to_i
+        info.limit = (response.headers['X-RateLimit-Limit'] || 5000).to_i
+        info.remaining = (response.headers['X-RateLimit-Remaining'] || 5000).to_i
         info.resets_at = Time.at(response.headers['X-RateLimit-Reset'].to_i)
         info.resets_in = (info.resets_at - Time.now).to_i
       end
@@ -30,15 +30,5 @@ module Octokit
       info
     end
 
-    # Check if rate limit exceeded
-    #
-    # @return [Boolean] Rate limit exceeded
-    def exceeded?
-      if remaining.is_a? Integer
-        remaining.zero?
-      else
-        false
-      end
-    end
   end
 end

--- a/spec/octokit/rate_limit_spec.rb
+++ b/spec/octokit/rate_limit_spec.rb
@@ -27,36 +27,15 @@ describe Octokit::RateLimit do
     expect(info.resets_at).to be_nil
   end
 
-  describe ".exceeded?" do
-    context "with exceeded rate limit" do
-      it "returns true" do
-        response = double()
-        expect(response).to receive(:headers).
-          at_least(:once).
-          and_return({"X-RateLimit-Remaining" => 0})
-        rate_limit = Octokit::RateLimit.from_response(response)
-        expect(rate_limit.exceeded?).to be true
-      end
-    end # with exceeded rate limit
-
-    context "without exceeded rate limit" do
-      it "returns false" do
-        response = double()
-        expect(response).to receive(:headers).
-          at_least(:once).
-          and_return({"X-RateLimit-Remaining" => 1})
-        rate_limit = Octokit::RateLimit.from_response(response)
-        expect(rate_limit.exceeded?).to be false
-      end
-    end # without exceeded rate limit
-
-    context "without rate limit headers" do
-      it "returns false" do
-        response = double()
-        expect(response).to receive(:headers).at_least(:once)
-        rate_limit = Octokit::RateLimit.from_response(response)
-        expect(rate_limit.exceeded?).to be false
-      end
-    end # without rate limit headers
-  end # .exceeded?
+  context "without rate limit headers" do
+    it "defaults remaining and limit to 5000" do
+      response = double
+      expect(response).to receive(:headers).
+        at_least(:once).
+        and_return({"X-RateLimit-Reset" => Time.now.to_i})
+      rate_limit = Octokit::RateLimit.from_response(response)
+      expect(rate_limit.remaining).to eq 5000
+      expect(rate_limit.limit).to eq 5000
+    end
+  end # without rate limit headers
 end


### PR DESCRIPTION
Added #exceeded? method to check if the rate limit is currently
exceeded. Returns false if there are no rate limit headers provided with
responses which is the case for GitHub enterprise users.
#437
