### PR TITLE
Paginate fetch organizations

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -76,7 +76,7 @@ module Octokit
       # @example
       #   @client.organizations
       def organizations(user=nil, options = {})
-        get "#{User.path user}/orgs", options
+        paginate "#{User.path user}/orgs", options
       end
       alias :list_organizations :organizations
       alias :list_orgs :organizations


### PR DESCRIPTION
Found that organizations won't show up if there are organizations more
than 30. This will allow use of `auto_paginate` and fetch all
organizations.