### PR TITLE
Update README.md to describe proper caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ Next, construct your own Faraday middleware:
 
 ```ruby
 stack = Faraday::RackBuilder.new do |builder|
-  builder.use Faraday::HttpCache
+  builder.use Faraday::HttpCache, serializer: Marshal, shared_cache: false
   builder.use Octokit::Response::RaiseError
   builder.adapter Faraday.default_adapter
 end


### PR DESCRIPTION
`shared_cache: false` is needed to cache responses with the `Cache-Control: private` header.

Without `serializer: Marshal`, `Faraday::HttpCache` would warn as:

> Response could not be serialized: "\\xE3" from ASCII-8BIT to UTF-8. Try using Marshal to serialize