### PR TITLE
Incorporate connection changes that were made

### DIFF
--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -81,11 +81,11 @@ module Octokit
         opts[:query][:per_page] ||=  @per_page || (@auto_paginate ? 100 : nil)
       end
 
-      data = request(:get, url, opts)
+      data = request(:get, url, opts.dup)
 
       if @auto_paginate
         while @last_response.rels[:next] && rate_limit.remaining > 0
-          @last_response = @last_response.rels[:next].get
+          @last_response = @last_response.rels[:next].get(:headers => opts[:headers])
           if block_given?
             yield(data, @last_response)
           else

--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -179,7 +179,7 @@ module Octokit
     end
 
     def parse_query_and_convenience_headers(options)
-      headers = options.fetch(:headers, {})
+      headers = options.delete(:headers) { Hash.new }
       CONVENIENCE_HEADERS.each do |h|
         if header = options.delete(h)
           headers[h] = header


### PR DESCRIPTION
@fotinakis rightly noticed that [some changes made to *client.rb*](https://github.com/octokit/octokit.rb/pull/582#issuecomment-110148506) were lost to the sands of time. This comes from 82ea118ec525b30a3d768c0cd2d04b4c9824dd62, which saw a bunch of shareable client connection methods moved out into their own module.

I went through the Git history and found two PRs that needed to be brought back in:

* https://github.com/octokit/octokit.rb/pull/583
* https://github.com/octokit/octokit.rb/pull/593

For an extra sanity check, it would be great if someone could verify that these are indeed the only client changes.

/cc @pengwynn for :eyes: 