### PR TITLE
Enhanced Octokit::TooManyRequests exception

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -181,7 +181,19 @@ module Octokit
 
   # Raised when GitHub returns a 403 HTTP status code
   # and body matches 'rate limit exceeded'
-  class TooManyRequests < Forbidden; end
+  class TooManyRequests < Forbidden
+    def limit_resets_at
+      Time.at(@response.response_headers["x-ratelimit-reset"].to_i)
+    end
+
+    def current_limit
+      @response.response_headers["x-ratelimit-limit"].to_i
+    end
+
+    def remaining_queries
+      @response.response_headers["x-ratelimit-remaining"].to_i
+    end
+  end
 
   # Raised when GitHub returns a 403 HTTP status code
   # and body matches 'login attempts exceeded'


### PR DESCRIPTION
Hi,

When I was trying to catch ```Octokit::TooManyRequests``` exception in my application, I found that there’s no way to return my current rate limit, as well as when limit will be reset.

Before, I had to do something like this:
```ruby 
begin
  Octokit.repo("rails/rails")
rescue Octokit::TooManyRequests => e
  reset = e.instance_variable_get(:@response).response_headers["x-ratelimit-reset"].to_i
  sleep Time.at(reset) - Time.now
  retry
end
```

This code is bad, and I feel bad that I wrote it ;)

With my patch, I don’t have to break encapsulation and write code like this:

```ruby
begin
  Octokit.repo("rails/rails")
rescue Octokit::TooManyRequests => e
  sleep e.limit_resets_at - Time.now
  retry
end
```
