### PR TITLE
Add `Client.lock_issue` and `Client.unlock_issue`

### DIFF
--- a/lib/octokit/client/issues.rb
+++ b/lib/octokit/client/issues.rb
@@ -146,6 +146,30 @@ module Octokit
         patch "#{Repository.path repo}/issues/#{number}", options.merge({:state => "open"})
       end
 
+      # Lock an issue's conversation, limiting it to collaborators
+      #
+      # @param repo [Integer, String, Repository, Hash] A GitHub repository
+      # @param number [Integer] Number ID of the issue
+      # @return [Boolean] Success
+      # @see https://developer.github.com/v3/issues/#lock-an-issue
+      # @example Lock Issue #25 from octokit/octokit.rb
+      #   Octokit.lock_issue("octokit/octokit.rb", "25")
+      def lock_issue(repo, number)
+        boolean_from_response :put, "#{Repository.path repo}/issues/#{number}/lock"
+      end
+
+      # Unlock an issue's conversation, opening it to all viewers
+      #
+      # @param repo [Integer, String, Repository, Hash] A GitHub repository
+      # @param number [Integer] Number ID of the issue
+      # @return [Boolean] Success
+      # @see https://developer.github.com/v3/issues/#unlock-an-issue
+      # @example Close Issue #25 from octokit/octokit.rb
+      #   Octokit.close_issue("octokit/octokit.rb", "25")
+      def unlock_issue(repo, number, options = {})
+        boolean_from_response :delete, "#{Repository.path repo}/issues/#{number}/lock"
+      end
+
       # Update an issue
       #
       # @overload update_issue(repo, number, title, body, options)

--- a/spec/octokit/client/issues_spec.rb
+++ b/spec/octokit/client/issues_spec.rb
@@ -113,6 +113,20 @@ describe Octokit::Client::Issues do
       end
     end # .reopen_issue
 
+    describe ".lock_issue" do
+      it "locks an issue" do
+        @client.lock_issue(@test_repo, @issue)
+        assert_requested :put, github_url("/repos/#{@test_repo}/issues/#{@issue.number}/lock")
+      end
+    end # .lock_issue
+
+    describe ".unlock_issue" do
+      it "unlocks an issue" do
+        @client.unlock_issue(@test_repo, @issue)
+        assert_requested :delete, github_url("/repos/#{@test_repo}/issues/#{@issue.number}/lock")
+      end
+    end # .unlock_issue
+
     describe ".update_issue" do
       it "updates an issue" do
         issue = @client.update_issue(@test_repo, @issue.number, "Use all the v3 api!", "")


### PR DESCRIPTION
With the recent finalizing of the API endpoints to lock and unlock
issues, we should include that functionality in Octokit.rb. This patch
adds two methods to lock or unlock an issue. Because the corresponding
API endpoints return a 204 NO CONTENT on success, we just coerce the
response into a Boolean for the Octokit methods.

Side note: not entirely sure what to do to get VCR to work in this repo. I
wrote some corresponding specs but I'm waiting to see what CI says.