### PR TITLE
Remove VCR.turned_off blocks

### DIFF
--- a/spec/octokit/client/legacy_search_spec.rb
+++ b/spec/octokit/client/legacy_search_spec.rb
@@ -23,19 +23,17 @@ describe Octokit::Client::LegacySearch do
     end
   end # .legacy_search_repos
 
-  describe ".legacy_search_users", :vcr do
-    it "returns matching username" do
+  describe ".legacy_search_users" do
+    it "returns matching username", :vcr do
       users = @client.legacy_search_users("sferik")
       expect(users.first.username).to eq("sferik")
       assert_requested :get, github_url("/legacy/user/search/sferik")
     end
+
     it "should not raise URI::InvalidURIError and returns success" do
-      VCR.eject_cassette
-      VCR.turned_off do
-        stub_get("https://api.github.com/legacy/user/search/followers:>0")
-        expect { @client.legacy_search_users("followers:>0") }.not_to raise_error
-        assert_requested :get, github_url("/legacy/user/search/followers:%3E0")
-      end
+      stub_get("https://api.github.com/legacy/user/search/followers:>0")
+      expect { @client.legacy_search_users("followers:>0") }.not_to raise_error
+      assert_requested :get, github_url("/legacy/user/search/followers:%3E0")
     end
   end # .legacy_searcy_users
 

--- a/spec/octokit/client/organizations_spec.rb
+++ b/spec/octokit/client/organizations_spec.rb
@@ -199,14 +199,11 @@ describe Octokit::Client::Organizations do
 
   end # new team methods
 
-  describe ".remove_organization_member", :vcr do
+  describe ".remove_organization_member" do
     it "removes a member from an organization" do
-      VCR.eject_cassette
-      VCR.turned_off do
-        stub_delete github_url("/orgs/api-playground/members/api-padawan")
-        @client.remove_organization_member("api-playground", "api-padawan")
-        assert_requested :delete, github_url("/orgs/api-playground/members/api-padawan")
-      end
+      stub_delete github_url("/orgs/api-playground/members/api-padawan")
+      @client.remove_organization_member("api-playground", "api-padawan")
+      assert_requested :delete, github_url("/orgs/api-playground/members/api-padawan")
     end
   end # .remove_organization_member
 

--- a/spec/octokit/client/pub_sub_hubbub_spec.rb
+++ b/spec/octokit/client/pub_sub_hubbub_spec.rb
@@ -9,20 +9,19 @@ describe Octokit::Client::PubSubHubbub do
 
   describe ".subscribe" do
     it "subscribes to pull events" do
-      VCR.turned_off do
-        request = stub_post(github_url("/hub")).
-          with(:body => {
-            :"hub.callback" => 'github://Travis?token=travistoken',
-            :"hub.mode" => 'subscribe',
-            :"hub.topic" => 'https://github.com/elskwid/github-services/events/push',
-            :"hub.secret" => '12345'
-          }).
-          to_return(:status => 204)
-        result = @client.subscribe("https://github.com/elskwid/github-services/events/push", "github://Travis?token=travistoken", "12345")
-        expect(result).to be true
-        assert_requested request
-      end
+      request = stub_post(github_url("/hub")).
+        with(:body => {
+          :"hub.callback" => 'github://Travis?token=travistoken',
+          :"hub.mode" => 'subscribe',
+          :"hub.topic" => 'https://github.com/elskwid/github-services/events/push',
+          :"hub.secret" => '12345'
+        }).
+        to_return(:status => 204)
+      result = @client.subscribe("https://github.com/elskwid/github-services/events/push", "github://Travis?token=travistoken", "12345")
+      expect(result).to be true
+      assert_requested request
     end
