### PR TITLE
Return Error documentation url if error data is a hash.

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -41,7 +41,7 @@ module Octokit
     #
     # @return [String]
     def documentation_url
-      data[:documentation_url] if data
+      data[:documentation_url] if data.is_a? Hash
     end
 
     # Returns most appropriate error for 401 HTTP status code

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -561,6 +561,16 @@ describe Octokit::Client do
         expect(e.documentation_url).to eq("http://developer.github.com/v3")
       end
     end
+
+    it "handles an error response with an array body" do
+      stub_get('/user').to_return \
+        :status => 500,
+        :headers => {
+          :content_type => "application/json"
+        },
+        :body => [].to_json
+      expect { Octokit.get('/user') }.to raise_error Octokit::ServerError
+    end
   end
 
   it "knows the difference between unauthorized and needs OTP" do


### PR DESCRIPTION
I don't have a reliable way of getting an error with an array body from the server but there is a path to it in the current code. Based on the stack trace and reviewing the code I believe this will fix #441.

/cc @pengwynn
