### PR TITLE
Remove Deployments API preview warnings

### DIFF
--- a/lib/octokit/client/deployments.rb
+++ b/lib/octokit/client/deployments.rb
@@ -6,15 +6,12 @@ module Octokit
     # @see https://developer.github.com/v3/repos/commits/deployments/
     module Deployments
 
-      DEPLOYMENTS_PREVIEW_MEDIA_TYPE = "application/vnd.github.cannonball-preview+json".freeze
-
       # List all deployments for a repository
       #
       # @param repo [Integer, String, Repository, Hash] A GitHub repository
       # @return [Array<Sawyer::Resource>] A list of deployments
       # @see https://developer.github.com/v3/repos/deployments/#list-deployments
       def deployments(repo, options = {})
-        options = ensure_deployments_api_media_type(options)
         get("#{Repository.path repo}/deployments", options)
       end
       alias :list_deployments :deployments
@@ -32,7 +29,6 @@ module Octokit
       # @return [Sawyer::Resource] A deployment
       # @see https://developer.github.com/v3/repos/deployments/#create-a-deployment
       def create_deployment(repo, ref, options = {})
-        options = ensure_deployments_api_media_type(options)
         options[:ref] = ref
         post("#{Repository.path repo}/deployments", options)
       end
@@ -43,7 +39,6 @@ module Octokit
       # @return [Array<Sawyer::Resource>] A list of deployment statuses
       # @see https://developer.github.com/v3/repos/deployments/#list-deployment-statuses
       def deployment_statuses(deployment_url, options = {})
-        options = ensure_deployments_api_media_type(options)
         deployment = get(deployment_url, :accept => options[:accept])
         get(deployment.rels[:statuses].href, options)
       end
@@ -56,29 +51,9 @@ module Octokit
       # @return [Sawyer::Resource] A deployment status
       # @see https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
       def create_deployment_status(deployment_url, state, options = {})
-        options = ensure_deployments_api_media_type(options)
         deployment = get(deployment_url, :accept => options[:accept])
         options[:state] = state.to_s.downcase
         post(deployment.rels[:statuses].href, options)
-      end
-
-      private
-
-      def ensure_deployments_api_media_type(options = {})
-        if options[:accept].nil?
-          options[:accept] = DEPLOYMENTS_PREVIEW_MEDIA_TYPE
-          warn_deployments_preview
-        end
-
-        options
-      end
-
-      def warn_deployments_preview
-        octokit_warn <<-EOS
-WARNING: The preview version of the Deployments API is not yet suitable for production use.
-You can avoid this message by supplying an appropriate media type in the 'Accept' request
-header. See the blog post for details: http://git.io/o2XZRA
-EOS
       end
     end
   end


### PR DESCRIPTION
Now that the [Deployments API is final](https://developer.github.com/changes/2014-11-25-the-deployments-api-is-official/), we can remove these warnings.

/cc @atmos 
