### PR TITLE
Use Organization path when creating repositories for an org.

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -155,7 +155,7 @@ module Octokit
         if organization.nil?
           post 'user/repos', options
         else
-          post "orgs/#{organization}/repos", options
+          post "#{Organization.path organization}/repos", options
         end
       end
       alias :create_repo :create_repository


### PR DESCRIPTION
Tracked this down with @kdaigle, this changes the path from `/orgs` to using  `Organization.path` so that a user can use the organization id to create a new repo if they so choose.