### PR TITLE
Fix @see links in documentation

### DIFF
--- a/lib/octokit/authentication.rb
+++ b/lib/octokit/authentication.rb
@@ -6,7 +6,7 @@ module Octokit
     # Indicates if the client was supplied  Basic Auth
     # username and password
     #
-    # @see http://developer.github.com/v3/#authentication
+    # @see https://developer.github.com/v3/#authentication
     # @return [Boolean]
     def basic_authenticated?
       !!(@login && @password)
@@ -15,7 +15,7 @@ module Octokit
     # Indicates if the client was supplied an OAuth
     # access token
     #
-    # @see http://developer.github.com/v3/#authentication
+    # @see https://developer.github.com/v3/#authentication
     # @return [Boolean]
     def token_authenticated?
       !!@access_token
@@ -24,7 +24,7 @@ module Octokit
     # Indicates if the client was supplied an OAuth
     # access token or Basic Auth username and password
     #
-    # @see http://developer.github.com/v3/#authentication
+    # @see https://developer.github.com/v3/#authentication
     # @return [Boolean]
     def user_authenticated?
       basic_authenticated? || token_authenticated?
@@ -34,7 +34,7 @@ module Octokit
     # client_id and secret credentials to make anonymous
     # requests at a higher rate limit
     #
-    # @see http://developer.github.com/v3/#unauthenticated-rate-limited-requests
+    # @see https://developer.github.com/v3/#unauthenticated-rate-limited-requests
     # @return Boolean
     def application_authenticated?
       !!application_authentication

--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -45,7 +45,7 @@ module Octokit
 
   # Client for the GitHub API
   #
-  # @see http://developer.github.com
+  # @see https://developer.github.com
   class Client
 
     include Octokit::Authentication

--- a/lib/octokit/client/authorizations.rb
+++ b/lib/octokit/client/authorizations.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Authorizations API
     #
-    # @see http://developer.github.com/v3/oauth_authorizations/#oauth-authorizations-api
+    # @see https://developer.github.com/v3/oauth_authorizations/#oauth-authorizations-api
     module Authorizations
 
       # List the authenticated user's authorizations
@@ -13,7 +13,7 @@ module Octokit
       # Basic Authentication.
       #
       # @return [Array<Sawyer::Resource>] A list of authorizations for the authenticated user
-      # @see http://developer.github.com/v3/oauth_authorizations/#list-your-authorizations
+      # @see https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations
       # @example List authorizations for user ctshryock
       #  client = Octokit::Client.new(:login => 'ctshryock', :password => 'secret')
       #  client.authorizations
@@ -27,7 +27,7 @@ module Octokit
       # Basic Authentication.
       #
       # @return [Sawyer::Resource] A single authorization for the authenticated user
-      # @see http://developer.github.com/v3/oauth_authorizations/#get-a-single-authorization
+      # @see https://developer.github.com/v3/oauth_authorizations/#get-a-single-authorization
       # @example Show authorization for user ctshryock's Travis auth
       #  client = Octokit::Client.new(:login => 'ctshryock', :password => 'secret')
       #  client.authorization(999999)
@@ -49,9 +49,9 @@ module Octokit
       # @option options [String] :client_secret  Client Secret we received when our application was registered with GitHub.
       #
       # @return [Sawyer::Resource] A single authorization for the authenticated user
-      # @see http://developer.github.com/v3/oauth/#scopes Available scopes
-      # @see http://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
-      # @see http://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app
+      # @see https://developer.github.com/v3/oauth/#scopes Available scopes
+      # @see https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
+      # @see https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app
       # @example Create a new authorization for user ctshryock's project Zoidberg
       #  client = Octokit::Client.new(:login => 'ctshryock', :password => 'secret')
       #  client.create_authorization({:scopes => ["public_repo","gist"], :note => "Why not Zoidberg?", :note_url=> "https://en.wikipedia.org/wiki/Zoidberg"})
@@ -85,8 +85,8 @@ module Octokit
       # @option options [String] :note_url A URL to remind you what app the OAuth token is for.
       #
       # @return [Sawyer::Resource] A single (updated) authorization for the authenticated user
-      # @see http://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization
-      # @see http://developer.github.com/v3/oauth/#scopes for available scopes
+      # @see https://developer.github.com/v3/oauth_authorizations/#update-an-existing-authorization
+      # @see https://developer.github.com/v3/oauth/#scopes for available scopes
       # @example Update the authorization for user ctshryock's project Zoidberg
       #  client = Octokit::Client.new(:login => 'ctshryock', :password => 'secret')
       #  client.update_authorization(999999, {:add_scopes => ["gist", "repo"], :note => "Why not Zoidberg possibly?"})
@@ -102,7 +102,7 @@ module Octokit
       # @param number [Number] An existing Authorization ID
       #
       # @return [Boolean] Success
-      # @see http://developer.github.com/v3/oauth_authorizations/#delete-an-authorization
+      # @see https://developer.github.com/v3/oauth_authorizations/#delete-an-authorization
       # @example Delete an authorization
       #  client = Octokit::Client.new(:login => 'ctshryock', :password => 'secret')
       #  client.delete_authorization(999999)
@@ -114,7 +114,7 @@ module Octokit
       #
       # @param token [String] GitHub OAuth token
       # @return [Array<String>] OAuth scopes
-      # @see http://developer.github.com/v3/oauth/#scopes
+      # @see https://developer.github.com/v3/oauth/#scopes
       def scopes(token = @access_token)
         raise ArgumentError.new("Access token required") if token.nil?
 
@@ -136,7 +136,7 @@ module Octokit
     # @option options [String] :state A random string to protect against CSRF.
     # @return [String] The url to redirect the user to authorize.
     # @see Octokit::Client
-    # @see http://developer.github.com/v3/oauth/#web-application-flow
+    # @see https://developer.github.com/v3/oauth/#web-application-flow
     # @example
     #   @client.authorize_url('xxxx')
     def authorize_url(app_id = client_id, options = {})

--- a/lib/octokit/client/commit_comments.rb
+++ b/lib/octokit/client/commit_comments.rb
@@ -3,14 +3,14 @@ module Octokit
 
     # Methods for the Commit Comments API
     #
-    # @see http://developer.github.com/v3/repos/comments/
+    # @see https://developer.github.com/v3/repos/comments/
     module CommitComments
 
       # List all commit comments
       #
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Array] List of commit comments
-      # @see http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository
+      # @see https://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository
       def list_commit_comments(repo, options = {})
         get "repos/#{Repository.new(repo)}/comments", options
       end
@@ -20,7 +20,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param sha [String] The SHA of the commit whose comments will be fetched
       # @return [Array]  List of commit comments
-      # @see http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit
+      # @see https://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit
       def commit_comments(repo, sha, options = {})
         get "repos/#{Repository.new(repo)}/commits/#{sha}/comments", options
       end
@@ -30,7 +30,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param id [String] The ID of the comment to fetch
       # @return [Sawyer::Resource] Commit comment
-      # @see http://developer.github.com/v3/repos/comments/#get-a-single-commit-comment
+      # @see https://developer.github.com/v3/repos/comments/#get-a-single-commit-comment
       def commit_comment(repo, id, options = {})
         get "repos/#{Repository.new(repo)}/comments/#{id}", options
       end
@@ -44,7 +44,7 @@ module Octokit
       # @param line [Integer] Line number in the file to comment on
       # @param position [Integer] Line index in the diff to comment on
       # @return [Sawyer::Resource] Commit comment
-      # @see http://developer.github.com/v3/repos/comments/#create-a-commit-comment
+      # @see https://developer.github.com/v3/repos/comments/#create-a-commit-comment
       # @example Create a commit comment
       #   comment = Octokit.create_commit_comment("octocat/Hello-World", "827efc6d56897b048c772eb4087f854f46256132", "My comment message", "README.md", 10, 1)
       #   comment.commit_id # => "827efc6d56897b048c772eb4087f854f46256132"
@@ -69,7 +69,7 @@ module Octokit
       # @param id [String] The ID of the comment to update
       # @param body [String] Message
       # @return [Sawyer::Resource] Updated commit comment
-      # @see http://developer.github.com/v3/repos/comments/#update-a-commit-comment
+      # @see https://developer.github.com/v3/repos/comments/#update-a-commit-comment
       # @example Update a commit comment
       #   comment = Octokit.update_commit_comment("octocat/Hello-World", "860296", "Updated commit comment")
       #   comment.id # => 860296
@@ -86,7 +86,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param id [String] The ID of the comment to delete
       # @return [Boolean] Success
-      # @see http://developer.github.com/v3/repos/comments/#delete-a-commit-comment
+      # @see https://developer.github.com/v3/repos/comments/#delete-a-commit-comment
       def delete_commit_comment(repo, id, options = {})
         boolean_from_response :delete, "repos/#{Repository.new(repo)}/comments/#{id}", options
       end

--- a/lib/octokit/client/commits.rb
+++ b/lib/octokit/client/commits.rb
@@ -5,7 +5,7 @@ module Octokit
 
     # Methods for the Commits API
     #
-    # @see http://developer.github.com/v3/repos/commits/
+    # @see https://developer.github.com/v3/repos/commits/
     module Commits
 
       # List commits
@@ -19,7 +19,7 @@ module Octokit
       #   @param repo [String, Hash, Repository] A GitHub repository
       #   @param options [String] :sha Commit SHA or branch name from which to start the list
       # @return [Array<Sawyer::Resource>] An array of hashes representing commits
-      # @see http://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
+      # @see https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
       def commits(*args)
         arguments = Octokit::RepoArguments.new(args)
         sha_or_branch = arguments.pop
@@ -43,7 +43,7 @@ module Octokit
       #   @param sha_or_branch [String] A commit SHA or branch name
       #   @param options [String] :sha Commit SHA or branch name from which to start the list
       # @return [Array<Sawyer::Resource>] An array of hashes representing commits
-      # @see http://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
+      # @see https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
       # @example
       #   Octokit.commits_since('octokit/octokit.rb', '2012-10-01')
       def commits_since(*args)
@@ -69,7 +69,7 @@ module Octokit
       #   @param date [String] Date on which we want to compare
       #   @param sha_or_branch [String] Commit SHA or branch name from which to start the list
       # @return [Array<Sawyer::Resource>] An array of hashes representing commits
-      # @see http://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
+      # @see https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
       # @example
       #   Octokit.commits_before('octokit/octokit.rb', '2012-10-01')
       def commits_before(*args)
@@ -95,7 +95,7 @@ module Octokit
       #   @param date [String] Date on which we want to compare
       #   @param sha_or_branch [String] Commit SHA or branch name from which to start the list
       # @return [Array<Sawyer::Resource>] An array of hashes representing commits
-      # @see http://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
+      # @see https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
       # @example
       #   Octokit.commits_on('octokit/octokit.rb', '2012-10-01')
       def commits_on(*args)
@@ -124,7 +124,7 @@ module Octokit
       #   @param end_date [String] End Date on which we want to compare
       #   @param sha_or_branch [String] Commit SHA or branch name from which to start the list
       # @return [Array<Sawyer::Resource>] An array of hashes representing commits
-      # @see http://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
+      # @see https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
       # @example
       #   Octokit.commits_on('octokit/octokit.rb', '2012-10-01', '2012-11-01')
       def commits_between(*args)
@@ -147,7 +147,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param sha [String] The SHA of the commit to fetch
       # @return [Sawyer::Resource] A hash representing the commit
-      # @see http://developer.github.com/v3/repos/commits/#get-a-single-commit
+      # @see https://developer.github.com/v3/repos/commits/#get-a-single-commit
       def commit(repo, sha, options = {})
         get "repos/#{Repository.new(repo)}/commits/#{sha}", options
       end
@@ -157,7 +157,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param sha [String] The SHA of the commit to fetch
       # @return [Sawyer::Resource] A hash representing the commit
-      # @see http://developer.github.com/v3/git/commits/#get-a-commit
+      # @see https://developer.github.com/v3/git/commits/#get-a-commit
       def git_commit(repo, sha, options = {})
         get "repos/#{Repository.new(repo)}/git/commits/#{sha}", options
       end
@@ -174,7 +174,7 @@ module Octokit
       # @param tree [String] The SHA of the tree object the new commit will point to
       # @param parents [String, Array] One SHA (for a normal commit) or an array of SHAs (for a merge) of the new commit's parent commits. If ommitted or empty, a root commit will be created
       # @return [Sawyer::Resource] A hash representing the new commit
-      # @see http://developer.github.com/v3/git/commits/#create-a-commit
+      # @see https://developer.github.com/v3/git/commits/#create-a-commit
       # @example Create a commit
       #   commit = Octokit.create_commit("octocat/Hello-World", "My commit message", "827efc6d56897b048c772eb4087f854f46256132", "7d1b31e74ee336d15cbd21741bc88a537ed063a0")
       #   commit.sha # => "7638417db6d59f3c431d3e1f261cc637155684cd"
@@ -193,7 +193,7 @@ module Octokit
       # @param start [String] The sha of the starting commit
       # @param endd [String] The sha of the ending commit
       # @return [Sawyer::Resource] A hash representing the comparison
-      # @see http://developer.github.com/v3/repos/commits/#compare-two-commits
+      # @see https://developer.github.com/v3/repos/commits/#compare-two-commits
       def compare(repo, start, endd, options = {})
         get "repos/#{Repository.new(repo)}/compare/#{start}...#{endd}", options
       end
@@ -205,7 +205,7 @@ module Octokit
       # @param head [String] The branch or SHA1 to merge
       # @option options [String] :commit_message The commit message for the merge
       # @return [Sawyer::Resource] A hash representing the comparison
