### PR TITLE
Fix passing options to all_organizations

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -96,7 +96,7 @@ module Octokit
       #
       # @return [Array<Sawyer::Resource>] List of GitHub organizations.
       def all_organizations(options = {})
-        paginate "organizations"
+        paginate "organizations", options
       end
       alias :all_orgs :all_organizations
 


### PR DESCRIPTION
Passing "since" did not work when calling "all_organizations" as it was
not passed to "paginate".