### PR TITLE
Update README to include note for oauth token.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ client = Octokit::Client.new \
   :login    => 'defunkt',
   :password => 'c0d3b4ssssss!'
 
-client.create_authorization(:scopes => ["user"], :headers => { "X-GitHub-OTP" => "<your 2FA token>" })
+client.create_authorization(:scopes => ["user"], :note => "Name of token",
+                            :headers => { "X-GitHub-OTP" => "<your 2FA token>" })
 # => <your new oauth token>
 ```
 


### PR DESCRIPTION
"Note" is now a required parameter for creating an authorization.
https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization

The current example throws an error because `note` is missing.

```
Octokit::UnprocessableEntity: POST https://api.github.com/authorizations: 422 - Validation Failed
Error summary:
  resource: OauthAccess
  code: missing_field
  field: description // See: https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
```
