### PR TITLE
Only require rss when parsing feeds

### DIFF
--- a/lib/octokit/response/feed_parser.rb
+++ b/lib/octokit/response/feed_parser.rb
@@ -7,14 +7,11 @@ module Octokit
     # Parses RSS and Atom feed responses.
     class FeedParser < Faraday::Response::Middleware
 
-      dependency do
-        require 'rss'
-      end
-
       private
 
       def on_complete(env)
         if env[:response_headers]["content-type"] =~ /(\batom|\brss)/
+          require 'rss'
           env[:body] = RSS::Parser.parse env[:body]
         end
       end


### PR DESCRIPTION
Should save some memory for folks not using the Feeds API.

/cc @dbussink