-      # @see http://developer.github.com/v3/repos/merging/#perform-a-merge
+      # @see https://developer.github.com/v3/repos/merging/#perform-a-merge
       def merge(repo, base, head, options = {})
         params = {
           :base => base,

--- a/lib/octokit/client/contents.rb
+++ b/lib/octokit/client/contents.rb
@@ -5,7 +5,7 @@ module Octokit
 
     # Methods for the Repo Contents API
     #
-    # @see http://developer.github.com/v3/repos/contents/
+    # @see https://developer.github.com/v3/repos/contents/
     module Contents
 
       # Receive the default Readme for a repository
@@ -13,7 +13,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @option options [String] :ref name of the Commit/Branch/Tag. Defaults to “master”.
       # @return [Sawyer::Resource] The detail of the readme
-      # @see http://developer.github.com/v3/repos/contents/#get-the-readme
+      # @see https://developer.github.com/v3/repos/contents/#get-the-readme
       # @example Get the readme file for a repo
       #   Octokit.readme("octokit/octokit.rb")
       def readme(repo, options={})
@@ -26,7 +26,7 @@ module Octokit
       # @option options [String] :path A folder or file path
       # @option options [String] :ref name of the Commit/Branch/Tag. Defaults to “master”.
       # @return [Sawyer::Resource] The contents of a file or list of the files in the folder
-      # @see http://developer.github.com/v3/repos/contents/#get-contents
+      # @see https://developer.github.com/v3/repos/contents/#get-contents
       # @example List the contents of lib/octokit.rb
       #   Octokit.contents("octokit/octokit.rb", :path => 'lib/octokit.rb')
       def contents(repo, options={})
@@ -46,7 +46,7 @@ module Octokit
       #   @option options [String] :branch The branch on which to add the content
       #   @option options [String] :file Path or Ruby File object for content
       # @return [Sawyer::Resource] The contents and commit info for the addition
-      # @see http://developer.github.com/v3/repos/contents/#create-a-file
+      # @see https://developer.github.com/v3/repos/contents/#create-a-file
       # @example Add content at lib/octokit.rb
       #   Octokit.create_contents("octokit/octokit.rb",
       #                    "lib/octokit.rb",
@@ -95,7 +95,7 @@ module Octokit
       #   @option options [String] :branch The branch on which to update the content
       #   @option options [String] :file Path or Ruby File object for content
       # @return [Sawyer::Resource] The contents and commit info for the update
-      # @see http://developer.github.com/v3/repos/contents/#update-a-file
+      # @see https://developer.github.com/v3/repos/contents/#update-a-file
       # @example Update content at lib/octokit.rb
       #   Octokit.update_contents("octokit/octokit.rb",
       #                    "lib/octokit.rb",
@@ -123,7 +123,7 @@ module Octokit
       # @param sha [String] The _blob sha_ of the content to delete
       # @option options [String] :branch The branch on which to delete the content
       # @return [Sawyer::Resource] The commit info for the delete
-      # @see http://developer.github.com/v3/repos/contents/#delete-a-file
+      # @see https://developer.github.com/v3/repos/contents/#delete-a-file
       # @example Delete content at lib/octokit.rb
       #   Octokit.delete_contents("octokit/octokit.rb",
       #                    "lib/octokit.rb",
@@ -146,7 +146,7 @@ module Octokit
       # @option options format [String] Either tarball (default) or zipball.
       # @option options [String] :ref Optional valid Git reference, defaults to master.
       # @return [String] Location of the download
-      # @see http://developer.github.com/v3/repos/contents/#get-archive-link
+      # @see https://developer.github.com/v3/repos/contents/#get-archive-link
       # @example Get archive link for octokit/octokit.rb
       #   Octokit.archive_link("octokit/octokit.rb")
       def archive_link(repo, options={})

--- a/lib/octokit/client/deployments.rb
+++ b/lib/octokit/client/deployments.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Deployments API
     #
-    # @see http://developer.github.com/v3/repos/commits/deployments/
+    # @see https://developer.github.com/v3/repos/commits/deployments/
     module Deployments
 
       DEPLOYMENTS_PREVIEW_MEDIA_TYPE = "application/vnd.github.cannonball-preview+json".freeze
@@ -12,7 +12,7 @@ module Octokit
       #
       # @param repo [String, Repository, Hash] A GitHub repository
       # @return [Array<Sawyer::Resource>] A list of deployments
-      # @see http://developer.github.com/v3/repos/deployments/#list-deployments
+      # @see https://developer.github.com/v3/repos/deployments/#list-deployments
       def deployments(repo, options = {})
         options = ensure_deployments_api_media_type(options)
         get("repos/#{Repository.new(repo)}/deployments", options)
@@ -28,7 +28,7 @@ module Octokit
       # @option options [String] :auto_merge Optional parameter to merge the default branch into the requested deployment branch if necessary. Default: false
       # @option options [String] :description Optional short description.
       # @return [Sawyer::Resource] A deployment
-      # @see http://developer.github.com/v3/repos/deployments/#create-a-deployment
+      # @see https://developer.github.com/v3/repos/deployments/#create-a-deployment
       def create_deployment(repo, ref, options = {})
         options = ensure_deployments_api_media_type(options)
         options[:ref] = ref
@@ -39,7 +39,7 @@ module Octokit
       #
       # @param deployment_url [String] A URL for a deployment resource
       # @return [Array<Sawyer::Resource>] A list of deployment statuses
-      # @see http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+      # @see https://developer.github.com/v3/repos/deployments/#list-deployment-statuses
       def deployment_statuses(deployment_url, options = {})
         options = ensure_deployments_api_media_type(options)
         deployment = get(deployment_url, :accept => options[:accept])
@@ -52,7 +52,7 @@ module Octokit
       # @param deployment_url [String] A URL for a deployment resource
       # @param state [String] The state: pending, success, failure, error
       # @return [Sawyer::Resource] A deployment status
-      # @see http://developer.github.com/v3/repos/deployments/#create-a-deployment-status
+      # @see https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
       def create_deployment_status(deployment_url, state, options = {})
         options = ensure_deployments_api_media_type(options)
         deployment = get(deployment_url, :accept => options[:accept])

--- a/lib/octokit/client/downloads.rb
+++ b/lib/octokit/client/downloads.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Repo Downloads API
     #
-    # @see http://developer.github.com/v3/repos/downloads/
+    # @see https://developer.github.com/v3/repos/downloads/
     module Downloads
 
       # List available downloads for a repository
@@ -11,7 +11,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A Github Repository
       # @return [Array] A list of available downloads
       # @deprecated As of December 11th, 2012: https://github.com/blog/1302-goodbye-uploads
-      # @see http://developer.github.com/v3/repos/downloads/#list-downloads-for-a-repository
+      # @see https://developer.github.com/v3/repos/downloads/#list-downloads-for-a-repository
       # @example List all downloads for Github/Hubot
       #   Octokit.downloads("github/hubot")
       def downloads(repo, options={})
@@ -25,7 +25,7 @@ module Octokit
       # @param id [Integer] ID of the download
       # @return [Sawyer::Resource] A single download from the repository
       # @deprecated As of December 11th, 2012: https://github.com/blog/1302-goodbye-uploads
-      # @see http://developer.github.com/v3/repos/downloads/#get-a-single-download
+      # @see https://developer.github.com/v3/repos/downloads/#get-a-single-download
       # @example Get the "Robawt" download from Github/Hubot
       #   Octokit.download("github/hubot")
       def download(repo, id, options={})
@@ -37,7 +37,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param id [Integer] ID of the download
       # @deprecated As of December 11th, 2012: https://github.com/blog/1302-goodbye-uploads
-      # @see http://developer.github.com/v3/repos/downloads/#delete-a-download
+      # @see https://developer.github.com/v3/repos/downloads/#delete-a-download
       # @return [Boolean] Status
       # @example Get the "Robawt" download from Github/Hubot
       #   Octokit.delete_download("github/hubot", 1234)

--- a/lib/octokit/client/emojis.rb
+++ b/lib/octokit/client/emojis.rb
@@ -7,7 +7,7 @@ module Octokit
       # List all emojis used on GitHub
       #
       # @return [Sawyer::Resource] A list of all emojis on GitHub
-      # @see http://developer.github.com/v3/emojis/#emojis
+      # @see https://developer.github.com/v3/emojis/#emojis
       # @example List all emojis
       #   Octokit.emojis
       def emojis(options = {})

--- a/lib/octokit/client/events.rb
+++ b/lib/octokit/client/events.rb
@@ -3,14 +3,14 @@ module Octokit
 
     # Method for the Events API
     #
-    # @see http://developer.github.com/v3/activity/events/
-    # @see http://developer.github.com/v3/issues/events/
+    # @see https://developer.github.com/v3/activity/events/
+    # @see https://developer.github.com/v3/issues/events/
     module Events
 
       # List all public events for GitHub
       #
       # @return [Array<Sawyer::Resource>] A list of all public events from GitHub
-      # @see http://developer.github.com/v3/activity/events/#list-public-events
+      # @see https://developer.github.com/v3/activity/events/#list-public-events
       # @example List all pubilc events
       #   Octokit.public_events
       def public_events(options = {})
@@ -20,7 +20,7 @@ module Octokit
       # List all user events
       #
       # @return [Array<Sawyer::Resource>] A list of all user events
-      # @see http://developer.github.com/v3/activity/events/#list-events-performed-by-a-user
+      # @see https://developer.github.com/v3/activity/events/#list-events-performed-by-a-user
       # @example List all user events
       #   Octokit.user_events("sferik")
       def user_events(user, options = {})
@@ -31,7 +31,7 @@ module Octokit
       #
       # @param user [String] GitHub username
       # @return [Array<Sawyer::Resource>] A list of public user events
-      # @see http://developer.github.com/v3/activity/events/#list-public-events-performed-by-a-user
+      # @see https://developer.github.com/v3/activity/events/#list-public-events-performed-by-a-user
       # @example List public user events
       #   Octokit.user_events("sferik")
       def user_public_events(user, options = {})
@@ -41,7 +41,7 @@ module Octokit
       # List events that a user has received
       #
       # @return [Array<Sawyer::Resource>] A list of all user received events
-      # @see http://developer.github.com/v3/activity/events/#list-events-that-a-user-has-received
+      # @see https://developer.github.com/v3/activity/events/#list-events-that-a-user-has-received
       # @example List all user received events
       #   Octokit.received_events("sferik")
       def received_events(user, options = {})
@@ -51,7 +51,7 @@ module Octokit
       # List public events a user has received
       #
       # @return [Array<Sawyer::Resource>] A list of public user received events
-      # @see http://developer.github.com/v3/activity/events/#list-public-events-that-a-user-has-received
+      # @see https://developer.github.com/v3/activity/events/#list-public-events-that-a-user-has-received
       # @example List public user received events
       #   Octokit.received_public_events("sferik")
       def received_public_events(user, options = {})
@@ -62,7 +62,7 @@ module Octokit
       #
       # @param repo [String, Repository, Hash] A GitHub repository
       # @return [Array<Sawyer::Resource>] A list of events for a repository
-      # @see http://developer.github.com/v3/activity/events/#list-repository-events
+      # @see https://developer.github.com/v3/activity/events/#list-repository-events
       # @example List events for a repository
       #   Octokit.repository_events("sferik/rails_admin")
       def repository_events(repo, options = {})
@@ -73,7 +73,7 @@ module Octokit
       #
       # @param repo [String, Repository, Hash] A GitHub repository
       # @return [Array<Sawyer::Resource>] A list of events for a repository's network
-      # @see http://developer.github.com/v3/activity/events/#list-public-events-for-a-network-of-repositories
+      # @see https://developer.github.com/v3/activity/events/#list-public-events-for-a-network-of-repositories
       # @example List events for a repository's network
       #   Octokit.repository_network_events("sferik/rails_admin")
       def repository_network_events(repo, options = {})
@@ -86,7 +86,7 @@ module Octokit
       #
       # @param org [String] Organization GitHub handle
       # @return [Array<Sawyer::Resource>] List of all events from a GitHub organization
-      # @see http://developer.github.com/v3/activity/events/#list-events-for-an-organization
+      # @see https://developer.github.com/v3/activity/events/#list-events-for-an-organization
       # @example List events for the lostisland organization
       #   @client.organization_events("lostisland")
       def organization_events(org, options = {})
@@ -97,7 +97,7 @@ module Octokit
       #
       # @param org [String] Organization GitHub username
       # @return [Array<Sawyer::Resource>] List of public events from a GitHub organization
-      # @see http://developer.github.com/v3/activity/events/#list-public-events-for-an-organization
+      # @see https://developer.github.com/v3/activity/events/#list-public-events-for-an-organization
       # @example List public events for GitHub
       #   Octokit.organization_public_events("GitHub")
       def organization_public_events(org, options = {})
@@ -109,8 +109,8 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       #
       # @return [Array<Sawyer::Resource>] Array of all Issue Events for this Repository
-      # @see http://developer.github.com/v3/issues/events/#list-events-for-a-repository
-      # @see http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+      # @see https://developer.github.com/v3/issues/events/#list-events-for-a-repository
+      # @see https://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
       # @example Get all Issue Events for Octokit
       #   Octokit.repository_issue_events("octokit/octokit.rb")
       def repository_issue_events(repo, options = {})
@@ -124,7 +124,7 @@ module Octokit
       # @param number [Integer] Issue number
       #
       # @return [Array<Sawyer::Resource>] Array of events for that issue
-      # @see http://developer.github.com/v3/issues/events/#list-events-for-an-issue
+      # @see https://developer.github.com/v3/issues/events/#list-events-for-an-issue
       # @example List all issues events for issue #38 on octokit/octokit.rb
       #   Octokit.issue_events("octokit/octokit.rb", 38)
       def issue_events(repo, number, options = {})
@@ -137,7 +137,7 @@ module Octokit
       # @param number [Integer] Event number
       #
       # @return [Sawyer::Resource] A single Event for an Issue
-      # @see http://developer.github.com/v3/issues/events/#get-a-single-event
+      # @see https://developer.github.com/v3/issues/events/#get-a-single-event
       # @example Get Event information for ID 3094334 (a pull request was closed)
       #   Octokit.issue_event("octokit/octokit.rb", 3094334)
       def issue_event(repo, number, options = {})

--- a/lib/octokit/client/feeds.rb
+++ b/lib/octokit/client/feeds.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Feeds API
     #
-    # @see http://developer.github.com/v3/activity/feeds/
+    # @see https://developer.github.com/v3/activity/feeds/
     module Feeds
 
       # List Feeds
@@ -12,7 +12,7 @@ module Octokit
       # for more information.
       #
       # @return [Array<Sawyer::Resource>] list of feeds
-      # @see http://developer.github.com/v3/activity/feeds/#list-feeds
+      # @see https://developer.github.com/v3/activity/feeds/#list-feeds
       def feeds
         get "feeds"
       end

--- a/lib/octokit/client/gists.rb
+++ b/lib/octokit/client/gists.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Gists API
     #
-    # @see http://developer.github.com/v3/gists/
+    # @see https://developer.github.com/v3/gists/
     module Gists
 
       # List gists for a user or all public gists
@@ -14,7 +14,7 @@ module Octokit
       #   Octokit.gists('defunkt')
       # @example Fetch all public gists
       #   Octokit.gists
-      # @see http://developer.github.com/v3/gists/#list-gists
+      # @see https://developer.github.com/v3/gists/#list-gists
       def gists(username=nil, options = {})
         if username.nil?
           paginate 'gists', options
@@ -29,7 +29,7 @@ module Octokit
       # @return [Array<Sawyer::Resource>] A list of gists
       # @example Fetch all public gists
       #   Octokit.public_gists
-      # @see http://developer.github.com/v3/gists/#list-gists
+      # @see https://developer.github.com/v3/gists/#list-gists
       def public_gists(options = {})
         paginate 'gists/public', options
       end
@@ -37,7 +37,7 @@ module Octokit
       # List the authenticated user’s starred gists
       #
       # @return [Array<Sawyer::Resource>] A list of gists
-      # @see http://developer.github.com/v3/gists/#list-gists
+      # @see https://developer.github.com/v3/gists/#list-gists
       def starred_gists(options = {})
         paginate 'gists/starred', options
       end
@@ -46,7 +46,7 @@ module Octokit
       #
       # @param gist [String] ID of gist to fetch
       # @return [Sawyer::Resource] Gist information
-      # @see http://developer.github.com/v3/gists/#get-a-single-gist
+      # @see https://developer.github.com/v3/gists/#get-a-single-gist
       def gist(gist, options = {})
         get "gists/#{Gist.new(gist)}", options
       end
@@ -60,7 +60,7 @@ module Octokit
       #   should be the filename, the value a Hash with a :content key with text
       #   content of the Gist.
       # @return [Sawyer::Resource] Newly created gist info
-      # @see http://developer.github.com/v3/gists/#create-a-gist
+      # @see https://developer.github.com/v3/gists/#create-a-gist
       def create_gist(options = {})
         post 'gists', options
       end
@@ -79,7 +79,7 @@ module Octokit
       #   can be performed by including the filename with a null hash.
       # @return
       #   [Sawyer::Resource] Newly created gist info
-      # @see http://developer.github.com/v3/gists/#edit-a-gist
+      # @see https://developer.github.com/v3/gists/#edit-a-gist
       # @example Update a gist
       #   @client.edit_gist('some_id', {
       #     :files => {"boo.md" => {"content" => "updated stuff"}}
@@ -93,7 +93,7 @@ module Octokit
       #
       # @param gist [String] Gist ID
       # @return [Boolean] Indicates if gist is starred successfully
-      # @see http://developer.github.com/v3/gists/#star-a-gist
+      # @see https://developer.github.com/v3/gists/#star-a-gist
       def star_gist(gist, options = {})
         boolean_from_response :put, "gists/#{Gist.new(gist)}/star", options
       end
@@ -102,7 +102,7 @@ module Octokit
       #
       # @param gist [String] Gist ID
       # @return [Boolean] Indicates if gist is unstarred successfully
-      # @see http://developer.github.com/v3/gists/#unstar-a-gist
+      # @see https://developer.github.com/v3/gists/#unstar-a-gist
       def unstar_gist(gist, options = {})
         boolean_from_response :delete, "gists/#{Gist.new(gist)}/star", options
       end
@@ -111,7 +111,7 @@ module Octokit
       #
       # @param gist [String] Gist ID
       # @return [Boolean] Indicates if gist is starred
-      # @see http://developer.github.com/v3/gists/#check-if-a-gist-is-starred
+      # @see https://developer.github.com/v3/gists/#check-if-a-gist-is-starred
       def gist_starred?(gist, options = {})
         boolean_from_response :get, "gists/#{Gist.new(gist)}/star", options
       end
@@ -120,7 +120,7 @@ module Octokit
       #
       # @param gist [String] Gist ID
       # @return [Sawyer::Resource] Data for the new gist
-      # @see http://developer.github.com/v3/gists/#fork-a-gist
+      # @see https://developer.github.com/v3/gists/#fork-a-gist
       def fork_gist(gist, options = {})
         post "gists/#{Gist.new(gist)}/forks", options
       end
@@ -129,7 +129,7 @@ module Octokit
       #
       # @param gist [String] Gist ID
       # @return [Boolean] Indicating success of deletion
-      # @see http://developer.github.com/v3/gists/#delete-a-gist
+      # @see https://developer.github.com/v3/gists/#delete-a-gist
       def delete_gist(gist, options = {})
         boolean_from_response :delete, "gists/#{Gist.new(gist)}", options
       end
@@ -138,7 +138,7 @@ module Octokit
       #
       # @param gist_id [String] Gist Id.
       # @return [Array<Sawyer::Resource>] Array of hashes representing comments.
-      # @see http://developer.github.com/v3/gists/comments/#list-comments-on-a-gist
+      # @see https://developer.github.com/v3/gists/comments/#list-comments-on-a-gist
       # @example
       #   Octokit.gist_comments('3528ae645')
       def gist_comments(gist_id, options = {})
@@ -150,7 +150,7 @@ module Octokit
       # @param gist_id [String] Id of the gist.
       # @param gist_comment_id [Integer] Id of the gist comment.
       # @return [Sawyer::Resource] Hash representing gist comment.
-      # @see http://developer.github.com/v3/gists/comments/#get-a-single-comment
+      # @see https://developer.github.com/v3/gists/comments/#get-a-single-comment
       # @example
       #   Octokit.gist_comment('208sdaz3', 1451398)
       def gist_comment(gist_id, gist_comment_id, options = {})
@@ -164,7 +164,7 @@ module Octokit
       # @param gist_id [String] Id of the gist.
       # @param comment [String] Comment contents.
       # @return [Sawyer::Resource] Hash representing the new comment.
-      # @see http://developer.github.com/v3/gists/comments/#create-a-comment
+      # @see https://developer.github.com/v3/gists/comments/#create-a-comment
       # @example
       #   @client.create_gist_comment('3528645', 'This is very helpful.')
       def create_gist_comment(gist_id, comment, options = {})
@@ -180,7 +180,7 @@ module Octokit
       # @param gist_comment_id [Integer] Id of the gist comment to update.
       # @param comment [String] Updated comment contents.
       # @return [Sawyer::Resource] Hash representing the updated comment.
-      # @see http://developer.github.com/v3/gists/comments/#edit-a-comment
+      # @see https://developer.github.com/v3/gists/comments/#edit-a-comment
       # @example
       #   @client.update_gist_comment('208sdaz3', '3528645', ':heart:')
       def update_gist_comment(gist_id, gist_comment_id, comment, options = {})
@@ -195,7 +195,7 @@ module Octokit
       # @param gist_id [String] Id of the gist.
       # @param gist_comment_id [Integer] Id of the gist comment to delete.
       # @return [Boolean] True if comment deleted, false otherwise.
-      # @see http://developer.github.com/v3/gists/comments/#delete-a-comment
+      # @see https://developer.github.com/v3/gists/comments/#delete-a-comment
       # @example
       #   @client.delete_gist_comment('208sdaz3', '586399')
       def delete_gist_comment(gist_id, gist_comment_id, options = {})

--- a/lib/octokit/client/gitignore.rb
+++ b/lib/octokit/client/gitignore.rb
@@ -3,14 +3,14 @@ module Octokit
 
     # Methods for the Gitignore API
     #
-    # @see http://developer.github.com/v3/gitignore/
+    # @see https://developer.github.com/v3/gitignore/
     module Gitignore
 
       # Listing available gitignore templates.
       #
       # These templates can be passed option when creating a repository.
       #
-      # @see http://developer.github.com/v3/gitignore/#listing-available-templates
+      # @see https://developer.github.com/v3/gitignore/#listing-available-templates
       #
       # @return [Array<String>] List of templates.
       #
@@ -29,7 +29,7 @@ module Octokit
       #   case sensitive, make sure to use a valid name from the
       #   .gitignore_templates list.
       #
-      # @see http://developer.github.com/v3/gitignore/#get-a-single-template
+      # @see https://developer.github.com/v3/gitignore/#get-a-single-template
       #
       # @return [Sawyer::Resource] Gitignore template
       #

--- a/lib/octokit/client/hooks.rb
+++ b/lib/octokit/client/hooks.rb
@@ -7,7 +7,7 @@ module Octokit
       # List all Service Hooks supported by GitHub
       #
       # @return [Sawyer::Resource] A list of all hooks on GitHub
-      # @see http://developer.github.com/v3/repos/hooks/#services
+      # @see https://developer.github.com/v3/repos/hooks/#services
       # @example List all hooks
       #   Octokit.available_hooks
       def available_hooks(options = {})

--- a/lib/octokit/client/issues.rb
+++ b/lib/octokit/client/issues.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Issues API
     #
-    # @see http://developer.github.com/v3/issues/
+    # @see https://developer.github.com/v3/issues/
     module Issues
 
       # List issues for the authenticated user or repository
@@ -20,8 +20,8 @@ module Octokit
       # @option options [String] :direction (desc) Direction: <tt>asc</tt> or <tt>desc</tt>.
       # @option options [Integer] :page (1) Page number.
       # @return [Array<Sawyer::Resource>] A list of issues for a repository.
-      # @see http://developer.github.com/v3/issues/#list-issues-for-a-repository
-      # @see http://developer.github.com/v3/issues/#list-issues
+      # @see https://developer.github.com/v3/issues/#list-issues-for-a-repository
+      # @see https://developer.github.com/v3/issues/#list-issues
       # @example List issues for a repository
       #   Octokit.list_issues("sferik/rails_admin")
       # @example List issues for the authenticted user across repositories
@@ -48,7 +48,7 @@ module Octokit
       # @option options [String] :since Timestamp in ISO 8601
       #   format: YYYY-MM-DDTHH:MM:SSZ
       # @return [Array<Sawyer::Resource>] A list of issues for a repository.
-      # @see http://developer.github.com/v3/issues/#list-issues
+      # @see https://developer.github.com/v3/issues/#list-issues
       # @example List issues for the authenticted user across owned and member repositories
       #   @client = Octokit::Client.new(:login => 'foo', :password => 'bar')
       #   @client.user_issues
@@ -69,7 +69,7 @@ module Octokit
       # @option options [String] :since Timestamp in ISO 8601
       #   format: YYYY-MM-DDTHH:MM:SSZ
       # @return [Array<Sawyer::Resource>] A list of issues.
-      # @see http://developer.github.com/v3/issues/#list-issues
+      # @see https://developer.github.com/v3/issues/#list-issues
       # @example List all issues for a given organization for the authenticated user
       #   @client = Octokit::Client.new(:login => 'foo', :password => 'bar')
       #   @client.org_issues("octokit")
@@ -87,7 +87,7 @@ module Octokit
       # @option options [Integer] :milestone Milestone number.
       # @option options [String] :labels List of comma separated Label names. Example: <tt>bug,ui,@high</tt>.
       # @return [Sawyer::Resource] Your newly created issue
-      # @see http://developer.github.com/v3/issues/#create-an-issue
+      # @see https://developer.github.com/v3/issues/#create-an-issue
       # @example Create a new Issues for a repository
       #   Octokit.create_issue("sferik/rails_admin", 'Updated Docs', 'Added some extra links')
       def create_issue(repo, title, body, options = {})
@@ -106,7 +106,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param number [Integer] Number ID of the issue
       # @return [Sawyer::Resource] The issue you requested, if it exists
-      # @see http://developer.github.com/v3/issues/#get-a-single-issue
+      # @see https://developer.github.com/v3/issues/#get-a-single-issue
       # @example Get issue #25 from octokit/octokit.rb
       #   Octokit.issue("octokit/octokit.rb", "25")
       def issue(repo, number, options = {})
@@ -122,7 +122,7 @@ module Octokit
       # @option options [Integer] :milestone Milestone number.
       # @option options [String] :labels List of comma separated Label names. Example: <tt>bug,ui,@high</tt>.
       # @return [Sawyer::Resource] The updated Issue
-      # @see http://developer.github.com/v3/issues/#edit-an-issue
+      # @see https://developer.github.com/v3/issues/#edit-an-issue
       # @example Close Issue #25 from octokit/octokit.rb
       #   Octokit.close_issue("octokit/octokit.rb", "25")
       def close_issue(repo, number, options = {})
@@ -138,7 +138,7 @@ module Octokit
       # @option options [Integer] :milestone Milestone number.
       # @option options [String] :labels List of comma separated Label names. Example: <tt>bug,ui,@high</tt>.
       # @return [Sawyer::Resource] The updated Issue
-      # @see http://developer.github.com/v3/issues/#edit-an-issue
+      # @see https://developer.github.com/v3/issues/#edit-an-issue
       # @example Reopen Issue #25 from octokit/octokit.rb
       #   Octokit.reopen_issue("octokit/octokit.rb", "25")
       def reopen_issue(repo, number, options = {})
@@ -157,7 +157,7 @@ module Octokit
       # @option options [String] :labels List of comma separated Label names. Example: <tt>bug,ui,@high</tt>.
       # @option options [String] :state State of the issue. <tt>open</tt> or <tt>closed</tt>
       # @return [Sawyer::Resource] The updated Issue
-      # @see http://developer.github.com/v3/issues/#edit-an-issue
+      # @see https://developer.github.com/v3/issues/#edit-an-issue
       # @example Change the title of Issue #25
       #   Octokit.update_issue("octokit/octokit.rb", "25", "A new title", "the same body"")
       def update_issue(repo, number, title, body, options = {})
@@ -178,7 +178,7 @@ module Octokit
       #
       # @return [Array<Sawyer::Resource>] List of issues comments.
       #
-      # @see http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository
+      # @see https://developer.github.com/v3/issues/comments/#list-comments-in-a-repository
       #
       # @example Get the comments for issues in the octokit repository
       #   @client.issues_comments("octokit/octokit.rb")
@@ -198,7 +198,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param number [Integer] Number ID of the issue
       # @return [Array<Sawyer::Resource>] Array of comments that belong to an issue
-      # @see http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue
+      # @see https://developer.github.com/v3/issues/comments/#list-comments-on-an-issue
       # @example Get comments for issue #25 from octokit/octokit.rb
       #   Octokit.issue_comments("octokit/octokit.rb", "25")
       def issue_comments(repo, number, options = {})
@@ -210,7 +210,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param number [Integer] Number ID of the comment
       # @return [Sawyer::Resource] The specific comment in question
-      # @see http://developer.github.com/v3/issues/comments/#get-a-single-comment
+      # @see https://developer.github.com/v3/issues/comments/#get-a-single-comment
       # @example Get comment #1194549 from an issue on octokit/octokit.rb
       #   Octokit.issue_comments("octokit/octokit.rb", 1194549)
       def issue_comment(repo, number, options = {})
@@ -223,7 +223,7 @@ module Octokit
       # @param number [Integer] Issue number
       # @param comment [String] Comment to be added
       # @return [Sawyer::Resource] Comment
-      # @see http://developer.github.com/v3/issues/comments/#create-a-comment
+      # @see https://developer.github.com/v3/issues/comments/#create-a-comment
       # @example Add the comment "Almost to v1" to Issue #23 on octokit/octokit.rb
       #   Octokit.add_comment("octokit/octokit.rb", 23, "Almost to v1")
       def add_comment(repo, number, comment, options = {})
@@ -236,7 +236,7 @@ module Octokit
       # @param number [Integer] Comment number
       # @param comment [String] Body of the comment which will replace the existing body.
       # @return [Sawyer::Resource] Comment
-      # @see http://developer.github.com/v3/issues/comments/#edit-a-comment
+      # @see https://developer.github.com/v3/issues/comments/#edit-a-comment
       # @example Update the comment #1194549 with body "I've started this on my 25-issue-comments-v3 fork" on an issue on octokit/octokit.rb
       #   Octokit.update_comment("octokit/octokit.rb", 1194549, "Almost to v1, added this on my fork")
       def update_comment(repo, number, comment, options = {})
@@ -248,7 +248,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param number [Integer] Comment number
       # @return [Boolean] Success
-      # @see http://developer.github.com/v3/issues/comments/#delete-a-comment
+      # @see https://developer.github.com/v3/issues/comments/#delete-a-comment
       # @example Delete the comment #1194549 on an issue on octokit/octokit.rb
       #   Octokit.delete_comment("octokit/octokit.rb", 1194549)
       def delete_comment(repo, number, options = {})

--- a/lib/octokit/client/labels.rb
+++ b/lib/octokit/client/labels.rb
@@ -5,14 +5,14 @@ module Octokit
 
     # Methods for the Issue Labels API
     #
-    # @see http://developer.github.com/v3/issues/labels/
+    # @see https://developer.github.com/v3/issues/labels/
     module Labels
 
       # List available labels for a repository
       #
       # @param repo [String, Repository, Hash] A GitHub repository
       # @return [Array<Sawyer::Resource>] A list of the labels across the repository
-      # @see http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository
+      # @see https://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository
       # @example List labels for octokit/octokit.rb
       #   Octokit.labels("octokit/octokit.rb")
       def labels(repo, options = {})
@@ -24,7 +24,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param name [String] Name of the label
       # @return [Sawyer::Resource] A single label from the repository
-      # @see http://developer.github.com/v3/issues/labels/#get-a-single-label
+      # @see https://developer.github.com/v3/issues/labels/#get-a-single-label
       # @example Get the "V3 Addition" label from octokit/octokit.rb
       #   Octokit.labels("octokit/octokit.rb", "V3 Addition")
       def label(repo, name, options = {})
@@ -37,7 +37,7 @@ module Octokit
       # @param label [String] A new label
       # @param color [String] A color, in hex, without the leading #
       # @return [Sawyer::Resource] The new label
-      # @see http://developer.github.com/v3/issues/labels/#create-a-label
+      # @see https://developer.github.com/v3/issues/labels/#create-a-label
       # @example Add a new label "Version 1.0" with color "#cccccc"
       #   Octokit.add_label("octokit/octokit.rb", "Version 1.0", "cccccc")
       def add_label(repo, label, color="ffffff", options = {})
@@ -52,7 +52,7 @@ module Octokit
       # @option options [String] :name An updated label name
       # @option options [String] :color An updated color value, in hex, without leading #
       # @return [Sawyer::Resource] The updated label
-      # @see http://developer.github.com/v3/issues/labels/#update-a-label
+      # @see https://developer.github.com/v3/issues/labels/#update-a-label
       # @example Update the label "Version 1.0" with new color "#cceeaa"
       #   Octokit.update_label("octokit/octokit.rb", "Version 1.0", {:color => "cceeaa"})
       def update_label(repo, label, options = {})
@@ -66,7 +66,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param label [String] String name of the label
       # @return [Boolean] Success
-      # @see http://developer.github.com/v3/issues/labels/#delete-a-label
+      # @see https://developer.github.com/v3/issues/labels/#delete-a-label
       # @example Delete the label "Version 1.0" from the repository.
       #   Octokit.delete_label!("octokit/octokit.rb", "Version 1.0")
       def delete_label!(repo, label, options = {})
@@ -81,7 +81,7 @@ module Octokit
       # @param number [Fixnum] Number ID of the issue
       # @param label [String] String name of the label
       # @return [Array<Sawyer::Resource>] A list of the labels currently on the issue
-      # @see http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue
+      # @see https://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue
       # @example Remove the label "Version 1.0" from the repository.
       #   Octokit.remove_label("octokit/octokit.rb", 23, "Version 1.0")
       def remove_label(repo, number, label, options = {})
@@ -95,7 +95,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param number [Fixnum] Number ID of the issue
       # @return [Boolean] Success of operation
-      # @see http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue
+      # @see https://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue
       # @example Remove all labels from Issue #23
       #   Octokit.remove_all_labels("octokit/octokit.rb", 23)
       def remove_all_labels(repo, number, options = {})
@@ -107,7 +107,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param number [Fixnum] Number ID of the issue
       # @return [Array<Sawyer::Resource>] A list of the labels currently on the issue
-      # @see http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue
+      # @see https://developer.github.com/v3/issues/labels/#list-labels-on-an-issue
       # @example List labels for octokit/octokit.rb, issue # 1
       #   Octokit.labels_for_issue("octokit/octokit.rb", 1)
       def labels_for_issue(repo, number, options = {})
@@ -120,7 +120,7 @@ module Octokit
       # @param number [Fixnum] Number ID of the issue
       # @param labels [Array] An array of labels to apply to this Issue
       # @return [Array<Sawyer::Resource>] A list of the labels currently on the issue
-      # @see http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
+      # @see https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
       # @example Add two labels for octokit/octokit.rb
       #   Octokit.add_labels_to_an_issue("octokit/octokit.rb", 10, ['V3 Transition', 'Improvement'])
       def add_labels_to_an_issue(repo, number, labels)
@@ -133,7 +133,7 @@ module Octokit
       # @param number [Fixnum] Number ID of the issue
       # @param labels [Array] An array of labels to use as replacement
       # @return [Array<Sawyer::Resource>] A list of the labels currently on the issue
-      # @see http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue
+      # @see https://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue
       # @example Replace labels for octokit/octokit.rb Issue #10
       #   Octokit.replace_all_labels("octokit/octokit.rb", 10, ['V3 Transition', 'Improvement'])
       def replace_all_labels(repo, number, labels, options = {})

--- a/lib/octokit/client/legacy_search.rb
+++ b/lib/octokit/client/legacy_search.rb
@@ -3,12 +3,12 @@ module Octokit
 
     # Methods for the Legacy Search API
     #
-    # @see http://developer.github.com/v3/search/
+    # @see https://developer.github.com/v3/search/
     module LegacySearch
 
       # Legacy repository search
       #
-      # @see http://developer.github.com/v3/search/#search-repositories
+      # @see https://developer.github.com/v3/search/#search-repositories
       # @param q [String] Search keyword
       # @return [Array<Sawyer::Resource>] List of repositories found
       def legacy_search_repositories(q, options = {})
@@ -31,7 +31,7 @@ module Octokit
       #
       # @param search [String] User to search for.
       # @return [Array<Sawyer::Resource>] Array of hashes representing users.
-      # @see http://developer.github.com/v3/search/#search-users
+      # @see https://developer.github.com/v3/search/#search-users
       # @example
       #   Octokit.search_users('pengwynn')
       def legacy_search_users(search, options = {})

--- a/lib/octokit/client/markdown.rb
+++ b/lib/octokit/client/markdown.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Markdown API
     #
-    # @see http://developer.github.com/v3/markdown/
+    # @see https://developer.github.com/v3/markdown/
     module Markdown
 
       # Render an arbitrary Markdown document
@@ -12,7 +12,7 @@ module Octokit
       # @option options [String] (optional) :mode (`markdown` or `gfm`)
       # @option options [String] (optional) :context Repo context
       # @return [String] HTML renderization
-      # @see http://developer.github.com/v3/markdown/#render-an-arbitrary-markdown-document
+      # @see https://developer.github.com/v3/markdown/#render-an-arbitrary-markdown-document
       # @example Render some GFM
       #   Octokit.markdown('Fixed in #111', :mode => "gfm", :context => "octokit/octokit.rb")
       def markdown(text, options = {})

--- a/lib/octokit/client/meta.rb
+++ b/lib/octokit/client/meta.rb
@@ -3,11 +3,11 @@ module Octokit
 
     # Methods for the Meta API
     #
-    # @see http://developer.github.com/v3/meta/
+    # @see https://developer.github.com/v3/meta/
     module Meta
 
       # Get meta information about GitHub.com, the service.
-      # @see http://developer.github.com/v3/meta/#meta
+      # @see https://developer.github.com/v3/meta/#meta
       # @return [Sawyer::Resource] Hash with meta information.
       # @example Get GitHub meta information
       #   @client.github_meta

--- a/lib/octokit/client/milestones.rb
+++ b/lib/octokit/client/milestones.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Issues Milestones API
     #
-    # @see http://developer.github.com/v3/issues/milestones/
+    # @see https://developer.github.com/v3/issues/milestones/
     module Milestones
 
       # List milestones for a repository
@@ -15,7 +15,7 @@ module Octokit
       # @option options [String] :sort (created) Sort: <tt>created</tt>, <tt>updated</tt>, or <tt>comments</tt>.
       # @option options [String] :direction (desc) Direction: <tt>asc</tt> or <tt>desc</tt>.
       # @return [Array<Sawyer::Resource>] A list of milestones for a repository.
-      # @see http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+      # @see https://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
       # @example List milestones for a repository
       #   Octokit.list_milestones("octokit/octokit.rb")
       def list_milestones(repository, options = {})
@@ -32,7 +32,7 @@ module Octokit
       # @option options [String] :sort (created) Sort: <tt>created</tt>, <tt>updated</tt>, or <tt>comments</tt>.
       # @option options [String] :direction (desc) Direction: <tt>asc</tt> or <tt>desc</tt>.
       # @return [Sawyer::Resource] A single milestone from a repository.
-      # @see http://developer.github.com/v3/issues/milestones/#get-a-single-milestone
+      # @see https://developer.github.com/v3/issues/milestones/#get-a-single-milestone
       # @example Get a single milestone for a repository
       #   Octokit.milestone("octokit/octokit.rb", 1)
       def milestone(repository, number, options = {})
@@ -48,7 +48,7 @@ module Octokit
       # @option options [String] :description A meaningful description
       # @option options [Time] :due_on Set if the milestone has a due date
       # @return [Sawyer::Resource] A single milestone object
-      # @see http://developer.github.com/v3/issues/milestones/#create-a-milestone
+      # @see https://developer.github.com/v3/issues/milestones/#create-a-milestone
       # @example Create a milestone for a repository
       #   Octokit.create_milestone("octokit/octokit.rb", "0.7.0", {:description => 'Add support for v3 of Github API'})
       def create_milestone(repository, title, options = {})
@@ -65,7 +65,7 @@ module Octokit
       # @option options [String] :description A meaningful description
       # @option options [Time] :due_on Set if the milestone has a due date
       # @return [Sawyer::Resource] A single milestone object
-      # @see http://developer.github.com/v3/issues/milestones/#update-a-milestone
+      # @see https://developer.github.com/v3/issues/milestones/#update-a-milestone
       # @example Update a milestone for a repository
       #   Octokit.update_milestone("octokit/octokit.rb", 1, {:description => 'Add support for v3 of Github API'})
       def update_milestone(repository, number, options = {})
@@ -79,7 +79,7 @@ module Octokit
       # @param options [Hash] A customizable set of options.
       # @option options [Integer] :milestone Milestone number.
       # @return [Boolean] Success
-      # @see http://developer.github.com/v3/issues/milestones/#delete-a-milestone
+      # @see https://developer.github.com/v3/issues/milestones/#delete-a-milestone
       # @example Delete a single milestone from a repository
       #   Octokit.delete_milestone("octokit/octokit.rb", 1)
       def delete_milestone(repository, number, options = {})

--- a/lib/octokit/client/notifications.rb
+++ b/lib/octokit/client/notifications.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Notifications API
     #
-    # @see http://developer.github.com/v3/activity/notifications/
+    # @see https://developer.github.com/v3/activity/notifications/
     module Notifications
 
       # List your notifications
@@ -18,7 +18,7 @@ module Octokit
       #   updated before the given time. The time should be passed in as UTC in
       #   the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Ex. '2012-10-09T23:39:01Z'
       # @return [Array<Sawyer::Resource>] Array of notifications.
-      # @see http://developer.github.com/v3/activity/notifications/#list-your-notifications
+      # @see https://developer.github.com/v3/activity/notifications/#list-your-notifications
       # @example Get users notifications
       #   @client.notifications
       # @example Get all notifications since a certain time.
@@ -40,7 +40,7 @@ module Octokit
       #   updated before the given time. The time should be passed in as UTC in
       #   the ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Ex. '2012-10-09T23:39:01Z'
       # @return [Array<Sawyer::Resource>] Array of notifications.
-      # @see http://developer.github.com/v3/activity/notifications/#list-your-notifications-in-a-repository
+      # @see https://developer.github.com/v3/activity/notifications/#list-your-notifications-in-a-repository
       # @example Get your notifications for octokit/octokit.rb
       #   @client.repository_notifications('octokit/octokit.rb')
       # @example Get your notifications for octokit/octokit.rb since a time.
@@ -61,7 +61,7 @@ module Octokit
       #   will not be updated. The time should be passed in as UTC in the
       #   ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Ex. '2012-10-09T23:39:01Z'
       # @return [Boolean] True if marked as read, false otherwise
-      # @see http://developer.github.com/v3/activity/notifications/#mark-as-read
+      # @see https://developer.github.com/v3/activity/notifications/#mark-as-read
       #
       # @example
       #   @client.mark_notifications_as_read
@@ -83,7 +83,7 @@ module Octokit
       #   will not be updated. The time should be passed in as UTC in the
       #   ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Ex. '2012-10-09T23:39:01Z'
       # @return [Boolean] True if marked as read, false otherwise
-      # @see http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository
+      # @see https://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository
       # @example
       #   @client.mark_notifications_as_read("octokit/octokit.rb")
       def mark_repository_notifications_as_read(repo, options = {})
@@ -97,7 +97,7 @@ module Octokit
       #
       # @param thread_id [Integer] Id of the thread.
       # @return [Array<Sawyer::Resource>] Array of notifications.
-      # @see http://developer.github.com/v3/activity/notifications/#view-a-single-thread
+      # @see https://developer.github.com/v3/activity/notifications/#view-a-single-thread
       #
       # @example
       #   @client.notification_thread(1000)
@@ -113,7 +113,7 @@ module Octokit
       #   threads.
       # @option options [Boolean] :read Inverse of 'unread'.
       # @return [Boolean] True if updated, false otherwise.
-      # @see http://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read
+      # @see https://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read
       # @example
       #   @client.mark_thread_as_ready(1, :read => false)
       def mark_thread_as_read(thread_id, options = {})
@@ -126,7 +126,7 @@ module Octokit
       #
       # @param thread_id [Integer] Id of the thread.
       # @return [Sawyer::Resource] Subscription.
-      # @see http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription
+      # @see https://developer.github.com/v3/activity/notifications/#get-a-thread-subscription
       # @example
       #   @client.thread_subscription(1)
       def thread_subscription(thread_id, options = {})
@@ -147,7 +147,7 @@ module Octokit
       # @option options [Boolean] :ignored Deterimines if all notifications
       #   should be blocked from this repository.
       # @return [Sawyer::Resource] Updated subscription.
-      # @see http://developer.github.com/v3/activity/notifications/#set-a-thread-subscription
+      # @see https://developer.github.com/v3/activity/notifications/#set-a-thread-subscription
       # @example Subscribe to notifications
       #   @client.update_thread_subscription(1, :subscribed => true)
       # @example Ignore notifications from a repo
@@ -160,7 +160,7 @@ module Octokit
       #
       # @param thread_id [Integer] Id of the thread.
       # @return [Boolean] True if delete successful, false otherwise.
-      # @see http://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription
+      # @see https://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription
       # @example
       #   @client.delete_thread_subscription(1)
       def delete_thread_subscription(thread_id, options = {})

--- a/lib/octokit/client/objects.rb
+++ b/lib/octokit/client/objects.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Git Data API
     #
-    # @see http://developer.github.com/v3/git/
+    # @see https://developer.github.com/v3/git/
     module Objects
 
       # Get a single tree, fetching information about its root-level objects
@@ -13,8 +13,8 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param tree_sha [String] The SHA of the tree to fetch
       # @return [Sawyer::Resource] A hash representing the fetched tree
-      # @see http://developer.github.com/v3/git/trees/#get-a-tree
-      # @see http://developer.github.com/v3/git/trees/#get-a-tree-recursively
+      # @see https://developer.github.com/v3/git/trees/#get-a-tree
+      # @see https://developer.github.com/v3/git/trees/#get-a-tree-recursively
       # @example Fetch a tree and inspect the path of one of its files
       #   tree = Octokit.tree("octocat/Hello-World", "9fb037999f264ba9a7fc6274d15fa3ae2ab98312")
       #   tree.tree.first.path # => "file.rb"
@@ -32,7 +32,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param tree [Array] An array of hashes representing a tree structure
       # @return [Sawyer::Resource] A hash representing the new tree
-      # @see http://developer.github.com/v3/git/trees/#create-a-tree
+      # @see https://developer.github.com/v3/git/trees/#create-a-tree
       # @example Create a tree containing one file
       #   tree = Octokit.create_tree("octocat/Hello-World", [ { :path => "file.rb", :mode => "100644", :type => "blob", :sha => "44b4fc6d56897b048c772eb4087f854f46256132" } ])
       #   tree.sha # => "cd8274d15fa3ae2ab983129fb037999f264ba9a7"
@@ -47,7 +47,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param blob_sha [String] The SHA of the blob to fetch
       # @return [Sawyer::Resource] A hash representing the fetched blob
-      # @see http://developer.github.com/v3/git/blobs/#get-a-blob
+      # @see https://developer.github.com/v3/git/blobs/#get-a-blob
       # @example Fetch a blob and inspect its contents
       #   blob = Octokit.blob("octocat/Hello-World", "827efc6d56897b048c772eb4087f854f46256132")
       #   blob.encoding # => "utf-8"
@@ -68,7 +68,7 @@ module Octokit
       # @param content [String] Content of the blob
       # @param encoding [String] The content's encoding. <tt>utf-8</tt> and <tt>base64</tt> are accepted. If your data cannot be losslessly sent as a UTF-8 string, you can base64 encode it
       # @return [String] The new blob's SHA, e.g. <tt>827efc6d56897b048c772eb4087f854f46256132</tt>
-      # @see http://developer.github.com/v3/git/blobs/#create-a-blob
+      # @see https://developer.github.com/v3/git/blobs/#create-a-blob
       # @example Create a blob containing <tt>foo bar baz</tt>
       #   Octokit.create_blob("octocat/Hello-World", "foo bar baz")
       # @example Create a blob containing <tt>foo bar baz</tt>, encoded using base64
@@ -89,7 +89,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @param tag_sha [String] The SHA of the tag to fetch.
       # @return [Sawyer::Resource] Hash representing the tag.
-      # @see http://developer.github.com/v3/git/tags/#get-a-tag
+      # @see https://developer.github.com/v3/git/tags/#get-a-tag
       # @example Fetch a tag
       #   Octokit.tag('octokit/octokit.rb', '23aad20633f4d2981b1c7209a800db3014774e96')
       def tag(repo, tag_sha, options = {})
@@ -110,7 +110,7 @@ module Octokit
       # @param tagger_email [String] Email of the author of the tag.
       # @param tagger_date [string] Timestamp of when this object was tagged.
       # @return [Sawyer::Resource] Hash representing new tag.
-      # @see http://developer.github.com/v3/git/tags/#create-a-tag-object
+      # @see https://developer.github.com/v3/git/tags/#create-a-tag-object
       # @example
       #   @client.create_tag(
       #     "octokit/octokit.rb",

--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -3,14 +3,14 @@ module Octokit
 
     # Methods for the Organizations API
     #
-    # @see http://developer.github.com/v3/orgs/
+    # @see https://developer.github.com/v3/orgs/
     module Organizations
 
       # Get an organization
       #
       # @param org [String] Organization GitHub username.
       # @return [Sawyer::Resource] Hash representing GitHub organization.
-      # @see http://developer.github.com/v3/orgs/#get-an-organization
+      # @see https://developer.github.com/v3/orgs/#get-an-organization
       # @example
       #   Octokit.organization('github')
       # @example
@@ -32,7 +32,7 @@ module Octokit
       # @option values [String] :location Location of organization.
       # @option values [String] :name GitHub username for organization.
       # @return [Sawyer::Resource] Hash representing GitHub organization.
-      # @see http://developer.github.com/v3/orgs/#edit-an-organization
+      # @see https://developer.github.com/v3/orgs/#edit-an-organization
       # @example
       #   @client.update_organization('github', {
       #     :billing_email => 'support@github.com',
@@ -61,7 +61,7 @@ module Octokit
       #
       # @param user [String] Username of the user to get list of organizations.
       # @return [Array<Sawyer::Resource>] Array of hashes representing organizations.
-      # @see http://developer.github.com/v3/orgs/#list-user-organizations
+      # @see https://developer.github.com/v3/orgs/#list-user-organizations
       # @example
       #   Octokit.organizations('pengwynn')
       # @example
@@ -95,7 +95,7 @@ module Octokit
       #   `all`, `public`, `member`, `sources`, `forks`, or `private`.
       #
       # @return [Array<Sawyer::Resource>] List of repositories
-      # @see http://developer.github.com/v3/repos/#list-organization-repositories
+      # @see https://developer.github.com/v3/repos/#list-organization-repositories
       # @example
       #   Octokit.organization_repositories('github')
       # @example
@@ -118,7 +118,7 @@ module Octokit
       #
       # @param org [String] Organization GitHub username.
       # @return [Array<Sawyer::Resource>] Array of hashes representing users.
-      # @see http://developer.github.com/v3/orgs/members/#members-list
+      # @see https://developer.github.com/v3/orgs/members/#members-list
       # @example
       #   Octokit.organization_members('github')
       # @example
@@ -135,7 +135,7 @@ module Octokit
       #
       # @param org [String] Organization GitHub username.
       # @return [Array<Sawyer::Resource>] Array of hashes representing users.
-      # @see http://developer.github.com/v3/orgs/members/#public-members-list
+      # @see https://developer.github.com/v3/orgs/members/#public-members-list
       # @example
       #   Octokit.organization_public_members('github')
       # @example
@@ -156,7 +156,7 @@ module Octokit
       #
       # @return [Boolean] Is a member?
       #
-      # @see http://developer.github.com/v3/orgs/members/#check-membership
+      # @see https://developer.github.com/v3/orgs/members/#check-membership
       #
       # @example Check if a user is in your organization
       #   @client.organization_member?('your_organization', 'pengwynn')
@@ -181,7 +181,7 @@ module Octokit
       #
       # @return [Boolean] Is a public member?
       #
-      # @see http://developer.github.com/v3/orgs/members/#check-public-membership
+      # @see https://developer.github.com/v3/orgs/members/#check-public-membership
       #
       # @example Check if a user is a hubbernaut
       #   @client.organization_public_member?('github', 'pengwynn')
@@ -197,7 +197,7 @@ module Octokit
       #
       # @param org [String] Organization GitHub username.
       # @return [Array<Sawyer::Resource>] Array of hashes representing teams.
-      # @see http://developer.github.com/v3/orgs/teams/#list-teams
+      # @see https://developer.github.com/v3/orgs/teams/#list-teams
       # @example
       #   @client.organization_teams('github')
       # @example
@@ -221,7 +221,7 @@ module Octokit
       #   `push` - team members can pull and push, but not administer these repositories.
       #   `admin` - team members can pull, push and administer these repositories.
       # @return [Sawyer::Resource] Hash representing new team.
-      # @see http://developer.github.com/v3/orgs/teams/#create-team
+      # @see https://developer.github.com/v3/orgs/teams/#create-team
       # @example
       #   @client.create_team('github', {
       #     :name => 'Designers',
@@ -238,7 +238,7 @@ module Octokit
       #
       # @param team_id [Integer] Team id.
       # @return [Sawyer::Resource] Hash representing team.
-      # @see http://developer.github.com/v3/orgs/teams/#get-team
+      # @see https://developer.github.com/v3/orgs/teams/#get-team
       # @example
       #   @client.team(100000)
       def team(team_id, options = {})
@@ -257,7 +257,7 @@ module Octokit
       #   `push` - team members can pull and push, but not administer these repositories.
       #   `admin` - team members can pull, push and administer these repositories.
       # @return [Sawyer::Resource] Hash representing updated team.
-      # @see http://developer.github.com/v3/orgs/teams/#edit-team
+      # @see https://developer.github.com/v3/orgs/teams/#edit-team
       # @example
       #   @client.update_team(100000, {
       #     :name => 'Front-end Designers',
@@ -273,7 +273,7 @@ module Octokit
       #
       # @param team_id [Integer] Team id.
       # @return [Boolean] True if deletion successful, false otherwise.
-      # @see http://developer.github.com/v3/orgs/teams/#delete-team
+      # @see https://developer.github.com/v3/orgs/teams/#delete-team
       # @example
       #   @client.delete_team(100000)
       def delete_team(team_id, options = {})
@@ -286,7 +286,7 @@ module Octokit
       #
       # @param team_id [Integer] Team id.
       # @return [Array<Sawyer::Resource>] Array of hashes representing users.
-      # @see http://developer.github.com/v3/orgs/teams/#list-team-members
+      # @see https://developer.github.com/v3/orgs/teams/#list-team-members
       # @example
       #   @client.team_members(100000)
       def team_members(team_id, options = {})
@@ -301,7 +301,7 @@ module Octokit
       # @param team_id [Integer] Team id.
       # @param user [String] GitHub username of new team member.
       # @return [Boolean] True on successful addition, false otherwise.
-      # @see http://developer.github.com/v3/orgs/teams/#add-team-member
+      # @see https://developer.github.com/v3/orgs/teams/#add-team-member
       # @example
       #   @client.add_team_member(100000, 'pengwynn')
       def add_team_member(team_id, user, options = {})
@@ -319,7 +319,7 @@ module Octokit
       # @param team_id [Integer] Team id.
       # @param user [String] GitHub username of the user to boot.
       # @return [Boolean] True if user removed, false otherwise.
-      # @see http://developer.github.com/v3/orgs/teams/#remove-team-member
+      # @see https://developer.github.com/v3/orgs/teams/#remove-team-member
       # @example
       #   @client.remove_team_member(100000, 'pengwynn')
       def remove_team_member(team_id, user, options = {})
@@ -336,7 +336,7 @@ module Octokit
       #
       # @return [Boolean] Is a member?
       #
-      # @see http://developer.github.com/v3/orgs/teams/#get-team-member
+      # @see https://developer.github.com/v3/orgs/teams/#get-team-member
       #
       # @example Check if a user is in your team
       #   @client.team_member?('your_team', 'pengwynn')
@@ -351,7 +351,7 @@ module Octokit
       #
       # @param team_id [Integer] Team id.
       # @return [Array<Sawyer::Resource>] Array of hashes representing repositories.
-      # @see http://developer.github.com/v3/orgs/teams/#list-team-repos
+      # @see https://developer.github.com/v3/orgs/teams/#list-team-repos
       # @example
       #   @client.team_repositories(100000)
       # @example
@@ -368,7 +368,7 @@ module Octokit
       # @return [Boolean] True if managed by a team. False if not managed by
       #   the team OR the requesting user does not have authorization to access
       #   the team information.
-      # @see http://developer.github.com/v3/orgs/teams/#get-team-repo
+      # @see https://developer.github.com/v3/orgs/teams/#get-team-repo
       # @example
       #   @client.team_repository?(8675309, 'octokit/octokit.rb')
       # @example
@@ -388,7 +388,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Boolean] True if successful, false otherwise.
       # @see Octokit::Repository
