### PR TITLE
Fix org creation to include login and admin.

### DIFF
--- a/lib/octokit/enterprise_admin_client/orgs.rb
+++ b/lib/octokit/enterprise_admin_client/orgs.rb
@@ -17,6 +17,8 @@ module Octokit
       # @example
       #   @admin_client.create_organization('SuchAGreatOrg', 'gjtorikian')
       def create_organization(login, admin, options = {})
+        options[:login] = login
+        options[:admin] = admin
         post "admin/organizations", options
       end
 


### PR DESCRIPTION
Login and Admin need to be added to the post options to properly create an org.