### PR TITLE
Allow creating repo under org using organization ID instead of owner/name

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -155,7 +155,7 @@ module Octokit
         if organization.nil?
           post 'user/repos', options
         else
-          post "orgs/#{organization}/repos", options
+          post "#{Organization.path organization}/repos", options
         end
       end
       alias :create_repo :create_repository

--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -46,6 +46,12 @@ describe Octokit::Client::Repositories do
       rescue Octokit::NotFound
       end
     end
+
+    it "creates a repository for an organization by ID" do
+      request = stub_post(github_url("/organizations/1/repos"))
+      repository = @client.create_repository("an-org-repo", :organization => 1)
+      assert_requested request
+    end
   end
 
   describe ".add_deploy_key" do


### PR DESCRIPTION
Builds on #619, adding a failing test to be sure future :penguin: doesn't break this. 

/cc @tarebyte @kdaigle.

Closes #619.