### PR TITLE
Deprecate "revoke all application authorizations" from Octokit

### DIFF
--- a/lib/octokit/client/authorizations.rb
+++ b/lib/octokit/client/authorizations.rb
@@ -203,30 +203,6 @@ module Octokit
       end
       alias :delete_application_authorization :revoke_application_authorization
 
-      # Revoke all tokens for an app
-      #
-      # Applications can revoke all of their tokens in a single request
-      #
-      # @return [Boolean] Result
-      # @see https://developer.github.com/v3/oauth_authorizations/#revoke-all-authorizations-for-an-application
-      # @example
-      #  client = Octokit::Client.new(:client_id => 'abcdefg12345', :client_secret => 'secret')
-      #  client.revoke_all_application_authorizations
-      def revoke_all_application_authorizations(options = {})
-        opts = options.dup
-        key    = opts.delete(:client_id)     || client_id
-        secret = opts.delete(:client_secret) || client_secret
-
-        as_app(key, secret) do |app_client|
-          app_client.delete "/applications/#{client_id}/tokens", opts
-
-          app_client.last_response.status == 204
-        end
-      rescue Octokit::NotFound
-        false
-      end
-      alias :delete_application_authorization :revoke_application_authorization
-
       # Get the URL to authorize a user for an application via the web flow
       #
       # @param app_id [String] Client Id we received when our application was registered with GitHub.

--- a/lib/octokit/client/authorizations.rb
+++ b/lib/octokit/client/authorizations.rb
@@ -203,6 +203,17 @@ module Octokit
       end
       alias :delete_application_authorization :revoke_application_authorization
 
+      # Revoke all tokens for an app
+      #
+      # Applications can revoke all of their tokens in a single request
+      #
+      # @deprecated As of January 25th, 2016: https://developer.github.com/changes/2014-04-08-reset-api-tokens/
+      # @return [Boolean] false
+      def revoke_all_application_authorizations(options = {})
+        octokit_warn("Deprecated: If you need to revoke all tokens for your application, you can do so via the settings page for your application.")
+        false
+      end
+
       # Get the URL to authorize a user for an application via the web flow
       #
       # @param app_id [String] Client Id we received when our application was registered with GitHub.

--- a/spec/octokit/client/authorizations_spec.rb
+++ b/spec/octokit/client/authorizations_spec.rb
@@ -199,6 +199,25 @@ describe Octokit::Client::Authorizations do
     end
   end # .revoke_application_authorization
 
+  describe ".revoke_all_application_authorizations" do
+    before do
+      allow(@app_client).to receive(:octokit_warn)
+    end
+
+    it "returns false" do
+      path = "/applications/#{test_github_client_id}/tokens"
+      revoke_url = basic_github_url path,
+        :login => test_github_client_id, :password => test_github_client_secret
+      stub_delete(revoke_url).to_return(:status => 204)
+
+      result = @app_client.revoke_all_application_authorizations
+      expect(result).not_to be
+
+      expect(@app_client).to have_received(:octokit_warn)
+        .with('Deprecated: If you need to revoke all tokens for your application, you can do so via the settings page for your application.')
+    end
+  end # .revoke_all_application_authorizations
+
   def create_app_token
     @client.create_authorization \
         :idempotent    => true,

--- a/spec/octokit/client/authorizations_spec.rb
+++ b/spec/octokit/client/authorizations_spec.rb
@@ -199,19 +199,6 @@ describe Octokit::Client::Authorizations do
     end
   end # .revoke_application_authorization
 
-  describe ".revoke_all_application_authorizations" do
-    it "deletes all authorizations for an application" do
-      path = "/applications/#{test_github_client_id}/tokens"
-      revoke_url = basic_github_url path,
-        :login => test_github_client_id, :password => test_github_client_secret
-      stub_delete(revoke_url).to_return(:status => 204)
-
-      result = @app_client.revoke_all_application_authorizations
-      expect(result).to be
-      assert_requested :delete, revoke_url
-    end
-  end # .revoke_all_application_authorizations
-
   def create_app_token
     @client.create_authorization \
         :idempotent    => true,


### PR DESCRIPTION
Since that endpoint [no longer exists](https://developer.github.com/changes/2014-04-08-reset-api-tokens/), it probably shouldn't be listed in Octokit.