### PR TITLE
Add validation of repository format

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -13,6 +13,8 @@ module Octokit
       # @return [Sawyer::Resource] if a repository exists, false otherwise
       def repository?(repo, options = {})
         !!repository(repo, options)
+      rescue Octokit::InvalidRepository
+        false
       rescue Octokit::NotFound
         false
       end

--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -238,4 +238,8 @@ module Octokit
   # Raised when a method requires an application client_id
   # and secret but none is provided
   class ApplicationCredentialsRequired < StandardError; end
+
+  # Raised when a repository is created with an invalid format
+  class InvalidRepository < ArgumentError; end
+
 end

--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -368,5 +368,13 @@ describe Octokit::Client::Repositories do
       expect(result).to be false
       assert_requested :get, github_url("/repos/pengwynn/octokit")
     end
+    it "returns false if the repository has an invalid format" do
+      result = @client.repository?("invalid format")
+      expect(result).to be false
+    end
+    it "returns false if the repository has more than one slash" do
+      result = @client.repository?("more_than/one/slash")
+      expect(result).to be false
+    end
   end # .repository?
 end

--- a/spec/octokit/repository_spec.rb
+++ b/spec/octokit/repository_spec.rb
@@ -30,28 +30,42 @@ describe Octokit::Repository do
   context "when passed a string without a slash" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new('raise-error') }.
-        to raise_error ArgumentError, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+    end
+  end
+
+  context "when passed a string with more than 1 slash" do
+    it "raises ArgumentError" do
+      expect { Octokit::Repository.new('more_than/one/slash') }.
+        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+    end
+  end
+
+  context "when passed an invalid path" do
+    it "raises ArgumentError" do
+      expect { Octokit::Repository.new('invalid / path') }.
+        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
     end
   end
 
   context "when passed a boolean true" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new(true) }.
-        to raise_error ArgumentError, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
     end
   end
 
   context "when passed a boolean false" do
     it "false raises ArgumentError" do
       expect { Octokit::Repository.new(false) }.
-        to raise_error ArgumentError, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
     end
   end
 
   context "when passed nil" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new(nil) }.
-        to raise_error ArgumentError, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
     end
   end
 
@@ -90,6 +104,34 @@ describe Octokit::Repository do
       repository = Octokit::Repository.new({:username => 'sferik', :name => 'octokit'})
       expect(repository.name).to eq("octokit")
       expect(repository.username).to eq("sferik")
+    end
+  end
+
+  context "when passed a hash with invalid username" do
+    it "raises ArgumentError" do
+      expect { Octokit::Repository.new({:username => 'invalid username!', :name => 'octokit'}) }.
+        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+    end
+  end
+
+  context "when passed a hash with a username that contains a slash" do
+    it "raises ArgumentError" do
+      expect { Octokit::Repository.new({:username => 'invalid/username', :name => 'octokit'}) }.
+        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+    end
+  end
+
+  context "when passed a hash with invalid repo" do
+    it "raises ArgumentError" do
+      expect { Octokit::Repository.new({:username => 'sferik', :name => 'invalid repo!'}) }.
+        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+    end
+  end
+
+  context "when passed a hash with a repo that contains a slash" do
+    it "raises ArgumentError" do
+      expect { Octokit::Repository.new({:username => 'sferik', :name => 'invalid/repo'}) }.
+        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
     end
   end
 


### PR DESCRIPTION
Hi,

I was using `Octokit.repository?` to check if a string was a valid github repository and I realised that it was returning `true` for repositories like `paths_with/more/than/one/slash`. I thought it could be a good idea to add a validation to the format of the repository and username.

This pull request:
- Validates repository format against `URI.regexp`
- Add `Octokit::InvalidRepository` error