### PR TITLE
Update add_collaborator and add_team_repository docs to include permission option

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -406,19 +406,28 @@ module Octokit
 
       # Add team repository
       #
+      # This can also be used to update the permission of an existing team
+      #
       # Requires authenticated user to be an owner of the organization that the
       # team is associated with. Also, the repo must be owned by the
       # organization, or a direct form of a repo owned by the organization.
       #
       # @param team_id [Integer] Team id.
       # @param repo [String, Hash, Repository] A GitHub repository.
+      # @option options [String] :permission The permission to grant the team.
+      #   Only valid on organization-owned repositories.
+      #   Can be one of: <tt>pull</tt>, <tt>push</tt>, or <tt>admin</tt>.
+      #   If not specified, the team's <tt>permission</tt> attribute will be
+      #   used to determine what permission to grant the team on this repository.
       # @return [Boolean] True if successful, false otherwise.
       # @see Octokit::Repository
-      # @see https://developer.github.com/v3/orgs/teams/#add-team-repository
+      # @see https://developer.github.com/v3/orgs/teams/#add-or-update-team-repository
       # @example
       #   @client.add_team_repository(100000, 'github/developer.github.com')
       # @example
       #   @client.add_team_repo(100000, 'github/developer.github.com')
+      # @example Add a team with admin permissions
+      #   @client.add_team_repository(100000, 'github/developer.github.com', permission: 'admin')
       def add_team_repository(team_id, repo, options = {})
         boolean_from_response :put, "teams/#{team_id}/repos/#{Repository.new(repo)}", options.merge(:name => Repository.new(repo))
       end

--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -291,16 +291,24 @@ module Octokit
 
       # Add collaborator to repo
       #
+      # This can also be used to update the permission of an existing collaborator
+      #
       # Requires authenticated client.
       #
       # @param repo [Integer, String, Hash, Repository] A GitHub repository.
       # @param collaborator [String] Collaborator GitHub username to add.
+      # @option options [String] :permission The permission to grant the collaborator.
+      #   Only valid on organization-owned repositories.
+      #   Can be one of: <tt>pull</tt>, <tt>push</tt>, or <tt>admin</tt>.
+      #   If not specified, defaults to <tt>push</tt>
       # @return [Boolean] True if collaborator added, false otherwise.
       # @see https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator
       # @example
       #   @client.add_collaborator('octokit/octokit.rb', 'holman')
       # @example
       #   @client.add_collab('octokit/octokit.rb', 'holman')
+      # @example Add a collaborator with admin permissions
+      #   @client.add_collaborator('octokit/octokit.rb', 'holman', permission: 'admin')
       def add_collaborator(repo, collaborator, options = {})
         boolean_from_response :put, "#{Repository.path repo}/collaborators/#{collaborator}", options
       end


### PR DESCRIPTION
I thought it would be useful to document this option.

If you regenerate the docs with this change, it'll look like:

<img width="701" alt="screen shot 2016-05-25 at 1 48 19 pm" src="https://cloud.githubusercontent.com/assets/1863540/15555842/749cd38c-227f-11e6-8935-6bc8a24a81e2.png">

Previously it looked like:

<img width="706" alt="screen shot 2016-05-25 at 1 48 48 pm" src="https://cloud.githubusercontent.com/assets/1863540/15555841/74952466-227f-11e6-8186-6477987a87dd.png">
