### PR TITLE
Docs for target_url & description status options

### DIFF
--- a/lib/octokit/client/deployments.rb
+++ b/lib/octokit/client/deployments.rb
@@ -48,6 +48,8 @@ module Octokit
       #
       # @param deployment_url [String] A URL for a deployment resource
       # @param state [String] The state: pending, success, failure, error
+      # @option options [String] :target_url The target URL to associate with this status. Default: ""
+      # @option options [String] :description A short description of the status. Maximum length of 140 characters. Default: ""
       # @return [Sawyer::Resource] A deployment status
       # @see https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
       def create_deployment_status(deployment_url, state, options = {})


### PR DESCRIPTION
I was playing around with this neat API earlier and noticed that some really cool options 
were not documented on the Octokit side: 
- https://developer.github.com/v3/repos/deployments/#create-a-deployment-status

I can confirm that `target_url` and `description` work from testing them. The first 
adds a link to the status text in a PR pointing to the `target_url`. The second 
becomes the `title` attribute on that link.

This:
```ruby
client.create_deployment_status(url, "success", { target_url: "https://www.codeschool.com", description: "Things happened.!" })
```

Turns into that:
![image](https://cloud.githubusercontent.com/assets/65950/13450105/47d84638-e008-11e5-9d29-200b676203c8.png)