### PR TITLE
let auto_paginate work with 2fa/otp

### DIFF
--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -199,11 +199,11 @@ module Octokit
         opts[:query][:per_page] ||=  @per_page || (@auto_paginate ? 100 : nil)
       end
 
-      data = request(:get, url, opts)
+      data = request(:get, url, opts.clone)
 
       if @auto_paginate
         while @last_response.rels[:next] && rate_limit.remaining > 0
-          @last_response = @last_response.rels[:next].get
+          @last_response = @last_response.rels[:next].get(opts)
           if block_given?
             yield(data, @last_response)
           else


### PR DESCRIPTION
I'm trying to automate some GitHub stuff at work. Here, I authenticate to GitHub's API with my password and TOTP, and then try to list org repos:

```
Octokit.auto_paginate = true

puts 'enter password'
client = Octokit::Client.new({
    :login    => 'edmund-huber',
    :password => STDIN.noecho(&:gets).chomp
})

puts 'enter TOTP token'
totp = gets.chomp

repos = client.organization_repositories('organization', {
    :headers => { 'X-GitHub-OTP' => totp },
    :type => 'private'
})
```

Because we have a shit ton of repos, I'm using `Octokit.auto_paginate = true` to save myself the trouble of paging through all the things I need. However, it did not work -- the first GET went fine, but the following ones (through auto_paginate) did not, because they did not send along the `X-GitHub-OTP` HTTP header and GitHub denied the request.

I hoped that the fix would be as simple as changing L206 a bit, but then I discovered that the `request` method destructively alters its passed parameters: https://github.com/octokit/octokit.rb/blob/master/lib/octokit/client.rb#L335 . So, on L206, the `opts` that I added was `{}`. So I added the `.clone` call on L202.

These changes fix my problem: 2fa and auto_paginate work together.

I am feeling too lazy to add a test, but the existing tests remain green:

```
$ ./script/test 
===> Bundling...
Please export OCTOKIT_TEST_GITHUB_LOGIN
Please export OCTOKIT_TEST_GITHUB_PASSWORD
Please export OCTOKIT_TEST_GITHUB_TOKEN
Please export OCTOKIT_TEST_GITHUB_CLIENT_ID
Please export OCTOKIT_TEST_GITHUB_CLIENT_SECRET
===> Running specs...
/usr/bin/ruby2.2 -I/home/edmund/fastly2/var/gems/gems/rspec-core-3.0.4/lib:/home/edmund/fastly2/var/gems/gems/rspec-support-3.0.4/lib -S /home/edmund/fastly2/var/gems/gems/rspec-core-3.0.4/exe/rspec ./spec/octokit/client/authorizations_spec.rb ./spec/octokit/client/commit_comments_spec.rb ./spec/octokit/client/commits_spec.rb ./spec/octokit/client/contents_spec.rb ./spec/octokit/client/deployments_spec.rb ./spec/octokit/client/downloads_spec.rb ./spec/octokit/client/emojis_spec.rb ./spec/octokit/client/events_spec.rb ./spec/octokit/client/feeds_spec.rb ./spec/octokit/client/gists_spec.rb ./spec/octokit/client/gitignore_spec.rb ./spec/octokit/client/hooks_spec.rb ./spec/octokit/client/issues_spec.rb ./spec/octokit/client/labels_spec.rb ./spec/octokit/client/legacy_search_spec.rb ./spec/octokit/client/licenses_spec.rb ./spec/octokit/client/markdown_spec.rb ./spec/octokit/client/meta_spec.rb ./spec/octokit/client/milestones_spec.rb ./spec/octokit/client/notifications_spec.rb ./spec/octokit/client/objects_spec.rb ./spec/octokit/client/organizations_spec.rb ./spec/octokit/client/pages_spec.rb ./spec/octokit/client/pub_sub_hubbub_spec.rb ./spec/octokit/client/pull_requests_spec.rb ./spec/octokit/client/rate_limit_spec.rb ./spec/octokit/client/refs_spec.rb ./spec/octokit/client/releases_spec.rb ./spec/octokit/client/repositories_spec.rb ./spec/octokit/client/say_spec.rb ./spec/octokit/client/search_spec.rb ./spec/octokit/client/service_status_spec.rb ./spec/octokit/client/stats_spec.rb ./spec/octokit/client/statuses_spec.rb ./spec/octokit/client/users_spec.rb ./spec/octokit/client_spec.rb ./spec/octokit/gist_spec.rb ./spec/octokit/organization_spec.rb ./spec/octokit/rate_limit_spec.rb ./spec/octokit/repository_spec.rb ./spec/octokit/user_spec.rb ./spec/octokit_spec.rb
..............................................................................................................................................................................................................................................................................................................................................................................................................DEPRECATED: Client#pull_requests: Passing state as positional argument is deprecated. Please use :state => 'closed'
...............................................................................

Finished in 12.24 seconds (files took 0.84536 seconds to load)
477 examples, 0 failures

Randomized with seed 42760

Coverage report generated for RSpec to /home/edmund/octokit.rb/coverage. 4097 / 4122 LOC (99.39%) covered.
[Coveralls] Outside the CI environment, not sending data.
```