### PR TITLE
remove preview API warning for team memberships API

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -6,8 +6,6 @@ module Octokit
     # @see https://developer.github.com/v3/orgs/
     module Organizations
 
-      ORG_INVITATIONS_PREVIEW_MEDIA_TYPE = "application/vnd.github.the-wasp-preview+json".freeze
-
       # Get an organization
       #
       # @param org [String, Integer] Organization GitHub login or id.


### PR DESCRIPTION
As the APIs are now [final](https://developer.github.com/changes/2014-09-23-one-more-week-before-the-add-team-member-api-breaking-change/), the special `Accept` header is no longer needed.

...right?