-      # @see http://developer.github.com/v3/orgs/teams/#add-team-repo
+      # @see https://developer.github.com/v3/orgs/teams/#add-team-repo
       # @example
       #   @client.add_team_repository(100000, 'github/developer.github.com')
       # @example
@@ -408,7 +408,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Boolean] Return true if repo removed from team, false otherwise.
       # @see Octokit::Repository
-      # @see http://developer.github.com/v3/orgs/teams/#remove-team-repo
+      # @see https://developer.github.com/v3/orgs/teams/#remove-team-repo
       # @example
       #   @client.remove_team_repository(100000, 'github/developer.github.com')
       # @example
@@ -425,7 +425,7 @@ module Octokit
       # @param org [String] Organization GitHub username.
       # @param user [String] GitHub username of user to remove.
       # @return [Boolean] True if removal is successful, false otherwise.
-      # @see http://developer.github.com/v3/orgs/members/#remove-a-member
+      # @see https://developer.github.com/v3/orgs/members/#remove-a-member
       # @example
       #   @client.remove_organization_member('github', 'pengwynn')
       # @example
@@ -444,7 +444,7 @@ module Octokit
       # @param org [String] Organization GitHub username.
       # @param user [String] GitHub username of user to publicize.
       # @return [Boolean] True if publicization successful, false otherwise.
