### PR TITLE
Expose response statuses when Octokit raises an error.

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -86,6 +86,13 @@ module Octokit
       end
     end
 
+    # Status code returned by the GitHub server.
+    #
+    # @return [Integer]
+    def response_status
+      @response[:status]
+    end
+
     private
 
     def data

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -862,6 +862,21 @@ describe Octokit::Client do
         :body => [].to_json
       expect { Octokit.get('/user') }.to raise_error Octokit::ServerError
     end
+
+    it "exposes the response status code" do
+      stub_get('/boom').
+        to_return \
+        :status => 422,
+        :headers => {
+          :content_type => "application/json",
+        },
+        :body => {:error => "No repository found for hubtopic"}.to_json
+      begin
+        Octokit.get('/boom')
+      rescue Octokit::UnprocessableEntity => e
+        expect(e.response_status).to eql 422
+      end
+    end
   end
 
   it "knows the difference between unauthorized and needs OTP" do


### PR DESCRIPTION
Octokit subclasses errors depending on the response status.
This is great because it allows consumers to handle specific
errors properly.

It is not great if you want to keep audit logs of responses from remote servers.
You could use the class name, and do some normalization. You could also
parse the message that Octokit provides, but that has some other issues:

1. You need to know all the possible error classes Octokit implements to
handle error responses.

2. Parsing string is not the best way to do this.

3. It becomes a bigger issue if you integrate with different
Git Hostings that use different libraries and handle errors in different
ways. Octokit::NotFound is not the same as Gitlab::NotFound (I just made
this one up).

Status codes are the canonical way to know what happened with
an http request. They are agnostic to programming languages,
libraries, producers, and consumers.

This patch exposes the status code from the response.

Signed-off-by: David Calavera <david.calavera@gmail.com>