### PR TITLE
Implement recognition of the `451` status code

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -22,6 +22,7 @@ module Octokit
                   when 409      then Octokit::Conflict
                   when 415      then Octokit::UnsupportedMediaType
                   when 422      then Octokit::UnprocessableEntity
+                  when 451      then Octokit::UnavailableForLegalReasons
                   when 400..499 then Octokit::ClientError
                   when 500      then Octokit::InternalServerError
                   when 501      then Octokit::NotImplemented
@@ -222,6 +223,9 @@ module Octokit
 
   # Raised when GitHub returns a 422 HTTP status code
   class UnprocessableEntity < ClientError; end
+
+  # Raised when GitHub returns a 451 HTTP status code
+  class UnavailableForLegalReasons < ClientError; end
 
   # Raised on errors in the 500-599 range
   class ServerError < Error; end

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -797,6 +797,13 @@ describe Octokit::Client do
         },
         :body => {:message => "At least one email address must be verified to do that"}.to_json
       expect { Octokit.post("/user/repos") }.to raise_error Octokit::UnverifiedEmail
+
+      stub_get('/torrentz').to_return \
+        :status => 451,
+        :headers => {
+          :content_type => "application/json",
+        }
+        expect { Octokit.get('/torrentz') }.to raise_error Octokit::UnavailableForLegalReasons
     end
 
     it "raises on unknown client errors" do


### PR DESCRIPTION
Those amazing folks at GitHub have started to support the `451` status code: https://developer.github.com/changes/2016-03-17-the-451-status-code-is-now-supported/

This PR modifies Octokit.rb to support this new code.

/cc Eagle-eyes @tarebyte 