-      # @see http://developer.github.com/v3/orgs/members/#publicize-a-users-membership
+      # @see https://developer.github.com/v3/orgs/members/#publicize-a-users-membership
       # @example
       #   @client.publicize_membership('github', 'pengwynn')
       def publicize_membership(org, user, options = {})
@@ -458,7 +458,7 @@ module Octokit
       # @param org [String] Organization GitHub username.
       # @param user [String] GitHub username of user to unpublicize.
       # @return [Boolean] True of unpublicization successful, false otherwise.
-      # @see http://developer.github.com/v3/orgs/members/#conceal-a-users-membership
+      # @see https://developer.github.com/v3/orgs/members/#conceal-a-users-membership
       # @example
       #   @client.unpublicize_membership('github', 'pengwynn')
       # @example
@@ -471,7 +471,7 @@ module Octokit
       # List all teams for the authenticated user across all their orgs
       #
       # @return [Array<Sawyer::Resource>] Array of team resources.
-      # @see http://developer.github.com/v3/orgs/teams/#list-user-teams
+      # @see https://developer.github.com/v3/orgs/teams/#list-user-teams
       def user_teams(options = {})
         paginate "/user/teams", options
       end

--- a/lib/octokit/client/pages.rb
+++ b/lib/octokit/client/pages.rb
@@ -3,14 +3,14 @@ module Octokit
 
     # Methods for the Pages API
     #
