### PR TITLE
Set `management_console_*` ivars as only writeable

### DIFF
--- a/lib/octokit/configurable.rb
+++ b/lib/octokit/configurable.rb
@@ -49,10 +49,10 @@ module Octokit
 
     attr_accessor :access_token, :auto_paginate, :client_id,
                   :client_secret, :default_media_type, :connection_options,
-                  :management_console_endpoint, :management_console_password,
                   :middleware, :netrc, :netrc_file,
                   :per_page, :proxy, :user_agent
-    attr_writer :password, :web_endpoint, :api_endpoint, :login
+    attr_writer :password, :web_endpoint, :api_endpoint, :login,
+                :management_console_endpoint, :management_console_password
 
     class << self
 


### PR DESCRIPTION
This should close https://github.com/octokit/octokit.rb/issues/671.

/cc @pvdb It'd be great if you could grab this branch and confirm there's no warning, if possible.
/c @pengwynn 