### PR TITLE
Add Octokit::AbuseDetected for the new abuse detected 403

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -62,6 +62,8 @@ module Octokit
         Octokit::TooManyRequests
       elsif body =~ /login attempts exceeded/i
         Octokit::TooManyLoginAttempts
+      elsif body =~ /abuse/i
+        Octokit::AbuseDetected
       else
         Octokit::Forbidden
       end
@@ -186,6 +188,10 @@ module Octokit
   # Raised when GitHub returns a 403 HTTP status code
   # and body matches 'login attempts exceeded'
   class TooManyLoginAttempts < Forbidden; end
+
+  # Raised when GitHub returns a 403 HTTP status code
+  # and body matches 'abuse'
+  class AbuseDetected < Forbidden; end
 
   # Raised when GitHub returns a 404 HTTP status code
   class NotFound < ClientError; end

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -618,7 +618,7 @@ describe Octokit::Client do
       end
     end
 
-    it "knows the difference between Forbidden and rate limiting" do
+    it "knows the difference between different kinds of forbidden" do
       stub_get('/some/admin/stuffs').to_return(:status => 403)
       expect { Octokit.get('/some/admin/stuffs') }.to raise_error Octokit::Forbidden
 
@@ -637,6 +637,14 @@ describe Octokit::Client do
         },
         :body => {:message => "Maximum number of login attempts exceeded"}.to_json
       expect { Octokit.get('/user') }.to raise_error Octokit::TooManyLoginAttempts
+
+      stub_get('/user').to_return \
+        :status => 403,
+        :headers => {
+          :content_type => "application/json",
+        },
+        :body => {:message => "You have triggered an abuse detection mechanism and have been temporarily blocked from content creation. Please retry your request again later."}.to_json
+      expect { Octokit.get('/user') }.to raise_error Octokit::AbuseDetected
     end
 
     it "raises on unknown client errors" do


### PR DESCRIPTION
Adds a new subclass of `Octokit::Forbidden` for the new abuse 403's. See https://developer.github.com/v3/#abuse-rate-limits.
