### PR TITLE
Link to list of Octokit::Client instance methods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Install via Rubygems
 
 ### Making requests
 
-API methods are available as module methods (consuming module-level
+[API methods][] are available as module methods (consuming module-level
 configuration) or as client instance methods.
 
 ```ruby
@@ -58,6 +58,8 @@ client = Octokit::Client.new(:login => 'defunkt', :password => 'c0d3b4ssssss!')
 # Fetch the current user
 client.user
 ```
+
+[API methods]: http://octokit.github.io/octokit.rb/method_list.html
 
 ### Consuming resources
 


### PR DESCRIPTION
Fixes #523, providing a link to API methods provided by the client.

Whatcha think @ajkamel?

![screen shot 2014-10-17 at 4 53 33 pm](https://cloud.githubusercontent.com/assets/865/4686630/2119c27e-5648-11e4-94e6-16d31e8b3fd4.png)
