### PR TITLE
Update documentation to reflect the {state: "all"} option

### DIFF
--- a/lib/octokit/client/issues.rb
+++ b/lib/octokit/client/issues.rb
@@ -11,7 +11,7 @@ module Octokit
       # @param repository [Integer, String, Repository, Hash] A GitHub repository.
       # @param options [Sawyer::Resource] A customizable set of options.
       # @option options [Integer] :milestone Milestone number.
-      # @option options [String] :state (open) State: <tt>open</tt> or <tt>closed</tt>.
+      # @option options [String] :state (open) State: <tt>open</tt>, <tt>closed</tt>, or <tt>all</tt>.
       # @option options [String] :assignee User login.
       # @option options [String] :creator User login.
       # @option options [String] :mentioned User login.
@@ -37,7 +37,7 @@ module Octokit
       #
       # @param options [Sawyer::Resource] A customizable set of options.
       # @option options [String] :filter (assigned) State: <tt>assigned</tt>, <tt>created</tt>, <tt>mentioned</tt>, <tt>subscribed</tt> or <tt>closed</tt>.
-      # @option options [String] :state (open) State: <tt>open</tt> or <tt>closed</tt>.
+      # @option options [String] :state (open) State: <tt>open</tt>, <tt>closed</tt>, or <tt>all</tt>.
       # @option options [String] :labels List of comma separated Label names. Example: <tt>bug,ui,@high</tt>.
       # @option options [String] :sort (created) Sort: <tt>created</tt>, <tt>updated</tt>, or <tt>comments</tt>.
       # @option options [String] :direction (desc) Direction: <tt>asc</tt> or <tt>desc</tt>.
@@ -58,7 +58,7 @@ module Octokit
       # @param org [String, Integer] Organization GitHub login or id.
       # @param options [Sawyer::Resource] A customizable set of options.
       # @option options [String] :filter (assigned) State: <tt>assigned</tt>, <tt>created</tt>, <tt>mentioned</tt>, <tt>subscribed</tt> or <tt>closed</tt>.
-      # @option options [String] :state (open) State: <tt>open</tt> or <tt>closed</tt>.
+      # @option options [String] :state (open) State: <tt>open</tt>, <tt>closed</tt>, or <tt>all</tt>.
       # @option options [String] :labels List of comma separated Label names. Example: <tt>bug,ui,@high</tt>.
       # @option options [String] :sort (created) Sort: <tt>created</tt>, <tt>updated</tt>, or <tt>comments</tt>.
       # @option options [String] :direction (desc) Direction: <tt>asc</tt> or <tt>desc</tt>.

--- a/lib/octokit/client/milestones.rb
+++ b/lib/octokit/client/milestones.rb
@@ -11,7 +11,7 @@ module Octokit
       # @param repository [String, Repository, Hash] A GitHub repository.
       # @param options [Hash] A customizable set of options.
       # @option options [Integer] :milestone Milestone number.
-      # @option options [String] :state (open) State: <tt>open</tt> or <tt>closed</tt>.
+      # @option options [String] :state (open) State: <tt>open</tt>, <tt>closed</tt>, or <tt>all</tt>.
       # @option options [String] :sort (created) Sort: <tt>created</tt>, <tt>updated</tt>, or <tt>comments</tt>.
       # @option options [String] :direction (desc) Direction: <tt>asc</tt> or <tt>desc</tt>.
       # @return [Array<Sawyer::Resource>] A list of milestones for a repository.
@@ -28,7 +28,7 @@ module Octokit
       # @param repository [String, Repository, Hash] A GitHub repository.
       # @param options [Hash] A customizable set of options.
       # @option options [Integer] :milestone Milestone number.
-      # @option options [String] :state (open) State: <tt>open</tt> or <tt>closed</tt>.
+      # @option options [String] :state (open) State: <tt>open</tt>, <tt>closed</tt>, or <tt>all</tt>.
       # @option options [String] :sort (created) Sort: <tt>created</tt>, <tt>updated</tt>, or <tt>comments</tt>.
       # @option options [String] :direction (desc) Direction: <tt>asc</tt> or <tt>desc</tt>.
       # @return [Sawyer::Resource] A single milestone from a repository.
@@ -44,7 +44,7 @@ module Octokit
       # @param repository [String, Repository, Hash] A GitHub repository.
       # @param title [String] A unique title.
       # @param options [Hash] A customizable set of options.
-      # @option options [String] :state (open) State: <tt>open</tt> or <tt>closed</tt>.
+      # @option options [String] :state (open) State: <tt>open</tt>, <tt>closed</tt>, or <tt>all</tt>.
       # @option options [String] :description A meaningful description
       # @option options [Time] :due_on Set if the milestone has a due date
       # @return [Sawyer::Resource] A single milestone object
@@ -61,7 +61,7 @@ module Octokit
       # @param number [String, Integer] ID of the milestone
       # @param options [Hash] A customizable set of options.
       # @option options [String] :title A unique title.
-      # @option options [String] :state (open) State: <tt>open</tt> or <tt>closed</tt>.
+      # @option options [String] :state (open) State: <tt>open</tt>, <tt>closed</tt>, or <tt>all</tt>.
       # @option options [String] :description A meaningful description
       # @option options [Time] :due_on Set if the milestone has a due date
       # @return [Sawyer::Resource] A single milestone object

--- a/lib/octokit/client/milestones.rb
+++ b/lib/octokit/client/milestones.rb
@@ -28,9 +28,6 @@ module Octokit
       # @param repository [String, Repository, Hash] A GitHub repository.
       # @param options [Hash] A customizable set of options.
       # @option options [Integer] :milestone Milestone number.
-      # @option options [String] :state (open) State: <tt>open</tt>, <tt>closed</tt>, or <tt>all</tt>.
-      # @option options [String] :sort (created) Sort: <tt>created</tt>, <tt>updated</tt>, or <tt>comments</tt>.
-      # @option options [String] :direction (desc) Direction: <tt>asc</tt> or <tt>desc</tt>.
       # @return [Sawyer::Resource] A single milestone from a repository.
       # @see https://developer.github.com/v3/issues/milestones/#get-a-single-milestone
       # @example Get a single milestone for a repository
@@ -44,7 +41,7 @@ module Octokit
       # @param repository [String, Repository, Hash] A GitHub repository.
       # @param title [String] A unique title.
       # @param options [Hash] A customizable set of options.
-      # @option options [String] :state (open) State: <tt>open</tt>, <tt>closed</tt>, or <tt>all</tt>.
+      # @option options [String] :state (open) State: <tt>open</tt> or <tt>closed</tt>.
       # @option options [String] :description A meaningful description
       # @option options [Time] :due_on Set if the milestone has a due date
       # @return [Sawyer::Resource] A single milestone object
@@ -61,7 +58,7 @@ module Octokit
       # @param number [String, Integer] ID of the milestone
       # @param options [Hash] A customizable set of options.
       # @option options [String] :title A unique title.
-      # @option options [String] :state (open) State: <tt>open</tt>, <tt>closed</tt>, or <tt>all</tt>.
+      # @option options [String] :state (open) State: <tt>open</tt> or <tt>closed</tt>.
       # @option options [String] :description A meaningful description
       # @option options [Time] :due_on Set if the milestone has a due date
       # @return [Sawyer::Resource] A single milestone object


### PR DESCRIPTION
This applies to both issues and milestones where the default state is "open".
Although undocumented, the "all" option is confirmed to work.

See the API docs:
  * https://developer.github.com/v3/issues/#parameters-1
  * https://developer.github.com/v3/issues/milestones/#parameters