### PR TITLE
Run coverage for ruby RUBY_ENGINE only.

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,11 +1,13 @@
-require 'simplecov'
-require 'coveralls'
+if RUBY_ENGINE == 'ruby'
+  require 'simplecov'
+  require 'coveralls'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]
-SimpleCov.start
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+  SimpleCov.start
+end
 
 require 'json'
 require 'octokit'


### PR DESCRIPTION
We can speed up the travis build by running coverage for MRI rubies. RBX build speeds up by 4~ minutes on CI, goes from 3 minutes to 30 seconds locally.
