### PR TITLE
Dupe the options hash in Repositories#create_repo

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -152,13 +152,14 @@ module Octokit
       # @return [Sawyer::Resource] Repository info for the new repository
       # @see https://developer.github.com/v3/repos/#create
       def create_repository(name, options = {})
-        organization = options.delete :organization
-        options.merge! :name => name
+        opts = options.dup
+        organization = opts.delete :organization
+        opts.merge! :name => name
 
         if organization.nil?
-          post 'user/repos', options
+          post 'user/repos', opts
         else
-          post "#{Organization.path organization}/repos", options
+          post "#{Organization.path organization}/repos", opts
         end
       end
       alias :create_repo :create_repository


### PR DESCRIPTION
WHY:
I was getting unexpected behavior from my program in a class that wraps
Octokit. After looking at the source code I realized it was because the
hash I was passing to Repositories#create_repo was being mutated inside
the method. I'm thinking it would be better to dupe the hash before
mutating it to avoid surprises to the user. I named the duped version `opts` so that it would be clear inside the method that this object is not the same as the one passed in.