-    # @see http://developer.github.com/v3/repos/pages/
+    # @see https://developer.github.com/v3/repos/pages/
     module Pages
 
       # List Pages information for a repository
       #
       # @param repo [String, Repository, Hash] A GitHub repository
       # @return Sawyer::Resource A GitHub Pages resource
-      # @see http://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site
+      # @see https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site
       def pages(repo, options = {})
         get "repos/#{Repository.new(repo)}/pages", options
       end
@@ -19,7 +19,7 @@ module Octokit
       #
       # @param repo [String, Repository, Hash] A GitHub repository
       # @return [Array<Sawyer::Resource>] A list of build history for a repository.
-      # @see http://developer.github.com/v3/repos/pages/#list-pages-builds
+      # @see https://developer.github.com/v3/repos/pages/#list-pages-builds
       def pages_builds(repo, options = {})
         get "repos/#{Repository.new(repo)}/pages/builds", options
       end
@@ -29,7 +29,7 @@ module Octokit
       #
       # @param repo [String, Repository, Hash] A GitHub repository
       # @return Sawyer::Resource A GitHub Pages resource about a build
-      # @see http://developer.github.com/v3/repos/pages/#list-latest-pages-build
+      # @see https://developer.github.com/v3/repos/pages/#list-latest-pages-build
       def latest_pages_build(repo, options = {})
         get "repos/#{Repository.new(repo)}/pages/builds/latest", options
       end

--- a/lib/octokit/client/pub_sub_hubbub.rb
+++ b/lib/octokit/client/pub_sub_hubbub.rb
@@ -10,7 +10,7 @@ module Octokit
 
     # Methods for the PubSubHubbub API
     #
-    # @see http://developer.github.com/v3/repos/hooks/#pubsubhubbub
+    # @see https://developer.github.com/v3/repos/hooks/#pubsubhubbub
     module PubSubHubbub
 
       # Subscribe to a pubsub topic
@@ -19,7 +19,7 @@ module Octokit
       # @param callback [String] A callback url to be posted to when the topic event is fired
       # @param secret [String] An optional shared secret used to generate a SHA1 HMAC of the outgoing body content
       # @return [Boolean] true if the subscribe was successful, otherwise an error is raised
-      # @see http://developer.github.com/v3/repos/hooks/#subscribing
+      # @see https://developer.github.com/v3/repos/hooks/#subscribing
       # @example Subscribe to push events from one of your repositories, having an email sent when fired
       #   client = Octokit::Client.new(:oauth_token = "token")
       #   client.subscribe("https://github.com/joshk/devise_imapable/events/push", "github://Email?address=josh.kalderimis@gmail.com")
@@ -41,7 +41,7 @@ module Octokit
       # @param topic [String] A recoginized pubsub topic
       # @param callback [String] A callback url to be unsubscribed from
       # @return [Boolean] true if the unsubscribe was successful, otherwise an error is raised
-      # @see http://developer.github.com/v3/repos/hooks/#subscribing
+      # @see https://developer.github.com/v3/repos/hooks/#subscribing
       # @example Unsubscribe to push events from one of your repositories, no longer having an email sent when fired
       #   client = Octokit::Client.new(:oauth_token = "token")
       #   client.unsubscribe("https://github.com/joshk/devise_imapable/events/push", "github://Email?address=josh.kalderimis@gmail.com")
@@ -65,7 +65,7 @@ module Octokit
       #    Please refer Data node for complete list of arguments.
       # @param secret [String] An optional shared secret used to generate a SHA1 HMAC of the outgoing body content
       # @return [Boolean] True if subscription successful, false otherwise
-      # @see http://developer.github.com/v3/repos/hooks/#subscribing
+      # @see https://developer.github.com/v3/repos/hooks/#subscribing
       # @example Subscribe to push events to one of your repositories to Travis-CI
       #    client = Octokit::Client.new(:oauth_token = "token")
       #    client.subscribe_service_hook('joshk/device_imapable', 'Travis', { :token => "test", :domain => "domain", :user => "user" })
@@ -80,7 +80,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param service_name [String] service name owner
       #    List of services is available @ https://github.com/github/github-services/tree/master/docs.
-      # @see http://developer.github.com/v3/repos/hooks/#subscribing
+      # @see https://developer.github.com/v3/repos/hooks/#subscribing
       # @example Subscribe to push events to one of your repositories to Travis-CI
       #    client = Octokit::Client.new(:oauth_token = "token")
       #    client.unsubscribe_service_hook('joshk/device_imapable', 'Travis')

--- a/lib/octokit/client/pull_requests.rb
+++ b/lib/octokit/client/pull_requests.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Pull Requests API
     #
-    # @see http://developer.github.com/v3/pulls/
+    # @see https://developer.github.com/v3/pulls/
     module PullRequests
 
       # List pull requests for a repository
@@ -18,7 +18,7 @@ module Octokit
       #   @param state [String] `open` or `closed`.
       #   @param options [Hash] Method options
       # @return [Array<Sawyer::Resource>] Array of pulls
-      # @see http://developer.github.com/v3/pulls/#list-pull-requests
+      # @see https://developer.github.com/v3/pulls/#list-pull-requests
       # @example
       #   Octokit.pull_requests('rails/rails', :state => 'closed')
       def pull_requests(*args)
@@ -35,7 +35,7 @@ module Octokit
 
       # Get a pull request
       #
-      # @see http://developer.github.com/v3/pulls/#get-a-single-pull-request
+      # @see https://developer.github.com/v3/pulls/#get-a-single-pull-request
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param number [Integer] Number of the pull request to fetch
       # @return [Sawyer::Resource] Pull request info
@@ -46,7 +46,7 @@ module Octokit
 
       # Create a pull request
       #
-      # @see http://developer.github.com/v3/pulls/#create-a-pull-request
+      # @see https://developer.github.com/v3/pulls/#create-a-pull-request
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param base [String] The branch (or git ref) you want your changes
       #                      pulled into. This should be an existing branch on the current
@@ -68,7 +68,7 @@ module Octokit
 
       # Create a pull request from existing issue
       #
-      # @see http://developer.github.com/v3/pulls/#alternative-input
+      # @see https://developer.github.com/v3/pulls/#alternative-input
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param base [String] The branch (or git ref) you want your changes
       #                      pulled into. This should be an existing branch on the current
@@ -101,7 +101,7 @@ module Octokit
       #   @option options [String] :body Body for the pull request.
       #   @option options [String] :state State for the pull request.
       # @return [Sawyer::Resource] Hash representing updated pull request.
-      # @see http://developer.github.com/v3/pulls/#update-a-pull-request
+      # @see https://developer.github.com/v3/pulls/#update-a-pull-request
       # @example
       #   @client.update_pull_request('octokit/octokit.rb', 67, 'new title', 'updated body', 'closed')
       # @example Passing nil for optional attributes to update specific attributes.
@@ -120,7 +120,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @param number [Integer] Number of pull request to update.
       # @return [Sawyer::Resource] Hash representing updated pull request.
-      # @see http://developer.github.com/v3/pulls/#update-a-pull-request
+      # @see https://developer.github.com/v3/pulls/#update-a-pull-request
       # @example
       #   @client.close_pull_request('octokit/octokit.rb', 67)
       def close_pull_request(repo, number, options = {})
@@ -130,7 +130,7 @@ module Octokit
 
       # List commits on a pull request
       #
-      # @see http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request
+      # @see https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param number [Integer] Number of pull request
       # @return [Array<Sawyer::Resource>] List of commits
