### PR TITLE
adding support for getting a single deployment by id

### DIFF
--- a/lib/octokit/client/deployments.rb
+++ b/lib/octokit/client/deployments.rb
@@ -16,6 +16,11 @@ module Octokit
       end
       alias :list_deployments :deployments
 
+      def deployment(repo, id, options = {})
+        get("#{Repository.path repo}/deployments/#{id}", options)
+      end
+      alias :get_deployment :deployment
+
       # Create a deployment for a ref
       #
       # @param repo [Integer, String, Repository, Hash] A GitHub repository

--- a/spec/octokit/client/deployments_spec.rb
+++ b/spec/octokit/client/deployments_spec.rb
@@ -19,6 +19,14 @@ describe Octokit::Client::Deployments do
     end
   end # .deployments
 
+  describe ".deployment", :vcr do
+    it "gets single deployment" do
+      deployment = @client.deployment(@test_repo, 137)
+      expect(deployment).to wont_be_kind_of Array
+      assert_requested :get, github_url("/repos/#{@test_repo}/deployments/137")
+    end
+  end # .deployment
+
   describe ".create_deployment", :vcr do
     before do
       @sha = "626ee940f85663dadf245210aaf8ded281fd4cd6"


### PR DESCRIPTION
This PR is to add support for getting a single deployment by id. Unfortunately, I'm not able to get my test to work because of a credential issue:

```
Failures:

  1) Octokit::Client::Deployments.deployment gets single deployment
     Failure/Error: deployment = @client.deployment(@test_repo, 137)
     Octokit::Unauthorized:
       GET https://api.github.com/repos/api-padawan/api-sandbox?auto_init=true: 401 - Bad credentials // See: https://developer.github.com/v3
```

Let me know how I can resolve this, and I'll make the necessary changes.