### PR TITLE
[ci skip] Remove option :public from gists.rb's doc

### DIFF
--- a/lib/octokit/client/gists.rb
+++ b/lib/octokit/client/gists.rb
@@ -75,7 +75,6 @@ module Octokit
       #
       # @param options [Hash] Gist information.
       # @option options [String] :description
-      # @option options [Boolean] :public Sets gist visibility
       # @option options [Hash] :files Files that make up this gist. Keys
       #   should be the filename, the value a Hash with a :content key with text
       #   content of the Gist.


### PR DESCRIPTION
Changing a Gist's visibility (`public` or `secret`) via the API is not supported, and not mentioned in the [Edit a gist](https://developer.github.com/v3/gists/#edit-a-gist) section of the [GitHub API documentation](https://developer.github.com/v3/). However in the [edit_gist](http://octokit.github.io/octokit.rb/Octokit/Client/Gists.html#edit_gist-instance_method) method of Octokit's documentation, `:public` option is described as if it were able to change a Gist's visibility:

> :public (Boolean) — Sets gist visibility

I tested this myself by using Octokit's `:public` option to try to change a Gist's visibility, however this does nothing. This is because the implementation of the API endpoint does not handle the `:public` option.

This PR removes the line from the Yard doc of the [edit_gist](http://octokit.github.io/octokit.rb/Octokit/Client/Gists.html#edit_gist-instance_method) method to align with the actual behavior of the [GitHub API endpoint](https://developer.github.com/v3/gists/#edit-a-gist).