### PR TITLE
Fix typo in documentation of languages method

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -432,7 +432,7 @@ module Octokit
       # @return [Array<Sawyer::Resource>] Array of Hashes representing languages.
       # @see https://developer.github.com/v3/repos/#list-languages
       # @example
-      #   Octokit.langauges('octokit/octokit.rb')
+      #   Octokit.languages('octokit/octokit.rb')
       # @example
       #   @client.languages('octokit/octokit.rb')
       def languages(repo, options = {})


### PR DESCRIPTION
Fixed  Octokit.langauges to Octokit.languages in method documentation.

Signed-off-by: Alissa Bonas abonas@redhat.com
