### PR TITLE
Simplify repo pattern

### DIFF
--- a/lib/octokit/repository.rb
+++ b/lib/octokit/repository.rb
@@ -4,7 +4,7 @@ module Octokit
   # URLs and to generate URLs
   class Repository
     attr_accessor :owner, :name, :id
-    NAME_WITH_OWNER_PATTERN = /\A(?<owner>[\.\w-]+)\/(?<name>[\.\w-]+)\z/i
+    NAME_WITH_OWNER_PATTERN = /\A[\w.-]+\/[\w.-]+\z/i
 
     # Instantiate from a GitHub repository URL
     #


### PR DESCRIPTION
Removes the unused named captures from the repository name-with-owner regex.