### PR TITLE
Fixes #727 - quick-n-dirty monkey patch

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -26,7 +26,7 @@ module Octokit
       # @param repo [Integer, String, Hash, Repository] A GitHub repository
       # @return [Sawyer::Resource] Repository information
       def repository(repo, options = {})
-        get Repository.path(repo), options
+        get_and_patch Repository.path(repo), options
       end
       alias :repo :repository
 
@@ -68,7 +68,7 @@ module Octokit
       #   to list repos.
       # @return [Array<Sawyer::Resource>] List of repositories
       def repositories(user=nil, options = {})
-        paginate "#{User.path user}/repos", options
+        paginate_and_patch "#{User.path user}/repos", options
       end
       alias :list_repositories :repositories
       alias :list_repos :repositories
@@ -86,7 +86,7 @@ module Octokit
       #   that you’ve seen.
       # @return [Array<Sawyer::Resource>] List of repositories.
       def all_repositories(options = {})
-        paginate 'repositories', options
+        paginate_and_patch 'repositories', options
       end
 
       # Star a repository
@@ -632,6 +632,30 @@ module Octokit
       #   @client.delete_subscription("octokit/octokit.rb")
       def delete_subscription(repo, options = {})
         boolean_from_response :delete, "#{Repository.path repo}/subscription", options
+      end
+
+      module_function
+
+      def get_and_patch(url, options = {})
+        monkey_patch(get(url, options))
+      end
+
+      def paginate_and_patch(url, options = {})
+        paginate(url, options).map { |repository| monkey_patch(repository) }
+      end
+
+      def monkey_patch repository
+        # more context for and details about this patch in
+        # https://github.com/octokit/octokit.rb/issues/727
+        if ssh_relation = repository.rels[:ssh]
+          unless ssh_relation =~ %r{\Assh://}
+            href_template = ssh_relation.href_template
+            scp_pattern   = href_template.pattern                     #       "git@github.com:octokit/octokit.rb.git"
+            ssh_pattern   = "ssh://%s/%s" % scp_pattern.split(':', 2) # "ssh://git@github.com/octokit/octokit.rb.git"
+            href_template.instance_variable_set(:"@pattern", ssh_pattern)
+          end
+        end
+        repository
       end
     end
   end


### PR DESCRIPTION
@pengwynn, in https://github.com/octokit/octokit.rb/issues/727#issuecomment-259302307 you wrote:

> If you want to push up a monkey patch, that'd be great.

And here it is, in all its glory!  :smile:

Because it's a monkey patch, it doesn't necessarily look pretty, but it works and the tests are green... but before I spend more time making it look acceptable, I thought I'd run the approach by you to see if you're OK with it, or else if you'd like to suggest a different direction.

The proof of the pudding is in eating it, or so they say:

```ruby
[1] pry(main)> Octokit::VERSION
=> "4.6.0"
[2] pry(main)> Sawyer::VERSION
=> "0.8.0"
[3] pry(main)> Addressable::VERSION::STRING
=> "2.5.0"
[4] pry(main)> repo = Octokit::Client.new.repository('octokit/octokit.rb') ; nil
=> nil
[5] pry(main)> repo.rels[:git].href
=> "git://github.com/octokit/octokit.rb.git"
[6] pry(main)> repo.rels[:svn].href
=> "https://github.com/octokit/octokit.rb"
[7] pry(main)> repo.rels[:ssh].href
=> "ssh://git@github.com/octokit/octokit.rb.git"
[8] pry(main)> _
```

Note how `repo.rels[:ssh].href` is now a RFC 2396 compliant SSH URL, as opposed to a shorter, `scp`-like URL, which is why `addressable` is no longer throwing the exception documented in #727.
