### PR TITLE
Escape options values in authorize_url

### DIFF
--- a/lib/octokit/client/authorizations.rb
+++ b/lib/octokit/client/authorizations.rb
@@ -230,10 +230,11 @@ module Octokit
           raise Octokit::ApplicationCredentialsRequired.new "client_id required"
         end
         authorize_url = options.delete(:endpoint) || Octokit.web_endpoint
-        authorize_url += "login/oauth/authorize?client_id=" + app_id
+        authorize_url << "login/oauth/authorize?client_id=#{app_id}"
 
+        require 'cgi'
         options.each do |key, value|
-          authorize_url += "&" + key.to_s + "=" + value
+          authorize_url << "&#{key}=#{CGI.escape value}"
         end
 
         authorize_url

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -2,7 +2,7 @@ if RUBY_ENGINE == 'ruby'
   require 'simplecov'
   require 'coveralls'
 
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new [
     SimpleCov::Formatter::HTMLFormatter,
     Coveralls::SimpleCov::Formatter
   ]
@@ -13,7 +13,7 @@ require 'json'
 require 'octokit'
 require 'rspec'
 require 'webmock/rspec'
-require "base64"
+require 'base64'
 
 WebMock.disable_net_connect!(:allow => 'coveralls.io')
 

--- a/spec/octokit/client/authorizations_spec.rb
+++ b/spec/octokit/client/authorizations_spec.rb
@@ -153,6 +153,18 @@ describe Octokit::Client::Authorizations do
         Octokit.authorize_url
       }.to raise_error Octokit::ApplicationCredentialsRequired
     end
+    context "with passed options hash" do
+      it "appends options hash as query params" do
+        url = Octokit.authorize_url('id_here', redirect_uri: 'git.io', scope: 'user')
+        expect(url).to eq('https://github.com/login/oauth/authorize?client_id=id_here&redirect_uri=git.io&scope=user')
+      end
+      it "escapes values before adding to query params" do
+        uri = Octokit.authorize_url('id_here', redirect_uri: 'http://git.io')
+        expect(uri).to eq('https://github.com/login/oauth/authorize?client_id=id_here&redirect_uri=http%3A%2F%2Fgit.io')
+        scope = Octokit.authorize_url('id_here', scope: 'repo:status')
+        expect(scope).to eq('https://github.com/login/oauth/authorize?client_id=id_here&scope=repo%3Astatus')
+      end
+    end
   end # .authorize_url
 
   describe ".check_application_authorization", :vcr do


### PR DESCRIPTION
`authorize_url` appends entries from `options` hash as query params *without* escaping values. This PR adds `CGI.escape` call to fix that, because `redirect_uri` and `scope` options probably have chars that should be encoded.