+
     it "raises an error when topic is not recognized", :vcr do
       subscribe_request_body = {
         :"hub.callback" => 'github://Travis?token=travistoken',
@@ -54,20 +53,19 @@ describe Octokit::Client::PubSubHubbub do
 
   describe ".subscribe_service_hook" do
     it "subscribes to pull event on specified topic" do
-      VCR.turned_off do
-        request = stub_post(github_url("/hub")).
-          with(:body => {
-            :"hub.callback" => 'github://Travis?token=travistoken',
-            :"hub.mode" => 'subscribe',
-            :"hub.topic" => 'https://github.com/elskwid/github-services/events/push',
-            :"hub.secret" => '12345'
-          }).
-          to_return(:status => 204)
-        result = @client.subscribe_service_hook("elskwid/github-services", "Travis", { :token => 'travistoken' }, "12345")
-        expect(result).to be true
-        assert_requested request
-      end
+      request = stub_post(github_url("/hub")).
+        with(:body => {
+          :"hub.callback" => 'github://Travis?token=travistoken',
+          :"hub.mode" => 'subscribe',
+          :"hub.topic" => 'https://github.com/elskwid/github-services/events/push',
+          :"hub.secret" => '12345'
+        }).
+        to_return(:status => 204)
+      result = @client.subscribe_service_hook("elskwid/github-services", "Travis", { :token => 'travistoken' }, "12345")
+      expect(result).to be true
+      assert_requested request
     end
+
     it "encodes URL parameters", :vcr  do
       irc_request_body = {
         :"hub.callback" => 'github://irc?server=chat.freenode.org&room=%23myproject',

--- a/spec/octokit/client/pull_requests_spec.rb
+++ b/spec/octokit/client/pull_requests_spec.rb
@@ -133,11 +133,9 @@ describe Octokit::Client::PullRequests do
   # stub this so we don't have to set up new fixture data
   describe ".merge_pull_request" do
     it "merges the pull request" do
-      VCR.turned_off do
-        request = stub_put(github_url("/repos/api-playground/api-sandbox/pulls/123/merge"))
-        @client.merge_pull_request("api-playground/api-sandbox", 123)
-        assert_requested request
-      end
+      request = stub_put(github_url("/repos/api-playground/api-sandbox/pulls/123/merge"))
+      @client.merge_pull_request("api-playground/api-sandbox", 123)
+      assert_requested request
     end
   end # .merge_pull_request
 

--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -17,27 +17,23 @@ describe Octokit::Client::Repositories do
 
   describe ".set_private" do
     it "sets a repository private" do
-      VCR.turned_off do
-        repo_name = "api-playground/api-sandbox"
-        # Stub this because Padawan is on a free plan
-        request = stub_patch(github_url("/repos/#{repo_name}")).
-          with(:body => {:private => true, :name => "api-sandbox"}.to_json)
-        @client.set_private repo_name
-        assert_requested request
-      end
+      repo_name = "api-playground/api-sandbox"
+      # Stub this because Padawan is on a free plan
+      request = stub_patch(github_url("/repos/#{repo_name}")).
+        with(:body => {:private => true, :name => "api-sandbox"}.to_json)
+      @client.set_private repo_name
+      assert_requested request
     end
   end # .set_private
 
   describe ".set_public" do
     it "sets a repository public" do
-      VCR.turned_off do
-        repo_name = "api-playground/api-sandbox"
-        # Stub this because Padawan is on a free plan
-        request = stub_patch(github_url("/repos/#{repo_name}")).
-          with(:body => {:private => false, :name => "api-sandbox"}.to_json)
-        @client.set_public repo_name
-        assert_requested request
-      end
+      repo_name = "api-playground/api-sandbox"
+      # Stub this because Padawan is on a free plan
+      request = stub_patch(github_url("/repos/#{repo_name}")).
+        with(:body => {:private => false, :name => "api-sandbox"}.to_json)
+      @client.set_public repo_name
+      assert_requested request
     end
   end # .set_public
 
@@ -57,47 +53,39 @@ describe Octokit::Client::Repositories do
 
   describe ".add_deploy_key" do
     it "adds a repository deploy keys" do
-      VCR.turned_off do
-        repo_name = "api-playground/api-sandbox"
-        request = stub_post(github_url("/repos/#{repo_name}/keys"))
-        @client.add_deploy_key(repo_name, "Padawan", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDN/h7Hf5TA6G4p19deF8YS9COfuBd133GPs49tO6AU/DKIt7tlitbnUnttT0VbNZM4fplyinPu5vJl60eusn/Ngq2vDfSHP5SfgHfA9H8cnHGPYG7w6F0CujFB3tjBhHa3L6Je50E3NC4+BGGhZMpUoTClEI5yEzx3qosRfpfJu/2MUp/V2aARCAiHUlUoj5eiB15zC25uDsY7SYxkh1JO0ecKSMISc/OCdg0kwi7it4t7S/qm8Wh9pVGuA5FmVk8w0hvL+hHWB9GT02WPqiesMaS9Sj3t0yuRwgwzLDaudQPKKTKYXi+SjwXxTJ/lei2bZTMC4QxYbqfqYQt66pQB wynn.netherland+api-padawan@gmail.com" )
-        assert_requested request
-      end
+      repo_name = "api-playground/api-sandbox"
+      request = stub_post(github_url("/repos/#{repo_name}/keys"))
+      @client.add_deploy_key(repo_name, "Padawan", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDN/h7Hf5TA6G4p19deF8YS9COfuBd133GPs49tO6AU/DKIt7tlitbnUnttT0VbNZM4fplyinPu5vJl60eusn/Ngq2vDfSHP5SfgHfA9H8cnHGPYG7w6F0CujFB3tjBhHa3L6Je50E3NC4+BGGhZMpUoTClEI5yEzx3qosRfpfJu/2MUp/V2aARCAiHUlUoj5eiB15zC25uDsY7SYxkh1JO0ecKSMISc/OCdg0kwi7it4t7S/qm8Wh9pVGuA5FmVk8w0hvL+hHWB9GT02WPqiesMaS9Sj3t0yuRwgwzLDaudQPKKTKYXi+SjwXxTJ/lei2bZTMC4QxYbqfqYQt66pQB wynn.netherland+api-padawan@gmail.com" )
+      assert_requested request
     end
   end # .add_deploy_key
 
   describe ".deploy_key" do
     it "returns a specific deploy key for a repo" do
-      VCR.turned_off do
-        repo = "api-playground/api-sandbox"
-        key_id = 8675309
-        request = stub_get github_url "/repos/#{repo}/keys/#{key_id}"
-        @client.deploy_key repo, key_id
-        assert_requested request
-      end
+      repo = "api-playground/api-sandbox"
+      key_id = 8675309
+      request = stub_get github_url "/repos/#{repo}/keys/#{key_id}"
+      @client.deploy_key repo, key_id
+      assert_requested request
     end
   end # .deploy_key
 
   describe ".edit_deploy_key" do
     it "modifies a deploy key" do
-      VCR.turned_off do
-        repo = "api-playground/api-sandbox"
-        key_id = 8675309
-        request = stub_patch github_url "/repos/#{repo}/keys/#{key_id}"
-        @client.edit_deploy_key(repo, key_id, :title => 'Staging')
-        assert_requested request
-      end
+      repo = "api-playground/api-sandbox"
+      key_id = 8675309
+      request = stub_patch github_url "/repos/#{repo}/keys/#{key_id}"
+      @client.edit_deploy_key(repo, key_id, :title => 'Staging')
+      assert_requested request
     end
   end # .edit_deploy_key
 
   describe ".remove_deploy_key" do
     it "removes a repository deploy keys" do
-      VCR.turned_off do
-        repo_name = "api-playground/api-sandbox"
-        request = stub_delete(github_url("/repos/#{repo_name}/keys/1234"))
-        @client.remove_deploy_key(repo_name, 1234)
-        assert_requested request
-      end
+      repo_name = "api-playground/api-sandbox"
+      request = stub_delete(github_url("/repos/#{repo_name}/keys/1234"))
+      @client.remove_deploy_key(repo_name, 1234)
+      assert_requested request
     end
   end # .remove_deploy_key
 

--- a/spec/octokit/client/users_spec.rb
+++ b/spec/octokit/client/users_spec.rb
@@ -219,16 +219,14 @@ describe Octokit::Client::Users do
 
   describe '.exchange_code_for_token' do
     it 'returns the access_token' do
-      VCR.turned_off do
-        post = stub_post("https://github.com/login/oauth/access_token").
-          with(:headers => {
-            :accept       => "application/json",
-            :content_type => "application/json"
-        }).to_return(json_response("web_flow_token.json"))
-        response = Octokit.exchange_code_for_token('code', 'id_here', 'secret_here')
-        expect(response.access_token).to eq('this_be_ye_token/use_it_wisely')
-        assert_requested post
-      end
+      post = stub_post("https://github.com/login/oauth/access_token").
+        with(:headers => {
+          :accept       => "application/json",
+          :content_type => "application/json"
+      }).to_return(json_response("web_flow_token.json"))
+      response = Octokit.exchange_code_for_token('code', 'id_here', 'secret_here')
+      expect(response.access_token).to eq('this_be_ye_token/use_it_wisely')
+      assert_requested post
     end
   end # .access_token
 

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -203,13 +203,12 @@ describe Octokit::Client do
           config.password = 'il0veruby'
         end
 
-        VCR.turned_off do
-          root_request = stub_get("https://pengwynn:il0veruby@api.github.com/")
-          Octokit.client.get("/")
-          assert_requested root_request
-        end
+        root_request = stub_get("https://pengwynn:il0veruby@api.github.com/")
+        Octokit.client.get("/")
+        assert_requested root_request
       end
     end
+
     describe "when token authenticated", :vcr do
       it "makes authenticated calls" do
         client = oauth_client
@@ -357,16 +356,14 @@ describe Octokit::Client do
       expect(conn.proxy[:uri].to_s).to eq('http://proxy.example.com')
     end
     it "passes along request headers for POST" do
-      VCR.turned_off do
-        headers = {"X-GitHub-Foo" => "bar"}
-        root_request = stub_post("/").
-          with(:headers => headers).
-          to_return(:status => 201)
-        client = Octokit::Client.new
-        client.post "/", :headers => headers
-        assert_requested root_request
-        expect(client.last_response.status).to eq(201)
-      end
+      headers = {"X-GitHub-Foo" => "bar"}
+      root_request = stub_post("/").
+        with(:headers => headers).
+        to_return(:status => 201)
+      client = Octokit::Client.new
+      client.post "/", :headers => headers
+      assert_requested root_request
+      expect(client.last_response.status).to eq(201)
     end
   end
 


### PR DESCRIPTION
Removed unnecessary turned off blocks as it is intended to be used
inside test blocks that are tagged with :vcr and make real requests.
These methods are completely stubbed and make no real requests and dont
need any partial vcr recordings.
