### PR TITLE
Return nil on timeout fetching stats

### DIFF
--- a/lib/octokit/client/stats.rb
+++ b/lib/octokit/client/stats.rb
@@ -96,7 +96,7 @@ module Octokit
           data = get("#{Repository.path repo}/stats/#{metric}", options)
           return data if last_response.status == 200
           return nil unless retry_timeout
-          return data if Time.now >= timeout
+          return nil if Time.now >= timeout
           sleep retry_wait if retry_wait
         end
       end

--- a/spec/octokit/client/stats_spec.rb
+++ b/spec/octokit/client/stats_spec.rb
@@ -36,6 +36,12 @@ describe Octokit::Client::Stats do
 
         assert_requested :get, github_url("/repos/octokit/octokit.rb/stats/contributors"), :times => 3
       end
+
+      it "returns nil on timeout" do
+        stats = @client.contributors_stats("octokit/octokit.rb", :retry_timeout => 1, :retry_wait => 1)
+        expect(stats).to be_nil
+        assert_requested :get, github_url("/repos/octokit/octokit.rb/stats/contributors"), :times => 2
+      end
     end # .contributors_stats
 
     describe ".commit_activity_stats" do


### PR DESCRIPTION
Currently any method from `Octokit::Client::Stats` may return an `Array` of `Sawyer::Resource` objects, `nil` or an empty `Sawyer::Resource`. That's because returning `data` upon timeout will return the data of the 202 response, which is an empty JSON object.

The documentation for the private `get_stats` method doesn't mention returning a single `Sawyer::Resource` so I assumed it's not a specified behavior. Additionally when using `retry_timeout: nil`, it returns nil when it gets a 202.

This changes `get_stats` to return `nil` in this case too.