### PR TITLE
Typo

### DIFF
--- a/Octokit/Client/Notifications.html
+++ b/Octokit/Client/Notifications.html
@@ -772,7 +772,7 @@ ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Ex. &#39;2012-10-09T23:39:01Z&#39;</p>
     <p class="tag_title">Examples:</p>
     
       
-      <pre class="example code"><code><span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_mark_thread_as_ready'>mark_thread_as_ready</span><span class='lparen'>(</span><span class='int'>1</span><span class='comma'>,</span> <span class='symbol'>:read</span> <span class='op'>=&gt;</span> <span class='kw'>false</span><span class='rparen'>)</span></code></pre>
+      <pre class="example code"><code><span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_mark_thread_as_read'>mark_thread_as_read</span><span class='lparen'>(</span><span class='int'>1</span><span class='comma'>,</span> <span class='symbol'>:read</span> <span class='op'>=&gt;</span> <span class='kw'>false</span><span class='rparen'>)</span></code></pre>
     
   </div>
 <p class="tag_title">Parameters:</p>


### PR DESCRIPTION
Not sure how http://octokit.github.io/octokit.rb/Octokit/Client/Notifications.html#mark_thread_as_read-instance_method works but there's a typo