### PR TITLE
Fix pubsubhubbub spec

### DIFF
--- a/spec/octokit/client/pub_sub_hubbub_spec.rb
+++ b/spec/octokit/client/pub_sub_hubbub_spec.rb
@@ -73,7 +73,7 @@ describe Octokit::Client::PubSubHubbub do
         :"hub.topic" => 'https://github.com/joshk/completeness-fu/events/push'
       }
       stub_post("/hub").
-        with(irc_request_body).
+        with(:body => irc_request_body).
         to_return(:status => 204)
       expect(@client.subscribe_service_hook("joshk/completeness-fu", "irc", { :server => "chat.freenode.org", :room => "#myproject"})).to eql(true)
       # Since we can't depend upon hash ordering across the Rubies


### PR DESCRIPTION
Updated webmock doesn't assume the parameter passed to .with is body by default anymore.

Ie fix this failure https://travis-ci.org/octokit/octokit.rb/jobs/40143604

```
Failures:
  1) Octokit::Client::PubSubHubbub.subscribe_service_hook encodes URL parameters
     Failure/Error: stub_post("/hub").
     ArgumentError:
       Unknown key: "hub.callback". Valid keys are: "body", "headers", "query"
     # ./spec/octokit/client/pub_sub_hubbub_spec.rb:75:in `block (3 levels) in <top (required)>'
Finished in 22.79 seconds (files took 2.58 seconds to load)
459 examples, 1 failure
Failed examples:
rspec ./spec/octokit/client/pub_sub_hubbub_spec.rb:69 # Octokit::Client::PubSubHubbub.subscribe_service_hook encodes URL parameters
```
