### PR TITLE
Deployment doc fixes

### DIFF
--- a/lib/octokit/client/deployments.rb
+++ b/lib/octokit/client/deployments.rb
@@ -26,6 +26,7 @@ module Octokit
       # @option options [String] :task Used by the deployment system to allow different execution paths. Defaults to "deploy".
       # @option options [String] :payload Meta info about the deployment
       # @option options [Boolean] :auto_merge Optional parameter to merge the default branch into the requested deployment branch if necessary. Default: true
+      # @option options [String] :environment Optional name for the target deployment environment (e.g., production, staging, qa). Default: "production"
       # @option options [String] :description Optional short description.
       # @return [Sawyer::Resource] A deployment
       # @see https://developer.github.com/v3/repos/deployments/#create-a-deployment


### PR DESCRIPTION
I noticed a couple of outdated items in the documentation for `create_deployment`.

/cc @atmos to make sure these changes are correct.
