### PR TITLE
Raise RepositoryUnavailable when repository is blocked

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -64,6 +64,8 @@ module Octokit
         Octokit::TooManyLoginAttempts
       elsif body =~ /abuse/i
         Octokit::AbuseDetected
+      elsif body =~ /repository access blocked/i
+        Octokit::RepositoryUnavailable
       else
         Octokit::Forbidden
       end
@@ -192,6 +194,10 @@ module Octokit
   # Raised when GitHub returns a 403 HTTP status code
   # and body matches 'abuse'
   class AbuseDetected < Forbidden; end
+
+  # Raised when GitHub returns a 403 HTTP status code
+  # and body matches 'repository access blocked'
+  class RepositoryUnavailable < Forbidden; end
 
   # Raised when GitHub returns a 404 HTTP status code
   class NotFound < ClientError; end

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -645,6 +645,14 @@ describe Octokit::Client do
         },
         :body => {:message => "You have triggered an abuse detection mechanism and have been temporarily blocked from content creation. Please retry your request again later."}.to_json
       expect { Octokit.get('/user') }.to raise_error Octokit::AbuseDetected
+
+      stub_get('/blocked/repository').to_return \
+        :status => 403,
+        :headers => {
+          :content_type => "application/json",
+        },
+        :body => {:message => "Repository access blocked"}.to_json
+      expect { Octokit.get("/blocked/repository") }.to raise_error Octokit::RepositoryUnavailable
     end
 
     it "raises on unknown client errors" do


### PR DESCRIPTION
Add a more explicit error when access to a repository is blocked.

See #563 for context.

Fixes #563