@@ -153,7 +153,7 @@ module Octokit
       #
       # @return [Array] List of pull request review comments.
       #
-      # @see http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository
+      # @see https://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository
       #
       # @example Get the pull request review comments in the octokit repository
       #   @client.issues_comments("octokit/octokit.rb")
@@ -172,7 +172,7 @@ module Octokit
 
       # List comments on a pull request
       #
-      # @see http://developer.github.com/v3/pulls/#list-comments-on-a-pull-request
+      # @see https://developer.github.com/v3/pulls/#list-comments-on-a-pull-request
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param number [Integer] Number of pull request
       # @return [Array<Sawyer::Resource>] List of comments
@@ -188,7 +188,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param comment_id [Integer] Id of comment to get
       # @return [Sawyer::Resource] Hash representing the comment
-      # @see http://developer.github.com/v3/pulls/comments/#get-a-single-comment
+      # @see https://developer.github.com/v3/pulls/comments/#get-a-single-comment
       # @example
       #   @client.pull_request_comment("pengwynn/octkit", 1903950)
       def pull_request_comment(repo, comment_id, options = {})
@@ -206,7 +206,7 @@ module Octokit
       # @param path [String] Relative path of the file to comment on.
       # @param position [Integer] Line index in the diff to comment on.
       # @return [Sawyer::Resource] Hash representing the new comment
-      # @see http://developer.github.com/v3/pulls/comments/#create-a-comment
+      # @see https://developer.github.com/v3/pulls/comments/#create-a-comment
       # @example
       #   @client.create_pull_request_comment("octokit/octokit.rb", 163, ":shipit:",
       #     "2d3201e4440903d8b04a5487842053ca4883e5f0", "lib/octokit/request.rb", 47)
@@ -229,7 +229,7 @@ module Octokit
       # @param body [String] Comment contents
       # @param comment_id [Integer] Comment id to reply to
       # @return [Sawyer::Resource] Hash representing new comment
-      # @see http://developer.github.com/v3/pulls/comments/#create-a-comment
+      # @see https://developer.github.com/v3/pulls/comments/#create-a-comment
       # @example
       #   @client.create_pull_request_comment_reply("octokit/octokit.rb", 1903950, "done.")
       def create_pull_request_comment_reply(repo, pull_id, body, comment_id, options = {})
@@ -248,7 +248,7 @@ module Octokit
       # @param comment_id [Integer] Id of the comment to update
       # @param body [String] Updated comment content
       # @return [Sawyer::Resource] Hash representing the updated comment
-      # @see http://developer.github.com/v3/pulls/comments/#edit-a-comment
+      # @see https://developer.github.com/v3/pulls/comments/#edit-a-comment
       # @example
       #   @client.update_pull_request_comment("octokit/octokit.rb", 1903950, ":shipit:")
       def update_pull_request_comment(repo, comment_id, body, options = {})
@@ -263,7 +263,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param comment_id [Integer] Id of the comment to delete
       # @return [Boolean] True if deleted, false otherwise
-      # @see http://developer.github.com/v3/pulls/comments/#delete-a-comment
+      # @see https://developer.github.com/v3/pulls/comments/#delete-a-comment
       # @example
       #   @client.delete_pull_request_comment("octokit/octokit.rb", 1902707)
       def delete_pull_request_comment(repo, comment_id, options = {})
@@ -274,7 +274,7 @@ module Octokit
 
       # List files on a pull request
       #
-      # @see http://developer.github.com/v3/pulls/#list-pull-requests-files
+      # @see https://developer.github.com/v3/pulls/#list-pull-requests-files
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param number [Integer] Number of pull request
       # @return [Array<Sawyer::Resource>] List of files
@@ -285,7 +285,7 @@ module Octokit
 
       # Merge a pull request
       #
-      # @see http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade
+      # @see https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param number [Integer] Number of pull request
       # @param commit_message [String] Optional commit message for the merge commit
@@ -296,7 +296,7 @@ module Octokit
 
       # Check pull request merge status
       #
-      # @see http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged
+      # @see https://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param number [Integer] Number of pull request
       # @return [Boolean] True if the pull request has been merged

--- a/lib/octokit/client/rate_limit.rb
+++ b/lib/octokit/client/rate_limit.rb
@@ -3,13 +3,13 @@ module Octokit
 
     # Methods for API rate limiting info
     #
-    # @see http://developer.github.com/v3/#rate-limiting
+    # @see https://developer.github.com/v3/#rate-limiting
     module RateLimit
 
       # Get rate limit info from last response if available
       # or make a new request to fetch rate limit
       #
-      # @see http://developer.github.com/v3/rate_limit/#rate-limit
+      # @see https://developer.github.com/v3/rate_limit/#rate-limit
       # @return [Octokit::RateLimit] Rate limit info
       def rate_limit(options = {})
         return rate_limit! if last_response.nil?
@@ -20,7 +20,7 @@ module Octokit
 
       # Get number of rate limted requests remaining
       #
-      # @see http://developer.github.com/v3/rate_limit/#rate-limit
+      # @see https://developer.github.com/v3/rate_limit/#rate-limit
       # @return [Fixnum] Number of requests remaining in this period
       def rate_limit_remaining(options = {})
         octokit_warn "Deprecated: Please use .rate_limit.remaining"
@@ -30,7 +30,7 @@ module Octokit
 
       # Refresh rate limit info by making a new request
       #
-      # @see http://developer.github.com/v3/rate_limit/#rate-limit
+      # @see https://developer.github.com/v3/rate_limit/#rate-limit
       # @return [Octokit::RateLimit] Rate limit info
       def rate_limit!(options = {})
         get "rate_limit"
@@ -40,7 +40,7 @@ module Octokit
 
       # Refresh rate limit info and get number of rate limted requests remaining
       #
-      # @see http://developer.github.com/v3/rate_limit/#rate-limit
+      # @see https://developer.github.com/v3/rate_limit/#rate-limit
       # @return [Fixnum] Number of requests remaining in this period
       def rate_limit_remaining!(options = {})
         octokit_warn "Deprecated: Please use .rate_limit!.remaining"

--- a/lib/octokit/client/refs.rb
+++ b/lib/octokit/client/refs.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for References for Git Data API
     #
-    # @see http://developer.github.com/v3/git/refs/
+    # @see https://developer.github.com/v3/git/refs/
     module Refs
 
       # List all refs for a given user and repo
@@ -11,7 +11,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param namespace [String] The ref namespace, e.g. <tt>tag</tt> or <tt>heads</tt>
       # @return [Array<Sawyer::Resource>] A list of references matching the repo and the namespace
-      # @see http://developer.github.com/v3/git/refs/#get-all-references
+      # @see https://developer.github.com/v3/git/refs/#get-all-references
       # @example Fetch all refs for sferik/rails_admin
       #   Octokit.refs("sferik/rails_admin")
       def refs(repo, namespace = nil, options = {})
@@ -28,7 +28,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param ref [String] The ref, e.g. <tt>tags/v0.0.3</tt>
       # @return [Sawyer::Resource] The reference matching the given repo and the ref id
-      # @see http://developer.github.com/v3/git/refs/#get-a-reference
+      # @see https://developer.github.com/v3/git/refs/#get-a-reference
       # @example Fetch tags/v0.0.3 for sferik/rails_admin
       #   Octokit.ref("sferik/rails_admin","tags/v0.0.3")
       def ref(repo, ref, options = {})
@@ -42,7 +42,7 @@ module Octokit
       # @param ref [String] The ref, e.g. <tt>tags/v0.0.3</tt>
       # @param sha [String] A SHA, e.g. <tt>827efc6d56897b048c772eb4087f854f46256132</tt>
       # @return [Array<Sawyer::Resource>] The list of references, already containing the new one
-      # @see http://developer.github.com/v3/git/refs/#create-a-reference
+      # @see https://developer.github.com/v3/git/refs/#create-a-reference
       # @example Create refs/heads/master for octocat/Hello-World with sha 827efc6d56897b048c772eb4087f854f46256132
       #   Octokit.create_ref("octocat/Hello-World","heads/master", "827efc6d56897b048c772eb4087f854f46256132")
       def create_ref(repo, ref, sha, options = {})
@@ -61,7 +61,7 @@ module Octokit
       # @param sha [String] A SHA, e.g. <tt>827efc6d56897b048c772eb4087f854f46256132</tt>
       # @param force [Boolean] A flag indicating one wants to force the update to make sure the update is a fast-forward update.
       # @return [Array<Sawyer::Resource>] The list of references updated
-      # @see http://developer.github.com/v3/git/refs/#update-a-reference
+      # @see https://developer.github.com/v3/git/refs/#update-a-reference
       # @example Force update heads/sc/featureA for octocat/Hello-World with sha aa218f56b14c9653891f9e74264a383fa43fefbd
       #   Octokit.update_ref("octocat/Hello-World","heads/sc/featureA", "aa218f56b14c9653891f9e74264a383fa43fefbd")
       def update_ref(repo, ref, sha, force = true, options = {})
@@ -80,7 +80,7 @@ module Octokit
       # @param sha [String] A SHA, e.g. <tt>827efc6d56897b048c772eb4087f854f46256132</tt>
       # @param force [Boolean] A flag indicating one wants to force the update to make sure the update is a fast-forward update.
       # @return [Array<Sawyer::Resource>] The list of references updated
-      # @see http://developer.github.com/v3/git/refs/#update-a-reference
+      # @see https://developer.github.com/v3/git/refs/#update-a-reference
       # @example Force update heads/sc/featureA for octocat/Hello-World with sha aa218f56b14c9653891f9e74264a383fa43fefbd
       #   Octokit.update_ref("octocat/Hello-World","sc/featureA", "aa218f56b14c9653891f9e74264a383fa43fefbd")
       def update_branch(repo, branch, sha, force = true, options = {})
@@ -92,7 +92,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param branch [String] The branch, e.g. <tt>fix-refs</tt>
       # @return [Boolean] Success
-      # @see http://developer.github.com/v3/git/refs/#delete-a-reference
+      # @see https://developer.github.com/v3/git/refs/#delete-a-reference
       # @example Delete uritemplate for sigmavirus24/github3.py
       #   Octokit.delete_branch("sigmavirus24/github3.py", "uritemplate")
       def delete_branch(repo, branch, options = {})
@@ -104,7 +104,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param ref [String] The ref, e.g. <tt>tags/v0.0.3</tt>
       # @return [Boolean] Success
-      # @see http://developer.github.com/v3/git/refs/#delete-a-reference
+      # @see https://developer.github.com/v3/git/refs/#delete-a-reference
       # @example Delete tags/v0.0.3 for sferik/rails_admin
       #   Octokit.delete_ref("sferik/rails_admin","tags/v0.0.3")
       def delete_ref(repo, ref, options = {})

--- a/lib/octokit/client/releases.rb
+++ b/lib/octokit/client/releases.rb
@@ -3,14 +3,14 @@ module Octokit
 
     # Methods for the Releases API
     #
-    # @see http://developer.github.com/v3/repos/releases/
+    # @see https://developer.github.com/v3/repos/releases/
     module Releases
 
       # List releases for a repository
       #
       # @param repo [String, Repository, Hash] A GitHub repository
       # @return [Array<Sawyer::Resource>] A list of releases
-      # @see http://developer.github.com/v3/repos/releases/#list-releases-for-a-repository
+      # @see https://developer.github.com/v3/repos/releases/#list-releases-for-a-repository
       def releases(repo, options = {})
         paginate "repos/#{Repository.new(repo)}/releases", options
       end
@@ -26,7 +26,7 @@ module Octokit
       # @option options [String] :draft Mark this release as a draft
       # @option options [String] :prerelease Mark this release as a pre-release
       # @return [Sawyer::Resource] The release
-      # @see http://developer.github.com/v3/repos/releases/#create-a-release
+      # @see https://developer.github.com/v3/repos/releases/#create-a-release
       def create_release(repo, tag_name, options = {})
         opts = options.merge(:tag_name => tag_name)
         post "repos/#{Repository.new(repo)}/releases", opts
@@ -36,7 +36,7 @@ module Octokit
       #
       # @param url [String] URL for the release as returned from .releases
       # @return [Sawyer::Resource] The release
-      # @see http://developer.github.com/v3/repos/releases/#get-a-single-release
+      # @see https://developer.github.com/v3/repos/releases/#get-a-single-release
       def release(url, options = {})
         get url, options
       end
@@ -50,7 +50,7 @@ module Octokit
       # @option options [String] :draft Mark this release as a draft
       # @option options [String] :prerelease Mark this release as a pre-release
       # @return [Sawyer::Resource] The release
-      # @see http://developer.github.com/v3/repos/releases/#edit-a-release
+      # @see https://developer.github.com/v3/repos/releases/#edit-a-release
       def update_release(url, options = {})
         patch url, options
       end
@@ -60,7 +60,7 @@ module Octokit
       #
       # @param url [String] URL for the release as returned from .releases
       # @return [Boolean] Success or failure
-      # @see http://developer.github.com/v3/repos/releases/#delete-a-release
+      # @see https://developer.github.com/v3/repos/releases/#delete-a-release
       def delete_release(url, options = {})
         boolean_from_response(:delete, url, options)
       end
@@ -69,7 +69,7 @@ module Octokit
       #
       # @param release_url [String] URL for the release as returned from .releases
       # @return [Array<Sawyer::Resource>] A list of release assets
-      # @see http://developer.github.com/v3/repos/releases/#list-assets-for-a-release
+      # @see https://developer.github.com/v3/repos/releases/#list-assets-for-a-release
       def release_assets(release_url, options = {})
         paginate release(release_url).rels[:assets].href, options
       end
@@ -81,7 +81,7 @@ module Octokit
       # @option options [String] :content_type The MIME type for the file to upload
       # @option options [String] :name The name for the file
       # @return [Sawyer::Resource] The release asset
-      # @see http://developer.github.com/v3/repos/releases/#upload-a-release-asset
+      # @see https://developer.github.com/v3/repos/releases/#upload-a-release-asset
       def upload_asset(release_url, path_or_file, options = {})
         file = path_or_file.respond_to?(:read) ? path_or_file : File.new(path_or_file, "r+b")
         options[:content_type] ||= content_type_from_file(file)
@@ -101,7 +101,7 @@ module Octokit
       #
       # @param asset_url [String] URL for the asset as returned from .release_assets
       # @return [Sawyer::Resource] The release asset
-      # @see http://developer.github.com/v3/repos/releases/#get-a-single-release-asset
+      # @see https://developer.github.com/v3/repos/releases/#get-a-single-release-asset
       def release_asset(asset_url, options = {})
         get(asset_url, options)
       end
@@ -112,7 +112,7 @@ module Octokit
       # @option options [String] :name The name for the file
       # @option options [String] :label The download text for the file
       # @return [Sawyer::Resource] The release asset
-      # @see http://developer.github.com/v3/repos/releases/#edit-a-release-asset
+      # @see https://developer.github.com/v3/repos/releases/#edit-a-release-asset
       def update_release_asset(asset_url, options = {})
         patch(asset_url, options)
       end
@@ -122,7 +122,7 @@ module Octokit
       #
       # @param asset_url [String] URL for the asset as returned from .release_assets
       # @return [Boolean] Success or failure
-      # @see http://developer.github.com/v3/repos/releases/#delete-a-release-asset
+      # @see https://developer.github.com/v3/repos/releases/#delete-a-release-asset
       def delete_release_asset(asset_url, options = {})
         boolean_from_response(:delete, asset_url, options)
       end

--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -3,12 +3,12 @@ module Octokit
 
     # Methods for the Repositories API
     #
-    # @see http://developer.github.com/v3/repos/
+    # @see https://developer.github.com/v3/repos/
     module Repositories
 
       # Check if a repository exists
       #
-      # @see http://developer.github.com/v3/repos/#get
+      # @see https://developer.github.com/v3/repos/#get
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Sawyer::Resource] if a repository exists, false otherwise
       def repository?(repo, options = {})
@@ -19,7 +19,7 @@ module Octokit
 
       # Get a single repository
       #
-      # @see http://developer.github.com/v3/repos/#get
+      # @see https://developer.github.com/v3/repos/#get
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Sawyer::Resource] Repository information
       def repository(repo, options = {})
@@ -29,7 +29,7 @@ module Octokit
 
       # Edit a repository
       #
