### PR TITLE
Fix for dropped headers on auto-pagination

### DIFF
--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -203,7 +203,7 @@ module Octokit
 
       if @auto_paginate
         while @last_response.rels[:next] && rate_limit.remaining > 0
-          @last_response = @last_response.rels[:next].get
+          @last_response = request(:get, @last_response.rels[:next], opts)
           if block_given?
             yield(data, @last_response)
           else

--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -203,7 +203,7 @@ module Octokit
 
       if @auto_paginate
         while @last_response.rels[:next] && rate_limit.remaining > 0
-          @last_response = request(:get, @last_response.rels[:next], opts)
+          @last_response = @last_response.rels[:next].get(headers: opts[:headers])
           if block_given?
             yield(data, @last_response)
           else


### PR DESCRIPTION
The code at line 206 is dropping custom headers (e.g. accept headers) after on auto-pagination requests after the first. Switching to use the request() method as in line 202 will fix the problem.