### PR TITLE
Add specific error when user has unverified email (for 403s)

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -66,6 +66,8 @@ module Octokit
         Octokit::AbuseDetected
       elsif body =~ /repository access blocked/i
         Octokit::RepositoryUnavailable
+      elsif body =~ /email address must be verified/i
+        Octokit::UnverifiedEmail
       else
         Octokit::Forbidden
       end
@@ -198,6 +200,10 @@ module Octokit
   # Raised when GitHub returns a 403 HTTP status code
   # and body matches 'repository access blocked'
   class RepositoryUnavailable < Forbidden; end
+
+  # Raised when GitHub returns a 403 HTTP status code
+  # and body matches 'email address must be verified'
+  class UnverifiedEmail < Forbidden; end
 
   # Raised when GitHub returns a 404 HTTP status code
   class NotFound < ClientError; end

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -789,6 +789,14 @@ describe Octokit::Client do
         },
         :body => {:message => "Repository access blocked"}.to_json
       expect { Octokit.get("/blocked/repository") }.to raise_error Octokit::RepositoryUnavailable
+
+      stub_post('/user/repos').to_return \
+        :status => 403,
+        :headers => {
+          :content_type => "application/json",
+        },
+        :body => {:message => "At least one email address must be verified to do that"}.to_json
+      expect { Octokit.post("/user/repos") }.to raise_error Octokit::UnverifiedEmail
     end
 
     it "raises on unknown client errors" do


### PR DESCRIPTION
A user with an unverified email address gets a 403 error when trying
to create a repository through the API. This can easily happen with a
brand new user account.

Some of the 403 errors (abuse, rate limits, etc) already have their
own error subclass to make it easier to work with -- this PR simply
adds a specific Octokit::UnverifiedEmail instead of relying on the
more generic Octokit::Forbidden error.