### PR TITLE
Run CI for MRI 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3
 
 bundler_args: --without development
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.1
 
 bundler_args: --without development
 

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ pass `state` in the method options.
 - adds support for new [Enterprise-only APIs](#working-with-github-enterprise).
 - adds support for [Repository redirects][redirects].
 
-[list-pulls]: https://github.com/octokit/octokit.rb/commit/e48e91f736d5fce51e3bf74d7c9022aaa52f5c5c 
+[list-pulls]: https://github.com/octokit/octokit.rb/commit/e48e91f736d5fce51e3bf74d7c9022aaa52f5c5c
 [redirects]: https://developer.github.com/changes/2015-05-26-repository-redirects-are-coming/
 
 Version 3.0 includes a couple breaking changes when upgrading from v2.x.x:
@@ -652,6 +652,7 @@ implementations:
 * Ruby 2.0
 * Ruby 2.1
 * Ruby 2.2
+* Ruby 2.3
 
 If something doesn't work on one of these Ruby versions, it's a bug.
 


### PR DESCRIPTION
- Updates the travis configuration to run on MRI 2.3.
- Updates README to include 2.3 as a supported version.