### PR TITLE
Repository: Avoid obsolete warning using URI::ABS_URI

### DIFF
--- a/lib/octokit/repository.rb
+++ b/lib/octokit/repository.rb
@@ -78,7 +78,7 @@ module Octokit
     private
 
       def validate_owner_and_name!
-        if @owner.include?('/') || @name.include?('/') || !url.match(/\A#{URI.regexp}\z/)
+        if @owner.include?('/') || @name.include?('/') || !url.match(/\A#{URI::ABS_URI}\z/)
           raise_invalid_repository!
         end
       end


### PR DESCRIPTION
Try to avoid the warning "URI.regexp is obsolete" by using one of the specific regular expressions made available to the `URI` module.

Benefit: much less chatty output. 

Example: [this test output](https://travis-ci.org/skywinder/github-changelog-generator/jobs/165365731)