### PR TITLE
Add method for authenticated user path

### DIFF
--- a/lib/octokit/client/users.rb
+++ b/lib/octokit/client/users.rb
@@ -177,12 +177,7 @@ module Octokit
       # @example
       #   Octokit.starred('pengwynn')
       def starred(user=login, options = {})
-        if user == login && user_authenticated?
-          path = "user/starred"
-        else
-          path = "users/#{user}/starred"
-        end
-        paginate path, options
+        paginate user_path(user, 'starred'), options
       end
 
       # Check if you are starring a repo.
@@ -344,15 +339,20 @@ module Octokit
       # @example
       #   @client.subscriptions("pengwynn")
       def subscriptions(user=login, options = {})
-        if user == login && user_authenticated?
-          path = "user/subscriptions"
-        else
-          path = "users/#{user}/subscriptions"
-        end
-        paginate path, options
+        paginate user_path(user, 'subscriptions'), options
       end
       alias :watched :subscriptions
 
+    end
+
+    private
+    # convenience method for constructing a user specific path, if the user is logged in
+    def user_path(user, path)
+      if user == login && user_authenticated?
+        "user/#{path}"
+      else
+        "users/#{user}/#{path}"
+      end
     end
   end
 end


### PR DESCRIPTION
Small and maybe insignificant refactor to `lib/octokit/client/users.rb` to remove some duplication.

Originally I wanted this method to reside in `lib/octokit/client.rb` for use in [blocks like this](https://github.com/octokit/octokit.rb/blob/master/lib/octokit/client/gists.rb#L18-L24), which I think occurs in a few other places, however I found the authenticated Gists path to be different:
- `GET /user/starred` for repositories being starred by the authenticated user
- `GET /user/subscriptions` for repositories being watched by the authenticated user

vs. 
- `GET /gists` for authenticated user’s gists 
