### PR TITLE
Implement /orgs/:org/memberships/:user methods

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -541,7 +541,11 @@ module Octokit
       # @return [Sawyer::Resource] Hash representing the organization membership.
       # @see https://developer.github.com/v3/orgs/members/#get-your-organization-membership
       def organization_membership(org, options = {})
-        get "user/memberships/orgs/#{org}", options
+        if user = options.delete(:user)
+          get "orgs/#{org}/memberships/#{user}", options
+        else
+          get "user/memberships/orgs/#{org}", options
+        end
       end
       alias :org_membership :organization_membership
 
@@ -552,9 +556,23 @@ module Octokit
       # @return [Sawyer::Resource] Hash representing the updated organization membership.
       # @see https://developer.github.com/v3/orgs/members/#edit-your-organization-membership
       def update_organization_membership(org, options = {})
-        patch "user/memberships/orgs/#{org}", options
+        if user = options.delete(:user)
+          put "orgs/#{org}/memberships/#{user}", options
+        else
+          patch "user/memberships/orgs/#{org}", options
+        end
       end
       alias :update_org_membership :update_organization_membership
+
+      # Remove an organization membership
+      #
+      # @param org [String] Organization GitHub login.
+      # @return [Boolean] Success
+      # @see https://developer.github.com/v3/orgs/members/#remove-organization-membership
+      def remove_organization_membership(org, options = {})
+        user = options.delete(:user)
+        user && boolean_from_response(:delete, "orgs/#{org}/memberships/#{user}", options)
+      end
     end
   end
 end

--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -535,11 +535,13 @@ module Octokit
       end
       alias :org_memberships :organization_memberships
 
-      # Get an organization membership for the authenticated user
+      # Get an organization membership
       #
       # @param org [String] Organization GitHub login.
+      # @option options [String] :user  The login of the user, otherwise authenticated user.
       # @return [Sawyer::Resource] Hash representing the organization membership.
       # @see https://developer.github.com/v3/orgs/members/#get-your-organization-membership
+      # @see https://developer.github.com/v3/orgs/members/#get-organization-membership
       def organization_membership(org, options = {})
         if user = options.delete(:user)
           get "orgs/#{org}/memberships/#{user}", options
@@ -549,12 +551,15 @@ module Octokit
       end
       alias :org_membership :organization_membership
 
-      # Edit an organization membership for the authenticated user
+      # Edit an organization membership
       #
       # @param org [String] Organization GitHub login.
+      # @option options [String] :role  The role of the user in the organization.
       # @option options [String] :state The state that the membership should be in.
+      # @option options [String] :user  The login of the user, otherwise authenticated user.
       # @return [Sawyer::Resource] Hash representing the updated organization membership.
       # @see https://developer.github.com/v3/orgs/members/#edit-your-organization-membership
+      # @see https://developer.github.com/v3/orgs/members/#add-or-update-organization-membership
       def update_organization_membership(org, options = {})
         if user = options.delete(:user)
           put "orgs/#{org}/memberships/#{user}", options

--- a/spec/octokit/client/organizations_spec.rb
+++ b/spec/octokit/client/organizations_spec.rb
@@ -223,7 +223,7 @@ describe Octokit::Client::Organizations do
 
   describe ".add_team_membership", :vcr do
     it "invites a user to a team" do
-      membership = @client.add_team_membership(946194, test_github_login) 
+      membership = @client.add_team_membership(946194, test_github_login)
       assert_requested :put, github_url("teams/946194/memberships/#{test_github_login}")
       expect(membership.status).to eq("active")
     end
@@ -245,11 +245,33 @@ describe Octokit::Client::Organizations do
     end
   end # .organization_memberships
 
+  describe ".remove_organization_membership", :vcr do
+    it "removes an organization membership for a given user" do
+      stub_delete github_url("orgs/#{test_github_org}/memberships/#{test_github_login}")
+      @client.remove_organization_membership(
+        test_github_org,
+        :user => test_github_login,
+        :accept => "application/vnd.github.moondragon+json"
+      )
+      assert_requested :delete, github_url("/orgs/#{test_github_org}/memberships/#{test_github_login}")
+    end
+  end
+
   describe ".organization_membership", :vcr do
     it "returns an organization membership" do
       stub_get github_url("/user/memberships/orgs/#{test_github_org}")
       membership = @client.organization_membership(test_github_org)
       assert_requested :get, github_url("/user/memberships/orgs/#{test_github_org}")
+    end
+
+    it "returns an organization membership for a given user" do
+      stub_get github_url("orgs/#{test_github_org}/memberships/#{test_github_login}")
+      @client.organization_membership(
+        test_github_org,
+        :user => test_github_login,
+        :accept => "application/vnd.github.moondragon+json"
+      )
+      assert_requested :get, github_url("/orgs/#{test_github_org}/memberships/#{test_github_login}")
     end
   end # .organization_membership
 
@@ -258,6 +280,17 @@ describe Octokit::Client::Organizations do
       stub_patch github_url("/user/memberships/orgs/#{test_github_org}")
       membership = @client.update_organization_membership(test_github_org, {:state => 'active'})
       assert_requested :patch, github_url("/user/memberships/orgs/#{test_github_org}")
+    end
+
+    it "adds or updates an organization membership for a given user" do
+      stub_put github_url("/orgs/#{test_github_org}/memberships/#{test_github_login}")
+      @client.update_organization_membership(
+        test_github_org,
+        :user => test_github_login,
+        :role => "admin",
+        :accept => "application/vnd.github.moondragon+json"
+      )
+      assert_requested :put, github_url("/orgs/#{test_github_org}/memberships/#{test_github_login}")
     end
   end # .update_organization_membership
 end


### PR DESCRIPTION
Adds Octokit support for a few methods that were overlooked in the [flurry of new Membership APIs][apis] last year.

/fyi @jakeboxer

[apis]: https://developer.github.com/changes/2014-09-16-finalizing-the-organization-and-team-membership-apis/