### PR TITLE
Avoid polluting global namespace

### DIFF
--- a/lib/ext/sawyer/relation.rb
+++ b/lib/ext/sawyer/relation.rb
@@ -1,10 +1,10 @@
 require 'sawyer'
 
-module Patch
+patch = Module.new do
   def href(options=nil)
     # Temporary workaround for: https://github.com/octokit/octokit.rb/issues/727
     name.to_s == "ssh" ? @href : super
   end
 end
 
-Sawyer::Relation.send(:prepend, Patch)
+Sawyer::Relation.send(:prepend, patch)


### PR DESCRIPTION
My app has a `::Patch` class. This PR fixes name collision problem. 