-      # @see http://developer.github.com/v3/repos/#edit
+      # @see https://developer.github.com/v3/repos/#edit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @param options [Hash] Repository information to update
       # @option options [String] :name Name of the repo
@@ -59,8 +59,8 @@ module Octokit
       #   organization's public repositories will be listed. For retrieving
       #   organization repositories the {Organizations#organization_repositories}
       #   method should be used instead.
-      # @see http://developer.github.com/v3/repos/#list-your-repositories
-      # @see http://developer.github.com/v3/repos/#list-user-repositories
+      # @see https://developer.github.com/v3/repos/#list-your-repositories
+      # @see https://developer.github.com/v3/repos/#list-user-repositories
       # @param username [String] Optional username for which to list repos
       # @return [Array<Sawyer::Resource>] List of repositories
       def repositories(username=nil, options = {})
@@ -79,7 +79,7 @@ module Octokit
       # This provides a dump of every repository, in the order that they were
       # created.
       #
-      # @see http://developer.github.com/v3/repos/#list-all-public-repositories
+      # @see https://developer.github.com/v3/repos/#list-all-public-repositories
       #
       # @param options [Hash] Optional options
       # @option options [Integer] :since The integer ID of the last Repository
@@ -93,7 +93,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Boolean] `true` if successfully starred
-      # @see http://developer.github.com/v3/activity/starring/#star-a-repository
+      # @see https://developer.github.com/v3/activity/starring/#star-a-repository
       def star(repo, options = {})
         boolean_from_response :put, "user/starred/#{Repository.new(repo)}", options
       end
@@ -102,7 +102,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Boolean] `true` if successfully unstarred
-      # @see http://developer.github.com/v3/activity/starring/#unstar-a-repository
+      # @see https://developer.github.com/v3/activity/starring/#unstar-a-repository
       def unstar(repo, options = {})
         boolean_from_response :delete, "user/starred/#{Repository.new(repo)}", options
       end
@@ -112,7 +112,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Boolean] `true` if successfully watched
       # @deprecated Use #star instead
-      # @see http://developer.github.com/v3/activity/watching/#watch-a-repository-legacy
+      # @see https://developer.github.com/v3/activity/watching/#watch-a-repository-legacy
       def watch(repo, options = {})
         boolean_from_response :put, "user/watched/#{Repository.new(repo)}", options
       end
@@ -122,7 +122,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Boolean] `true` if successfully unwatched
       # @deprecated Use #unstar instead
-      # @see http://developer.github.com/v3/activity/watching/#stop-watching-a-repository-legacy
+      # @see https://developer.github.com/v3/activity/watching/#stop-watching-a-repository-legacy
       def unwatch(repo, options = {})
         boolean_from_response :delete, "user/watched/#{Repository.new(repo)}", options
       end
@@ -131,7 +131,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Sawyer::Resource] Repository info for the new fork
-      # @see http://developer.github.com/v3/repos/forks/#create-a-fork
+      # @see https://developer.github.com/v3/repos/forks/#create-a-fork
       def fork(repo, options = {})
         post "repos/#{Repository.new(repo)}/forks", options
       end
@@ -150,7 +150,7 @@ module Octokit
       # @option options [Boolean] :auto_init `true` to create an initial commit with empty README. Default is `false`.
       # @option options [String] :gitignore_template Desired language or platform .gitignore template to apply. Ignored if auto_init parameter is not provided.
       # @return [Sawyer::Resource] Repository info for the new repository
-      # @see http://developer.github.com/v3/repos/#create
+      # @see https://developer.github.com/v3/repos/#create
       def create_repository(name, options = {})
         organization = options.delete :organization
         options.merge! :name => name
@@ -168,7 +168,7 @@ module Octokit
       #
       # Note: If OAuth is used, 'delete_repo' scope is required
       #
-      # @see http://developer.github.com/v3/repos/#delete-a-repository
+      # @see https://developer.github.com/v3/repos/#delete-a-repository
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Boolean] `true` if repository was deleted
       def delete_repository(repo, options = {})
@@ -200,7 +200,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Array<Sawyer::Resource>] Array of hashes representing deploy keys.
-      # @see http://developer.github.com/v3/repos/keys/#list
+      # @see https://developer.github.com/v3/repos/keys/#list
       # @example
       #   @client.deploy_keys('octokit/octokit.rb')
       # @example
@@ -215,7 +215,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @param id [Integer] Deploy key ID.
       # @return [Sawyer::Resource] Deploy key.
-      # @see http://developer.github.com/v3/repos/keys/#get
+      # @see https://developer.github.com/v3/repos/keys/#get
       # @example
       #   @client.deploy_key('octokit/octokit.rb', 8675309)
       def deploy_key(repo, id, options={})
@@ -230,7 +230,7 @@ module Octokit
       # @param title [String] Title reference for the deploy key.
       # @param key [String] Public key.
       # @return [Sawyer::Resource] Hash representing newly added key.
-      # @see http://developer.github.com/v3/repos/keys/#create
+      # @see https://developer.github.com/v3/repos/keys/#create
       # @example
       #    @client.add_deploy_key('octokit/octokit.rb', 'Staging server', 'ssh-rsa AAA...')
       def add_deploy_key(repo, title, key, options = {})
@@ -245,7 +245,7 @@ module Octokit
       # @option title [String] Key title.
       # @option key [String] Public key.
       # @return [Sawyer::Resource] Updated deploy key.
-      # @see http://developer.github.com/v3/repos/keys/#edit
+      # @see https://developer.github.com/v3/repos/keys/#edit
       # @example Update the key for a deploy key.
       #   @client.edit_deploy_key('octokit/octokit.rb', 8675309, :key => 'ssh-rsa BBB...')
       # @example
@@ -262,7 +262,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @param id [Integer] Id of the deploy key to remove.
       # @return [Boolean] True if key removed, false otherwise.
-      # @see http://developer.github.com/v3/repos/keys/#delete
+      # @see https://developer.github.com/v3/repos/keys/#delete
       # @example
       #   @client.remove_deploy_key('octokit/octokit.rb', 100000)
       def remove_deploy_key(repo, id, options = {})
@@ -275,7 +275,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Array<Sawyer::Resource>] Array of hashes representing collaborating users.
-      # @see http://developer.github.com/v3/repos/collaborators/#list
+      # @see https://developer.github.com/v3/repos/collaborators/#list
       # @example
       #   Octokit.collaborators('octokit/octokit.rb')
       # @example
@@ -294,7 +294,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @param collaborator [String] Collaborator GitHub username to add.
       # @return [Boolean] True if collaborator added, false otherwise.
-      # @see http://developer.github.com/v3/repos/collaborators/#add-collaborator
+      # @see https://developer.github.com/v3/repos/collaborators/#add-collaborator
       # @example
       #   @client.add_collaborator('octokit/octokit.rb', 'holman')
       # @example
@@ -311,7 +311,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @param collaborator [String] Collaborator GitHub username to remove.
       # @return [Boolean] True if collaborator removed, false otherwise.
-      # @see http://developer.github.com/v3/repos/collaborators/#remove-collaborator
+      # @see https://developer.github.com/v3/repos/collaborators/#remove-collaborator
       # @example
       #   @client.remove_collaborator('octokit/octokit.rb', 'holman')
       # @example
@@ -328,7 +328,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @param collaborator [String] Collaborator GitHub username to check.
       # @return [Boolean] True if user is a collaborator, false otherwise.
-      # @see http://developer.github.com/v3/repos/collaborators/#get
+      # @see https://developer.github.com/v3/repos/collaborators/#get
       # @example
       #   @client.collaborator?('octokit/octokit.rb', 'holman')
       def collaborator?(repo, collaborator, options={})
@@ -341,7 +341,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Array<Sawyer::Resource>] Array of hashes representing teams.
-      # @see http://developer.github.com/v3/repos/#list-teams
+      # @see https://developer.github.com/v3/repos/#list-teams
       # @example
       #   @client.repository_teams('octokit/pengwynn')
       # @example
@@ -361,7 +361,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @param anon [Boolean] Set true to include annonymous contributors.
       # @return [Array<Sawyer::Resource>] Array of hashes representing users.
-      # @see http://developer.github.com/v3/repos/#list-contributors
+      # @see https://developer.github.com/v3/repos/#list-contributors
       # @example
       #   Octokit.contributors('octokit/octokit.rb', true)
       # @example
@@ -380,7 +380,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Array<Sawyer::Resource>] Array of hashes representing users.
-      # @see http://developer.github.com/v3/activity/starring/#list-stargazers
+      # @see https://developer.github.com/v3/activity/starring/#list-stargazers
       # @example
       #   Octokit.stargazers('octokit/octokit.rb')
       # @example
@@ -397,7 +397,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Array<Sawyer::Resource>] Array of hashes representing users.
-      # @see http://developer.github.com/v3/repos/watching/#list-watchers
+      # @see https://developer.github.com/v3/repos/watching/#list-watchers
       # @example
       #   Octokit.watchers('octokit/octokit.rb')
       # @example
@@ -412,7 +412,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Array<Sawyer::Resource>] Array of hashes representing repos.
-      # @see http://developer.github.com/v3/repos/forks/#list-forks
+      # @see https://developer.github.com/v3/repos/forks/#list-forks
       # @example
       #   Octokit.forks('octokit/octokit.rb')
       # @example
@@ -430,7 +430,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Array<Sawyer::Resource>] Array of Hashes representing languages.
-      # @see http://developer.github.com/v3/repos/#list-languages
+      # @see https://developer.github.com/v3/repos/#list-languages
       # @example
       #   Octokit.langauges('octokit/octokit.rb')
       # @example
@@ -445,7 +445,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Array<Sawyer::Resource>] Array of hashes representing tags.
-      # @see http://developer.github.com/v3/repos/#list-tags
+      # @see https://developer.github.com/v3/repos/#list-tags
       # @example
       #   Octokit.tags('octokit/octokit.rb')
       # @example
@@ -460,7 +460,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Array<Sawyer::Resource>] Array of hashes representing branches.
-      # @see http://developer.github.com/v3/repos/#list-branches
+      # @see https://developer.github.com/v3/repos/#list-branches
       # @example
       #   Octokit.branches('octokit/octokit.rb')
       # @example
@@ -474,7 +474,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @param branch [String] Branch name
       # @return [Sawyer::Resource] The branch requested, if it exists
-      # @see http://developer.github.com/v3/repos/#get-branch
+      # @see https://developer.github.com/v3/repos/#get-branch
       # @example Get branch 'master` from octokit/octokit.rb
       #   Octokit.branch("octokit/octokit.rb", "master")
       def branch(repo, branch, options = {})
@@ -488,7 +488,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Array<Sawyer::Resource>] Array of hashes representing hooks.
-      # @see http://developer.github.com/v3/repos/hooks/#list-hooks
+      # @see https://developer.github.com/v3/repos/hooks/#list-hooks
       # @example
       #   @client.hooks('octokit/octokit.rb')
       def hooks(repo, options = {})
@@ -502,7 +502,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @param id [Integer] Id of the hook to get.
       # @return [Sawyer::Resource] Hash representing hook.
-      # @see http://developer.github.com/v3/repos/hooks/#get-single-hook
+      # @see https://developer.github.com/v3/repos/hooks/#get-single-hook
       # @example
       #   @client.hook('octokit/octokit.rb', 100000)
       def hook(repo, id, options = {})
@@ -526,7 +526,7 @@ module Octokit
       # @return [Sawyer::Resource] Hook info for the new hook
       # @see https://api.github.com/hooks
       # @see https://github.com/github/github-services
-      # @see http://developer.github.com/v3/repos/hooks/#create-a-hook
+      # @see https://developer.github.com/v3/repos/hooks/#create-a-hook
       # @example
       #   @client.create_hook(
       #     'octokit/octokit.rb',
@@ -567,7 +567,7 @@ module Octokit
       # @return [Sawyer::Resource] Hook info for the updated hook
       # @see https://api.github.com/hooks
       # @see https://github.com/github/github-services
-      # @see http://developer.github.com/v3/repos/hooks/#edit-a-hook
+      # @see https://developer.github.com/v3/repos/hooks/#edit-a-hook
       # @example
       #   @client.edit_hook(
       #     'octokit/octokit.rb',
@@ -595,7 +595,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @param id [Integer] Id of the hook to remove.
       # @return [Boolean] True if hook removed, false otherwise.
-      # @see http://developer.github.com/v3/repos/hooks/#delete-a-hook
+      # @see https://developer.github.com/v3/repos/hooks/#delete-a-hook
       # @example
       #   @client.remove_hook('octokit/octokit.rb', 1000000)
       def remove_hook(repo, id, options = {})
@@ -609,7 +609,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @param id [Integer] Id of the hook to test.
       # @return [Boolean] Success
-      # @see http://developer.github.com/v3/repos/hooks/#test-a-push-hook
+      # @see https://developer.github.com/v3/repos/hooks/#test-a-push-hook
       # @example
       #   @client.test_hook('octokit/octokit.rb', 1000000)
       def test_hook(repo, id, options = {})
@@ -622,7 +622,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Array<Sawyer::Resource>] Array of hashes representing users.
-      # @see http://developer.github.com/v3/issues/assignees/#list-assignees
+      # @see https://developer.github.com/v3/issues/assignees/#list-assignees
       # @example
       #   Octokit.repository_assignees('octokit/octokit.rb')
       # @example
@@ -639,7 +639,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @param assignee [String] User login to check
       # @return [Boolean] True if assignable on project, false otherwise.
-      # @see http://developer.github.com/v3/issues/assignees/#check-assignee
+      # @see https://developer.github.com/v3/issues/assignees/#check-assignee
       # @example
       #   Octokit.check_assignee('octokit/octokit.rb', 'andrew')
       def check_assignee(repo, assignee, options = {})
@@ -650,7 +650,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Array<Sawyer::Resource>] Array of users watching.
-      # @see http://developer.github.com/v3/activity/watching/#list-watchers
+      # @see https://developer.github.com/v3/activity/watching/#list-watchers
       # @example
       #   @client.subscribers("octokit/octokit.rb")
       def subscribers(repo, options = {})
@@ -661,7 +661,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Sawyer::Resource] Repository subscription.
-      # @see http://developer.github.com/v3/activity/watching/#get-a-repository-subscription
+      # @see https://developer.github.com/v3/activity/watching/#get-a-repository-subscription
       # @example
       #   @client.subscription("octokit/octokit.rb")
       def subscription(repo, options = {})
@@ -678,7 +678,7 @@ module Octokit
       # @option options [Boolean] :ignored Deterimines if all notifications
       #   should be blocked from this repository.
       # @return [Sawyer::Resource] Updated repository subscription.
-      # @see http://developer.github.com/v3/activity/watching/#set-a-repository-subscription
+      # @see https://developer.github.com/v3/activity/watching/#set-a-repository-subscription
       # @example Subscribe to notifications for a repository
       #   @client.update_subscription("octokit/octokit.rb", {subscribed: true})
       def update_subscription(repo, options = {})
@@ -689,7 +689,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository.
       # @return [Boolean] True if subscription deleted, false otherwise.
-      # @see http://developer.github.com/v3/activity/watching/#delete-a-repository-subscription
+      # @see https://developer.github.com/v3/activity/watching/#delete-a-repository-subscription
       #
       # @example
       #   @client.delete_subscription("octokit/octokit.rb")

--- a/lib/octokit/client/search.rb
+++ b/lib/octokit/client/search.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Search API
     #
-    # @see http://developer.github.com/v3/search/
+    # @see https://developer.github.com/v3/search/
     module Search
 
       # Search code
@@ -15,7 +15,7 @@ module Octokit
       # @option options [Fixnum] :page Page of paginated results
       # @option options [Fixnum] :per_page Number of items per page
       # @return [Sawyer::Resource] Search results object
-      # @see http://developer.github.com/v3/search/#search-code
+      # @see https://developer.github.com/v3/search/#search-code
       def search_code(query, options = {})
         search "search/code", query, options
       end
@@ -29,7 +29,7 @@ module Octokit
       # @option options [Fixnum] :page Page of paginated results
       # @option options [Fixnum] :per_page Number of items per page
       # @return [Sawyer::Resource] Search results object
-      # @see http://developer.github.com/v3/search/#search-issues
+      # @see https://developer.github.com/v3/search/#search-issues
       def search_issues(query, options = {})
         search "search/issues", query, options
       end
