### PR TITLE
remove developer preview warning from .combined_status()

### DIFF
--- a/lib/octokit/client/statuses.rb
+++ b/lib/octokit/client/statuses.rb
@@ -5,7 +5,6 @@ module Octokit
     #
     # @see https://developer.github.com/v3/repos/statuses/
     module Statuses
-      COMBINED_STATUS_MEDIA_TYPE = "application/vnd.github.she-hulk-preview+json"
 
       # List all statuses for a given commit
       #
@@ -25,7 +24,6 @@ module Octokit
       # @return [Sawyer::Resource] The combined status for the commit
       # @see https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
       def combined_status(repo, ref, options = {})
-        ensure_combined_status_api_media_type(options)
         get "#{Repository.path repo}/commits/#{ref}/status", options
       end
       alias :status :combined_status
@@ -43,24 +41,6 @@ module Octokit
       def create_status(repo, sha, state, options = {})
         options.merge!(:state => state)
         post "#{Repository.path repo}/statuses/#{sha}", options
-      end
-
-      private
-
-      def ensure_combined_status_api_media_type(options = {})
-        unless options[:accept]
-          options[:accept] = COMBINED_STATUS_MEDIA_TYPE
-          warn_combined_status_preview
-        end
-        options
-      end
-
-      def warn_combined_status_preview
-        octokit_warn <<-EOS
-WARNING: The preview version of the combined status API is not yet suitable
-for production use. You can avoid this message by supplying an appropriate
-media type in the 'Accept' header. See the blog post for details http://git.io/wtsdaA
-EOS
       end
     end
   end


### PR DESCRIPTION
The combined_status API endpoint is no longer in development preview. This patch makes the following changes:
- removes the HTTP `Accept` header that was required for this call while it was in its preview period
- remove the warning printed about the method being in the development preview

All tests passed locally when following the steps in the contribution information. Please let me know if there are any changes that are needed to be made.
