### PR TITLE
Move depreciation warning to ruby 1.9 syntax

### DIFF
--- a/lib/octokit/client/pull_requests.rb
+++ b/lib/octokit/client/pull_requests.rb
@@ -20,13 +20,13 @@ module Octokit
       # @return [Array<Sawyer::Resource>] Array of pulls
       # @see https://developer.github.com/v3/pulls/#list-pull-requests
       # @example
-      #   Octokit.pull_requests('rails/rails', :state => 'closed')
+      #   Octokit.pull_requests('rails/rails', state: 'closed')
       def pull_requests(*args)
         arguments = Arguments.new(args)
         opts = arguments.options
         repo = arguments.shift
         if state = arguments.shift
-          octokit_warn "DEPRECATED: Client#pull_requests: Passing state as positional argument is deprecated. Please use :state => '#{state}'"
+          octokit_warn "DEPRECATED: Client#pull_requests: Passing state as positional argument is deprecated. Please use state: '#{state}'"
           opts[:state] = state if state
         end
         paginate "#{Repository.path repo}/pulls", opts


### PR DESCRIPTION
I happened to come across the warning while working on another gem.

Since the gem require `ruby 1.9.2` and above, it should probably reflect the newer hash syntax.

Nothing life altering.

Thanks for a great project!