@@ -43,7 +43,7 @@ module Octokit
       # @option options [Fixnum] :page Page of paginated results
       # @option options [Fixnum] :per_page Number of items per page
       # @return [Sawyer::Resource] Search results object
-      # @see http://developer.github.com/v3/search/#search-repositories
+      # @see https://developer.github.com/v3/search/#search-repositories
       def search_repositories(query, options = {})
         search "search/repositories", query, options
       end
@@ -58,7 +58,7 @@ module Octokit
       # @option options [Fixnum] :page Page of paginated results
       # @option options [Fixnum] :per_page Number of items per page
       # @return [Sawyer::Resource] Search results object
-      # @see http://developer.github.com/v3/search/#search-users
+      # @see https://developer.github.com/v3/search/#search-users
       def search_users(query, options = {})
         search "search/users", query, options
       end

--- a/lib/octokit/client/stats.rb
+++ b/lib/octokit/client/stats.rb
@@ -3,14 +3,14 @@ module Octokit
 
     # Methods for the Repository Statistics API
     #
-    # @see http://developer.github.com/v3/repos/statistics/
+    # @see https://developer.github.com/v3/repos/statistics/
     module Stats
 
       # Get contributors list with additions, deletions, and commit counts
       #
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Array<Sawyer::Resource>] Array of contributor stats
-      # @see http://developer.github.com/v3/repos/statistics/#contributors
+      # @see https://developer.github.com/v3/repos/statistics/#contributors
       # @example Get contributor stats for octokit
       #   @client.contributors_stats('octokit/octokit.rb')
       def contributors_stats(repo, options = {})
@@ -23,7 +23,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Array<Sawyer::Resource>] The last year of commit activity grouped by
       #   week. The days array is a group of commits per day, starting on Sunday.
-      # @see http://developer.github.com/v3/repos/statistics/#get-the-last-year-of-commit-activity-data
+      # @see https://developer.github.com/v3/repos/statistics/#get-the-last-year-of-commit-activity-data
       # @example Get commit activity for octokit
       #   @client.commit_activity_stats('octokit/octokit.rb')
       def commit_activity_stats(repo, options = {})
@@ -35,7 +35,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Array<Sawyer::Resource>] Weekly aggregate of the number of additions
       #   and deletions pushed to a repository.
-      # @see http://developer.github.com/v3/repos/statistics/#code-frequency
+      # @see https://developer.github.com/v3/repos/statistics/#code-frequency
       # @example Get code frequency stats for octokit
       #   @client.code_frequency_stats('octokit/octokit.rb')
       def code_frequency_stats(repo, options = {})
@@ -49,7 +49,7 @@ module Octokit
       #   counts in all. all is everyone combined, including the owner in the last
       #   52 weeks. If you’d like to get the commit counts for non-owners, you can
       #   subtract all from owner.
-      # @see http://developer.github.com/v3/repos/statistics/#participation
+      # @see https://developer.github.com/v3/repos/statistics/#participation
       # @example Get weekly commit counts for octokit
       #   @client.participation_stats("octokit/octokit.rb")
       def participation_stats(repo, options = {})
@@ -61,7 +61,7 @@ module Octokit
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Array<Array>] Arrays containing the day number, hour number, and
       #   number of commits
-      # @see http://developer.github.com/v3/repos/statistics/#punch-card
+      # @see https://developer.github.com/v3/repos/statistics/#punch-card
       # @example Get octokit punch card
       #   @octokit.punch_card_stats
       def punch_card_stats(repo, options = {})

--- a/lib/octokit/client/statuses.rb
+++ b/lib/octokit/client/statuses.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Commit Statuses API
     #
-    # @see http://developer.github.com/v3/repos/statuses/
+    # @see https://developer.github.com/v3/repos/statuses/
     module Statuses
       COMBINED_STATUS_MEDIA_TYPE = "application/vnd.github.she-hulk-preview+json"
 
@@ -12,7 +12,7 @@ module Octokit
       # @param repo [String, Repository, Hash] A GitHub repository
       # @param sha [String] The SHA1 for the commit
       # @return [Array<Sawyer::Resource>] A list of statuses
-      # @see http://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+      # @see https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
       def statuses(repo, sha, options = {})
         get "repos/#{Repository.new(repo)}/statuses/#{sha}", options
       end
@@ -39,7 +39,7 @@ module Octokit
       # @option options [String] :target_url A link to more details about this status
       # @option options [String] :description A short human-readable description of this status
       # @return [Sawyer::Resource] A status
-      # @see http://developer.github.com/v3/repos/statuses/#create-a-status
+      # @see https://developer.github.com/v3/repos/statuses/#create-a-status
       def create_status(repo, sha, state, options = {})
         options.merge!(:state => state)
         post "repos/#{Repository.new(repo)}/statuses/#{sha}", options

--- a/lib/octokit/client/users.rb
+++ b/lib/octokit/client/users.rb
@@ -3,7 +3,7 @@ module Octokit
 
     # Methods for the Users API
     #
-    # @see http://developer.github.com/v3/users/
+    # @see https://developer.github.com/v3/users/
     module Users
 
       # List all GitHub users
@@ -15,7 +15,7 @@ module Octokit
       # @option options [Integer] :since The integer ID of the last User that
       #   you’ve seen.
       #
-      # @see http://developer.github.com/v3/users/#get-all-users
+      # @see https://developer.github.com/v3/users/#get-all-users
       #
       # @return [Array<Sawyer::Resource>] List of GitHub users.
       def all_users(options = {})
@@ -26,8 +26,8 @@ module Octokit
       #
       # @param user [String] A GitHub user name.
       # @return [Sawyer::Resource]
-      # @see http://developer.github.com/v3/users/#get-a-single-user
-      # @see http://developer.github.com/v3/users/#get-the-authenticated-user
+      # @see https://developer.github.com/v3/users/#get-a-single-user
+      # @see https://developer.github.com/v3/users/#get-the-authenticated-user
       # @example
       #   Octokit.user("sferik")
       def user(user=nil, options = {})
@@ -44,7 +44,7 @@ module Octokit
       # @param app_id [String] Client Id we received when our application was registered with GitHub. Defaults to client_id.
       # @param app_secret [String] Client Secret we received when our application was registered with GitHub. Defaults to client_secret.
       # @return [Sawyer::Resource] Hash holding the access token.
-      # @see http://developer.github.com/v3/oauth/#web-application-flow
+      # @see https://developer.github.com/v3/oauth/#web-application-flow
       # @example
       #   Octokit.exchange_code_for_token('aaaa', 'xxxx', 'yyyy', {:accept => 'application/json'})
       def exchange_code_for_token(code, app_id = client_id, app_secret = client_secret, options = {})
@@ -83,7 +83,7 @@ module Octokit
       # @option options [Boolean] :hireable
       # @option options [String] :bio
       # @return [Sawyer::Resource]
-      # @see http://developer.github.com/v3/users/#update-the-authenticated-user
+      # @see https://developer.github.com/v3/users/#update-the-authenticated-user
       # @example
       #   Octokit.update_user(:name => "Erik Michaels-Ober", :email => "sferik@gmail.com", :company => "Code for America", :location => "San Francisco", :hireable => false)
       def update_user(options)
@@ -94,7 +94,7 @@ module Octokit
       #
       # @param user [String] Username of the user whose list of followers you are getting.
       # @return [Array<Sawyer::Resource>] Array of hashes representing users followers.
-      # @see http://developer.github.com/v3/users/followers/#list-followers-of-a-user
+      # @see https://developer.github.com/v3/users/followers/#list-followers-of-a-user
       # @example
       #   Octokit.followers('pengwynn')
       def followers(user=login, options = {})
@@ -105,7 +105,7 @@ module Octokit
       #
       # @param user [String] Username of the user who you are getting the list of the people they follow.
       # @return [Array<Sawyer::Resource>] Array of hashes representing users a user is following.
-      # @see http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user
+      # @see https://developer.github.com/v3/users/followers/#list-users-followed-by-another-user
       # @example
       #   Octokit.following('pengwynn')
       def following(user=login, options = {})
@@ -123,8 +123,8 @@ module Octokit
       #   @param user [String] Username of first user
       #   @param target [String] Username of the target user
       # @return [Boolean] True following target user, false otherwise.
-      # @see http://developer.github.com/v3/users/followers/#check-if-you-are-following-a-user
-      # @see http://developer.github.com/v3/users/followers/#check-if-one-user-follows-another
+      # @see https://developer.github.com/v3/users/followers/#check-if-you-are-following-a-user
+      # @see https://developer.github.com/v3/users/followers/#check-if-one-user-follows-another
       # @example
       #   @client.follows?('pengwynn')
       # @example
@@ -146,7 +146,7 @@ module Octokit
       #
       # @param user [String] Username of the user to follow.
       # @return [Boolean] True if follow was successful, false otherwise.
-      # @see http://developer.github.com/v3/users/followers/#follow-a-user
+      # @see https://developer.github.com/v3/users/followers/#follow-a-user
       # @example
       #   @client.follow('holman')
       def follow(user, options = {})
@@ -159,7 +159,7 @@ module Octokit
       #
       # @param user [String] Username of the user to unfollow.
       # @return [Boolean] True if unfollow was successful, false otherwise.
-      # @see http://developer.github.com/v3/users/followers/#unfollow-a-user
+      # @see https://developer.github.com/v3/users/followers/#unfollow-a-user
       # @example
       #   @client.unfollow('holman')
       def unfollow(user, options = {})
@@ -173,7 +173,7 @@ module Octokit
       # @option options [String] :sort (created) Sort: <tt>created</tt> or <tt>updated</tt>.
       # @option options [String] :direction (desc) Direction: <tt>asc</tt> or <tt>desc</tt>.
       # @return [Array<Sawyer::Resource>] Array of hashes representing repositories starred by user.
-      # @see http://developer.github.com/v3/activity/starring/#list-repositories-being-starred
+      # @see https://developer.github.com/v3/activity/starring/#list-repositories-being-starred
       # @example
       #   Octokit.starred('pengwynn')
       def starred(user=login, options = {})
@@ -191,7 +191,7 @@ module Octokit
       #
       # @param repo [String, Hash, Repository] A GitHub repository
       # @return [Boolean] True if you are following the repo, false otherwise.
-      # @see http://developer.github.com/v3/activity/starring/#check-if-you-are-starring-a-repository
+      # @see https://developer.github.com/v3/activity/starring/#check-if-you-are-starring-a-repository
       # @example
       #   @client.starred?('pengwynn/octokit')
       def starred?(repo, options = {})
@@ -208,7 +208,7 @@ module Octokit
       #
       # @param key_id [Integer] Key to retreive.
       # @return [Sawyer::Resource] Hash representing the key.
-      # @see http://developer.github.com/v3/users/keys/#get-a-single-public-key
+      # @see https://developer.github.com/v3/users/keys/#get-a-single-public-key
       # @example
       #   @client.key(1)
       # @example Retrieve public key contents
@@ -230,7 +230,7 @@ module Octokit
       # Requires authenticated client.
       #
       # @return [Array<Sawyer::Resource>] Array of hashes representing public keys.
-      # @see http://developer.github.com/v3/users/keys/#list-your-public-keys
+      # @see https://developer.github.com/v3/users/keys/#list-your-public-keys
       # @example
       #   @client.keys
       def keys(options = {})
@@ -242,7 +242,7 @@ module Octokit
       # Requires authenticated client.
       #
       # @return [Array<Sawyer::Resource>] Array of hashes representing public keys.
-      # @see http://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
+      # @see https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
       # @example
       #   @client.user_keys('pengwynn'
       def user_keys(user, options = {})
@@ -257,7 +257,7 @@ module Octokit
       # @param title [String] Title to give reference to the public key.
       # @param key [String] Public key.
       # @return [Sawyer::Resource] Hash representing the newly added public key.
-      # @see http://developer.github.com/v3/users/keys/#create-a-public-key
+      # @see https://developer.github.com/v3/users/keys/#create-a-public-key
       # @example
       #   @client.add_key('Personal projects key', 'ssh-rsa AAA...')
       def add_key(title, key, options = {})
@@ -273,7 +273,7 @@ module Octokit
       # @option options [String] :title
       # @option options [String] :key
       # @return [Sawyer::Resource] Hash representing the updated public key.
-      # @see http://developer.github.com/v3/users/keys/#update-a-public-key
+      # @see https://developer.github.com/v3/users/keys/#update-a-public-key
       # @example
       #   @client.update_key(1, :title => 'new title', :key => "ssh-rsa BBB")
       def update_key(key_id, options = {})
@@ -286,7 +286,7 @@ module Octokit
       #
       # @param id [String] Id of the public key to remove.
       # @return [Boolean] True if removal was successful, false otherwise.
-      # @see http://developer.github.com/v3/users/keys/#delete-a-public-key
+      # @see https://developer.github.com/v3/users/keys/#delete-a-public-key
       # @example
       #   @client.remove_key(1)
       def remove_key(id, options = {})
@@ -298,7 +298,7 @@ module Octokit
       # Requires authenticated client.
       #
       # @return [Array<String>] Array of email addresses.
-      # @see http://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user
+      # @see https://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user
       # @example
       #   @client.emails
       def emails(options = {})
@@ -311,7 +311,7 @@ module Octokit
       #
       # @param email [String] Email address to add to the user.
       # @return [Array<String>] Array of all email addresses of the user.
-      # @see http://developer.github.com/v3/users/emails/#add-email-addresses
+      # @see https://developer.github.com/v3/users/emails/#add-email-addresses
       # @example
       #   @client.add_email('new_email@user.com')
       def add_email(email, options = {})
@@ -325,7 +325,7 @@ module Octokit
       #
       # @param email [String] Email address to remove.
       # @return [Array<String>] Array of all email addresses of the user.
-      # @see http://developer.github.com/v3/users/emails/#delete-email-addresses
+      # @see https://developer.github.com/v3/users/emails/#delete-email-addresses
       # @example
       #   @client.remove_email('old_email@user.com')
       def remove_email(email)
@@ -339,7 +339,7 @@ module Octokit
       #
       # @return [Array<Sawyer::Resource>] Array of repositories.
       #
-      # @see http://developer.github.com/v3/activity/watching/#list-repositories-being-watched
+      # @see https://developer.github.com/v3/activity/watching/#list-repositories-being-watched
       #
       # @example
       #   @client.subscriptions("pengwynn")

--- a/lib/octokit/configurable.rb
+++ b/lib/octokit/configurable.rb
@@ -4,20 +4,20 @@ module Octokit
   # in {Default}
   module Configurable
     # @!attribute [w] access_token
-    #   @see http://developer.github.com/v3/oauth/
+    #   @see https://developer.github.com/v3/oauth/
     #   @return [String] OAuth2 access token for authentication
     # @!attribute api_endpoint
     #   @return [String] Base URL for API requests. default: https://api.github.com/
     # @!attribute auto_paginate
     #   @return [Boolean] Auto fetch next page of results until rate limit reached
     # @!attribute client_id
-    #   @see http://developer.github.com/v3/oauth/
+    #   @see https://developer.github.com/v3/oauth/
     #   @return [String] Configure OAuth app key
     # @!attribute [w] client_secret
-    #   @see http://developer.github.com/v3/oauth/
+    #   @see https://developer.github.com/v3/oauth/
     #   @return [String] Configure OAuth app secret
     # @!attribute default_media_type
-    #   @see http://developer.github.com/v3/media/
+    #   @see https://developer.github.com/v3/media/
     #   @return [String] Configure preferred media type (for API versioning, for example)
     # @!attribute connection_options
     #   @see https://github.com/lostisland/faraday

--- a/lib/octokit/rate_limit.rb
+++ b/lib/octokit/rate_limit.rb
@@ -11,7 +11,7 @@ module Octokit
   # @!attribute [w] resets_in
   #   @return [Fixnum] Number of seconds when rate limit resets
   #
-  # @see http://developer.github.com/v3/#rate-limiting
+  # @see https://developer.github.com/v3/#rate-limiting
   class RateLimit < Struct.new(:limit, :remaining, :resets_at, :resets_in)
 
     # Get rate limit info from HTTP response


### PR DESCRIPTION
All of the deep links in the docs (`@see http://`) are "broken", because `developer.github.com` site redirects all `http` to `https`, breaking the deep links:
- http://developer.github.com/v3/#authentication becomes
  http://developer.github.com/v3

This commit simply mass-find-and-replaced all the `@see http://` with `@see https://`. I checked a few but not all.
