### PR TITLE
Support Bearer JWT authentication #812

### DIFF
--- a/lib/octokit/authentication.rb
+++ b/lib/octokit/authentication.rb
@@ -21,6 +21,14 @@ module Octokit
       !!@access_token
     end
 
+    # Indicates if the client was supplied a bearer token
+    #
+    # @see https://developer.github.com/early-access/integrations/authentication/#as-an-integration
+    # @return [Boolean]
+    def bearer_authenticated?
+      !!@bearer_token
+    end
+
     # Indicates if the client was supplied an OAuth
     # access token or Basic Auth username and password
     #

--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -121,6 +121,7 @@ module Octokit
       # mask password
       inspected = inspected.gsub! @password, "*******" if @password
       inspected = inspected.gsub! @management_console_password, "*******" if @management_console_password
+      inspected = inspected.gsub! @bearer_token, '********' if @bearer_token
       # Only show last 4 of token, secret
       if @access_token
         inspected = inspected.gsub! @access_token, "#{'*'*36}#{@access_token[36..-1]}"
@@ -181,6 +182,14 @@ module Octokit
       @access_token = value
     end
 
+    # Set Bearer Token for authentication
+    #
+    # @param value [String] JWT
+    def bearer_token=(value)
+      reset_agent
+      @bearer_token = value
+    end
+
     # Set OAuth app client_id
     #
     # @param value [String] 20 character GitHub OAuth app client_id
@@ -207,6 +216,8 @@ module Octokit
           http.basic_auth(@login, @password)
         elsif token_authenticated?
           http.authorization 'token', @access_token
+        elsif bearer_authenticated?
+          http.authorization 'Bearer', @bearer_token
         end
         http.headers['accept'] = options[:accept] if options.key?(:accept)
       end

--- a/lib/octokit/configurable.rb
+++ b/lib/octokit/configurable.rb
@@ -10,6 +10,9 @@ module Octokit
     #   @return [String] Base URL for API requests. default: https://api.github.com/
     # @!attribute auto_paginate
     #   @return [Boolean] Auto fetch next page of results until rate limit reached
+    # @!attribute [w] bearer_token
+    #   @see https://developer.github.com/early-access/integrations/authentication/#as-an-integration
+    #   @return [String] JWT bearer token for authentication
     # @!attribute client_id
     #   @see https://developer.github.com/v3/oauth/
     #   @return [String] Configure OAuth app key
@@ -47,7 +50,7 @@ module Octokit
     # @!attribute web_endpoint
     #   @return [String] Base URL for web URLs. default: https://github.com/
 
-    attr_accessor :access_token, :auto_paginate, :client_id,
+    attr_accessor :access_token, :auto_paginate, :bearer_token, :client_id,
                   :client_secret, :default_media_type, :connection_options,
                   :middleware, :netrc, :netrc_file,
                   :per_page, :proxy, :user_agent
@@ -63,6 +66,7 @@ module Octokit
           :access_token,
           :api_endpoint,
           :auto_paginate,
+          :bearer_token,
           :client_id,
           :client_secret,
           :connection_options,

--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -110,6 +110,8 @@ module Octokit
           http.basic_auth(@login, @password)
         elsif token_authenticated?
           http.authorization 'token', @access_token
+        elsif bearer_authenticated?
+          http.authorization 'Bearer', @bearer_token
         elsif application_authenticated?
           http.params = http.params.merge application_authentication
         end

--- a/lib/octokit/default.rb
+++ b/lib/octokit/default.rb
@@ -57,6 +57,12 @@ module Octokit
         ENV['OCTOKIT_AUTO_PAGINATE']
       end
 
+      # Default bearer token from ENV
+      # @return [String]
+      def bearer_token
+        ENV['OCTOKIT_BEARER_TOKEN']
+      end
+
       # Default OAuth app key from ENV
       # @return [String]
       def client_id

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -79,6 +79,12 @@ describe Octokit::Client do
         expect(inspected).not_to include("87614b09dd141c22800f96f11737ade5226d7ba8")
       end
 
+      it "masks bearer token on inspect" do
+        client = Octokit::Client.new(bearer_token: 'secret JWT')
+        inspected = client.inspect
+        expect(inspected).not_to include("secret JWT")
+      end
+
       it "masks client secrets on inspect" do
         client = Octokit::Client.new(:client_secret => '87614b09dd141c22800f96f11737ade5226d7ba8')
         inspected = client.inspect
@@ -140,6 +146,7 @@ describe Octokit::Client do
       before do
         Octokit.reset!
       end
+
       it "sets basic auth creds with .configure" do
         Octokit.configure do |config|
           config.login = 'pengwynn'
@@ -147,11 +154,13 @@ describe Octokit::Client do
         end
         expect(Octokit.client).to be_basic_authenticated
       end
+
       it "sets basic auth creds with module methods" do
         Octokit.login = 'pengwynn'
         Octokit.password = 'il0veruby'
         expect(Octokit.client).to be_basic_authenticated
       end
+
       it "sets oauth token with .configure" do
         Octokit.configure do |config|
           config.access_token = 'd255197b4937b385eb63d1f4677e3ffee61fbaea'
@@ -159,11 +168,27 @@ describe Octokit::Client do
         expect(Octokit.client).not_to be_basic_authenticated
         expect(Octokit.client).to be_token_authenticated
       end
+
       it "sets oauth token with module methods" do
         Octokit.access_token = 'd255197b4937b385eb63d1f4677e3ffee61fbaea'
         expect(Octokit.client).not_to be_basic_authenticated
         expect(Octokit.client).to be_token_authenticated
       end
+
+      it "sets bearer token with module method" do
+        Octokit.bearer_token = 'secret JWT'
+        expect(Octokit.client).to be_bearer_authenticated
+      end
+
+      it "sets bearer token with .configure" do
+        Octokit.configure do |config|
+          config.bearer_token = 'secret JWT'
+        end
+        expect(Octokit.client).not_to be_basic_authenticated
+        expect(Octokit.client).not_to be_token_authenticated
+        expect(Octokit.client).to be_bearer_authenticated
+      end
+
       it "sets oauth application creds with .configure" do
         Octokit.configure do |config|
           config.client_id     = '97b4937b385eb63d1f46'
@@ -173,6 +198,7 @@ describe Octokit::Client do
         expect(Octokit.client).not_to be_token_authenticated
         expect(Octokit.client).to be_application_authenticated
       end
+
       it "sets oauth token with module methods" do
         Octokit.client_id     = '97b4937b385eb63d1f46'
         Octokit.client_secret = 'd255197b4937b385eb63d1f4677e3ffee61fbaea'
@@ -252,6 +278,19 @@ describe Octokit::Client do
         assert_requested :get, github_url('/user')
       end
     end
+
+    describe "when bearer authenticated", :vcr do
+      it "makes authenticated calls" do
+        jwt = 'secret JWT'
+        client = Octokit::Client.new(bearer_token: jwt)
+
+        root_request = stub_get("/").
+          with(:headers => {:authorization => "Bearer #{jwt}"})
+        client.get("/")
+        assert_requested root_request
+      end
+    end
+
     describe "when application authenticated" do
       it "makes authenticated calls" do
         client = Octokit.client


### PR DESCRIPTION
Support authenticating Octokit with JWT bearer tokens #812

```ruby
Octokit::Client.new(bearer_token: 'super_secret_token') =>
Authorization: Bearer super_secret_token
```