### PR TITLE
Expect the payload to return properly decoded from GitHub

### DIFF
--- a/lib/octokit/client/deployments.rb
+++ b/lib/octokit/client/deployments.rb
@@ -15,7 +15,7 @@ module Octokit
       # @see http://developer.github.com/v3/repos/deployments/#list-deployments
       def deployments(repo, options = {})
         options = ensure_deployments_api_media_type(options)
-        deployments = get("repos/#{Repository.new(repo)}/deployments", options)
+        get("repos/#{Repository.new(repo)}/deployments", options)
       end
       alias :list_deployments :deployments
 
@@ -32,7 +32,7 @@ module Octokit
       def create_deployment(repo, ref, options = {})
         options = ensure_deployments_api_media_type(options)
         options[:ref] = ref
-        deployment = post("repos/#{Repository.new(repo)}/deployments", options)
+        post("repos/#{Repository.new(repo)}/deployments", options)
       end
 
       # List all statuses for a Deployment
@@ -43,7 +43,7 @@ module Octokit
       def deployment_statuses(deployment_url, options = {})
         options = ensure_deployments_api_media_type(options)
         deployment = get(deployment_url, :accept => options[:accept])
-        statuses = get(deployment.rels[:statuses].href, options)
+        get(deployment.rels[:statuses].href, options)
       end
       alias :list_deployment_statuses :deployment_statuses
 
@@ -57,7 +57,7 @@ module Octokit
         options = ensure_deployments_api_media_type(options)
         deployment = get(deployment_url, :accept => options[:accept])
         options[:state] = state.to_s.downcase
-        status = post(deployment.rels[:statuses].href, options)
+        post(deployment.rels[:statuses].href, options)
       end
 
       private


### PR DESCRIPTION
Remove the manual decoding of the payloads since we're going to start sending them back as normal JSON today or tomorrow.

I looked into regenerating the cassettes but didn't seen an obvious way to change the repository that things were working on. I did find [this issue]() that was helpful. Are there docs somewhere that I'm missing?
