### PR TITLE
changed handling of results from netrc [] operator

### DIFF
--- a/lib/octokit/authentication.rb
+++ b/lib/octokit/authentication.rb
@@ -62,8 +62,8 @@ module Octokit
         # creds will be nil if there is no netrc for this end point
         octokit_warn "Error loading credentials from netrc file for #{api_endpoint}"
       else
-        self.login = creds.shift
-        self.password = creds.shift
+        self.login = creds.login
+        self.password = creds.password
       end
     rescue LoadError
       octokit_warn "Please install netrc gem for .netrc support"


### PR DESCRIPTION
The new return type from the [] operator is Netrc::Entry, defined as:

```
  Entry = Struct.new(:login, :password) do
    alias to_ary to_a
  end
```

This commit replaces the calls to `.shift` on the result with calls to `.login` and `.password`.
