### PR TITLE
Ensure Repository is valid when passed a string. Fixes #552

### DIFF
--- a/lib/octokit/repository.rb
+++ b/lib/octokit/repository.rb
@@ -18,6 +18,9 @@ module Octokit
         @id = repo
       when String
         @owner, @name = repo.split('/')
+        unless @owner && @name
+          raise ArgumentError, "Invalid Repository. Use user/repo format."
+        end
       when Repository
         @owner = repo.owner
         @name = repo.name

--- a/spec/octokit/repository_spec.rb
+++ b/spec/octokit/repository_spec.rb
@@ -27,6 +27,13 @@ describe Octokit::Repository do
     end
   end
 
+  context "when passed a string without a slash" do
+    it "raises ArgumentError" do
+      expect { Octokit::Repository.new('raise-error') }.
+        to raise_error ArgumentError, "Invalid Repository. Use user/repo format."
+    end
+  end
+
   describe ".path" do
     context "with named repository" do
       it "returns the url path" do


### PR DESCRIPTION
Raise an error when a Repository object is initialized with a string
that is not valid user/repo format.