### PR TITLE
Ensure the correct preview warning message is issued

### DIFF
--- a/lib/octokit/preview.rb
+++ b/lib/octokit/preview.rb
@@ -11,7 +11,7 @@ module Octokit
     def ensure_api_media_type(type, options)
       if options[:accept].nil?
         options[:accept] = PREVIEW_TYPES[type]
-        warn_preview(:migrations)
+        warn_preview(type)
       end
       options
     end


### PR DESCRIPTION
@pengwynn, @spraints, @jonmagic, _et al._ - this PR fixes the problem I documented in #627, namely that the message issued by the `Octokit::Preview.warn_preview` method is always warning about the "Migrations API", irrespective of the preview type passed into the `Octokit::Preview.ensure_api_media_type` method... small change, big difference! :smile:  thanks!

---

**before:**

```ruby
[1] pry(main)> Octokit::Preview.send(:module_function, :warn_preview)
=> Octokit::Preview
[2] pry(main)> Octokit::Preview.send(:module_function, :ensure_api_media_type)
=> Octokit::Preview
[3] pry(main)> Octokit::Preview.ensure_api_media_type(:migrations, {})
WARNING: The preview version of the Migrations API is not yet suitable for production use.
You can avoid this message by supplying an appropriate media type in the 'Accept' request
header.
=> {:accept=>"application/vnd.github.wyandotte-preview+json"}
[4] pry(main)> Octokit::Preview.ensure_api_media_type(:licenses, {})
WARNING: The preview version of the Migrations API is not yet suitable for production use.
You can avoid this message by supplying an appropriate media type in the 'Accept' request
header.
=> {:accept=>"application/vnd.github.drax-preview+json"}
[5] pry(main)> _
```

**after:**

```ruby
[1] pry(main)> Octokit::Preview.send(:module_function, :warn_preview)
=> Octokit::Preview
[2] pry(main)> Octokit::Preview.send(:module_function, :ensure_api_media_type)
=> Octokit::Preview
[3] pry(main)> Octokit::Preview.ensure_api_media_type(:migrations, {})
WARNING: The preview version of the Migrations API is not yet suitable for production use.
You can avoid this message by supplying an appropriate media type in the 'Accept' request
header.
=> {:accept=>"application/vnd.github.wyandotte-preview+json"}
[4] pry(main)> Octokit::Preview.ensure_api_media_type(:licenses, {})
WARNING: The preview version of the Licenses API is not yet suitable for production use.
You can avoid this message by supplying an appropriate media type in the 'Accept' request
header.
=> {:accept=>"application/vnd.github.drax-preview+json"}
[5] pry(main)> _
```
