### PR TITLE
Support the "branch protection" preview API (`loki`)

### DIFF
--- a/lib/octokit/preview.rb
+++ b/lib/octokit/preview.rb
@@ -4,8 +4,9 @@ module Octokit
   module Preview
 
     PREVIEW_TYPES = {
-      :migrations    => 'application/vnd.github.wyandotte-preview+json'.freeze,
-      :licenses      => 'application/vnd.github.drax-preview+json'.freeze
+      :branch_protection => 'application/vnd.github.loki-preview+json'.freeze,
+      :migrations        => 'application/vnd.github.wyandotte-preview+json'.freeze,
+      :licenses          => 'application/vnd.github.drax-preview+json'.freeze
     }
 
     def ensure_api_media_type(type, options)


### PR DESCRIPTION
@pengwynn, @spraints, @jonmagic, _et al._ - this PR adds support for the "branch protection" preview API - code-named `loki-preview` - which was announced yesterday:

https://developer.github.com/changes/2015-11-11-protected-branches-api/

Use of `loki-preview` is left optional and up to the user, but - if used - retrieves the `protection` data of a branch, as illustrated by this example:

```shell
[1] pry(main)> ENV['OCTOKIT_ACCESS_TOKEN'].empty?
=> false
[2] pry(main)> pry Octokit::Client.new
[1] pry(#<Octokit::Client>)> ensure_api_media_type(:branch_protection, {})
WARNING: The preview version of the Migrations API is not yet suitable for production use.
You can avoid this message by supplying an appropriate media type in the 'Accept' request
header.
=> {:accept=>"application/vnd.github.loki-preview+json"}
[2] pry(#<Octokit::Client>)> # WITHOUT the "branch protection" preview
[3] pry(#<Octokit::Client>)> get_branch('octokit/octokit.rb', 'master')[:protection]
=> nil
[4] pry(#<Octokit::Client>)> # WITH the "branch protection" preview
[5] pry(#<Octokit::Client>)> get_branch('octokit/octokit.rb', 'master', ensure_api_media_type(:branch_protection, {}))[:protection]
WARNING: The preview version of the Migrations API is not yet suitable for production use.
You can avoid this message by supplying an appropriate media type in the 'Accept' request
header.
=> {:enabled=>false, :required_status_checks=>{:enforcement_level=>"off", :contexts=>[]}}
[6] pry(#<Octokit::Client>)> _
```

---

Note that the warning messages in the above example are wrong due the a bug introduced in #627, but will be correct once #661 gets merged in.