### PR TITLE
Adding require to spec to fix JRuby and Rubinius

### DIFF
--- a/spec/octokit/client/contents_spec.rb
+++ b/spec/octokit/client/contents_spec.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'tempfile'
 
 describe Octokit::Client::Contents do
 


### PR DESCRIPTION
The spec appears to fail currently in JRuby and Rubinius because of this missing require.