### PR TITLE
Override the yard doc generate to fix hash links in the readme

### DIFF
--- a/yard/default/layout/html/setup.rb
+++ b/yard/default/layout/html/setup.rb
@@ -8,8 +8,9 @@ def diskfile
   # changes to the generate docs so the links work both on
   # GitHub and in the documentation.
   if @file.name == "README"
-    bad_link = data.match(/href\=\"\#(.+)\"/)[1]
-    data.gsub!(bad_link, bad_link.capitalize.gsub!('-', '_'))
+    data.scan(/href\=\"\#(.+)\"/).each do |bad_link|
+      data.gsub!(bad_link.first, bad_link.first.capitalize.gsub('-', '_'))
+    end
   end
 
   "<div id='filecontents'>" + data + "</div>"


### PR DESCRIPTION
The readme uses GitHub hash links which go something like
like #another-section and yard generates hash links that
go something like #Another_section.

This changes the yard generator to make the transformation to
capitalized underscored hash links so they work both on GitHub
and in the yard generated documentation.

Fix #458
