### PR TITLE
Add .netrc support to Octokit::EnterpriseAdminClient

### DIFF
--- a/lib/octokit/enterprise_admin_client.rb
+++ b/lib/octokit/enterprise_admin_client.rb
@@ -32,6 +32,8 @@ module Octokit
       Octokit::Configurable.keys.each do |key|
         instance_variable_set(:"@#{key}", options[key] || Octokit.instance_variable_get(:"@#{key}"))
       end
+
+      login_from_netrc unless user_authenticated? || application_authenticated?
     end
 
   end

--- a/spec/octokit/enterprise_admin_client_spec.rb
+++ b/spec/octokit/enterprise_admin_client_spec.rb
@@ -9,6 +9,26 @@ describe Octokit::EnterpriseAdminClient do
       expect admin_client.is_a? Octokit::Client
     end
 
+    describe "with .netrc" do
+      before do
+        File.chmod(0600, File.join(fixture_path, '.netrc'))
+      end
+
+      it "can read .netrc files" do
+        Octokit.reset!
+        admin_client = Octokit::EnterpriseAdminClient.new(:netrc => true, :netrc_file => File.join(fixture_path, '.netrc'))
+        expect(admin_client.login).to eq("sferik")
+        expect(admin_client.instance_variable_get(:"@password")).to eq("il0veruby")
+      end
+
+      it "can read non-standard API endpoint creds from .netrc" do
+        Octokit.reset!
+        admin_client = Octokit::EnterpriseAdminClient.new(:netrc => true, :netrc_file => File.join(fixture_path, '.netrc'), :api_endpoint => 'http://api.github.dev')
+        expect(admin_client.login).to eq("defunkt")
+        expect(admin_client.instance_variable_get(:"@password")).to eq("il0veruby")
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
I thought I was doing something wrong when `Octokit::EnterpriseAdminClient.new(:netrc => true)` didn't seem to work, but it wasn't implemented, [like it is](https://github.com/octokit/octokit.rb/blob/265de586860c2e108dc815d7e5609c622e5c8660/lib/octokit/client.rb#L112) for `Octokit::Client`.

This adds `.netrc` support to `Octokit::EnterpriseAdminClient`.

On `master`:

```
admin_client = Octokit::EnterpriseAdminClient.new(:netrc => true)
admin_client.login
=> nil
```

On this branch:

```
admin_client = Octokit::EnterpriseAdminClient.new(:netrc => true)
admin_client.login
=> "jdennes"
```
