### PR TITLE
Fix error not paginate with comment_comments. Auto paginate not working.

### DIFF
--- a/lib/octokit/client/commit_comments.rb
+++ b/lib/octokit/client/commit_comments.rb
@@ -12,7 +12,7 @@ module Octokit
       # @return [Array] List of commit comments
       # @see https://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository
       def list_commit_comments(repo, options = {})
-        get "#{Repository.path repo}/comments", options
+        paginate "#{Repository.path repo}/comments", options
       end
 
       # List comments for a single commit
@@ -22,7 +22,7 @@ module Octokit
       # @return [Array]  List of commit comments
       # @see https://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit
       def commit_comments(repo, sha, options = {})
-        get "#{Repository.path repo}/commits/#{sha}/comments", options
+        paginate "#{Repository.path repo}/commits/#{sha}/comments", options
       end
 
       # Get a single commit comment
@@ -32,7 +32,7 @@ module Octokit
       # @return [Sawyer::Resource] Commit comment
       # @see https://developer.github.com/v3/repos/comments/#get-a-single-commit-comment
       def commit_comment(repo, id, options = {})
-        get "#{Repository.path repo}/comments/#{id}", options
+        paginate "#{Repository.path repo}/comments/#{id}", options
       end
 
       # Create a commit comment

--- a/lib/octokit/client/commit_comments.rb
+++ b/lib/octokit/client/commit_comments.rb
@@ -32,7 +32,7 @@ module Octokit
       # @return [Sawyer::Resource] Commit comment
       # @see https://developer.github.com/v3/repos/comments/#get-a-single-commit-comment
       def commit_comment(repo, id, options = {})
-        paginate "#{Repository.path repo}/comments/#{id}", options
+        get "#{Repository.path repo}/comments/#{id}", options
       end
 
       # Create a commit comment


### PR DESCRIPTION
I have problem when pull the commit_comments from github, the auto_paginate feature does not work. I checked in the commit_comments file and found out that, it used the method `get` instead of `paginate`.