### PR TITLE
Fix Readme so the upgrade notice is more generic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Ruby toolkit for the GitHub API.
 ![Logo][logo]
 [logo]: http://cl.ly/image/3Y013H0A2z3z/gundam-ruby.png
 
-Octokit 2.0 is out, check the [Upgrade Guide](#upgrading-guide) before
-upgrading from 1.x.
+If you have an older version of Octokit, check the [Upgrade Guide](#upgrading-guide) before
+upgrading.
 
 ## Philosophy
 


### PR DESCRIPTION
I created this pull request so that the upgrade warning is a bit more generic so it doesn't have to be updated with every new version of Octokit.  It now reads that Octokit 2.0 is out while in fact, I just got 3.3.1.  Hope this helps.
