### PR TITLE
Loosen sawyer dependency to allow 0.8.0

### DIFF
--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -5,7 +5,7 @@ require 'octokit/version'
 
 Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.0'
-  spec.add_dependency 'sawyer', '>= 0.5.3', '~> 0.7.0'
+  spec.add_dependency 'sawyer', '>= 0.5.3', '~> 0.8.0'
   spec.authors = ["Wynn Netherland", "Erik Michaels-Ober", "Clint Shryock"]
   spec.description = %q{Simple wrapper for the GitHub API}
   spec.email = ['wynn.netherland@gmail.com', 'sferik@gmail.com', 'clint@ctshryock.com']


### PR DESCRIPTION
Following on from loosing the addressable dependency in sawyer https://github.com/lostisland/sawyer/pull/46

🐰 