### PR TITLE
Remove requested 'Accept' header from GET /repos/o/r/pages

### DIFF
--- a/lib/octokit/client/pages.rb
+++ b/lib/octokit/client/pages.rb
@@ -12,8 +12,7 @@ module Octokit
       # @return Sawyer::Resource A GitHub Pages resource
       # @see https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site
       def pages(repo, options = {})
-        opts = ensure_api_media_type(:pages, options)
-        get "#{Repository.path repo}/pages", opts
+        get "#{Repository.path repo}/pages", options
       end
 
       # Get a specific Pages build by ID


### PR DESCRIPTION
@joeyw This addresses my comment from https://github.com/octokit/octokit.rb/pull/815/files#r84807489.

This is currently broken in v4.4.0.