### PR TITLE
#edit_hook should not have defaults

### DIFF
--- a/lib/octokit/client/hooks.rb
+++ b/lib/octokit/client/hooks.rb
@@ -116,7 +116,7 @@ module Octokit
       #     }
       #   )
       def edit_hook(repo, id, name, config, options = {})
-        options = {:name => name, :config => config, :events => ["push"], :active => true}.merge(options)
+        options = {:name => name, :config => config}.merge(options)
         patch "#{Repository.path repo}/hooks/#{id}", options
       end
 


### PR DESCRIPTION
Because of theses defaults `edit_hook` is basically unusable. Imagine you want to add an event type:

```
client.edit_hook('my/repo', 'web', {}, add_events: ['status'])
```

This will actually mutate your hook to offer only the `push` event.

@pengwynn for review please.