### PR TITLE
Fix guard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rake'
 
 group :development do
   gem 'awesome_print', :require => 'ap'
-  gem 'guard-rspec'
+  gem 'guard-rspec', '~> 4.5'
   gem 'hirb-unicode'
   gem 'pry'
   gem 'redcarpet'

--- a/Guardfile
+++ b/Guardfile
@@ -2,11 +2,4 @@ guard "rspec", :cmd => "bundle exec rspec" do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
   watch("spec/helper.rb")  { "spec" }
-
-  notification :tmux,
-    :display_message => true,
-    :timeout => 5, # in seconds
-    :default_message_format => '%s // %s',
-    :line_separator => ' > ', # since we are single line we need a separator
-    :color_location => 'status-left-fg' # to customize which tmux element will change color
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,7 +1,7 @@
-guard 'rspec' do
+guard "rspec", :cmd => "bundle exec rspec" do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
-  watch('spec/helper.rb')  { "spec" }
+  watch("spec/helper.rb")  { "spec" }
 
   notification :tmux,
     :display_message => true,


### PR DESCRIPTION
Guard notifier settings are per-user and should be placed in `~.guard.rb`.

Fixes #569.

/cc @jasonrudolph 