### PR TITLE
Fixing #437; no rate_limit headers are send by Enterprise

### DIFF
--- a/lib/octokit/rate_limit.rb
+++ b/lib/octokit/rate_limit.rb
@@ -21,9 +21,9 @@ module Octokit
     def self.from_response(response)
       info = new
       if response && !response.headers.nil?
-        info.limit = response.headers['X-RateLimit-Limit'].to_i
-        info.remaining = response.headers['X-RateLimit-Remaining'].to_i
-        info.resets_at = Time.at(response.headers['X-RateLimit-Reset'].to_i)
+        info.limit = (response.headers['X-RateLimit-Limit'] || 1).to_i
+        info.remaining = (response.headers['X-RateLimit-Remaining'] || 1).to_i
+        info.resets_at = Time.at((response.headers['X-RateLimit-Reset'] || Time.now).to_i)
         info.resets_in = (info.resets_at - Time.now).to_i
       end
 

--- a/spec/octokit/rate_limit_spec.rb
+++ b/spec/octokit/rate_limit_spec.rb
@@ -19,6 +19,18 @@ describe Octokit::RateLimit do
     expect(info.resets_at).to be_kind_of(Time)
   end
 
+  it "returns a positive rate limit for Enterprise" do
+    response = double()
+    expect(response).to receive(:headers).
+      at_least(:once).
+      and_return({ })
+    info = Octokit::RateLimit.from_response(response)
+    expect(info.limit).to eq(1)
+    expect(info.remaining).to eq(1)
+    expect(info.resets_in).to eq(0)
+    expect(info.resets_at).to be_kind_of(Time)
+  end
+
   it "handles nil responses" do
     info = Octokit::RateLimit.from_response(nil)
     expect(info.limit).to be_nil


### PR DESCRIPTION
This fix prevents the rate_limit to be set to 0 when no headers are
present
