### PR TITLE
Fix deprecated `constant ::Fixnum`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.1
+  - 2.4.0
 
 bundler_args: --without development
 

--- a/lib/octokit/client/labels.rb
+++ b/lib/octokit/client/labels.rb
@@ -78,7 +78,7 @@ module Octokit
       # This removes the label from the Issue
       #
       # @param repo [Integer, String, Repository, Hash] A GitHub repository
-      # @param number [Fixnum] Number ID of the issue
+      # @param number [Integer] Number ID of the issue
       # @param label [String] String name of the label
       # @return [Array<Sawyer::Resource>] A list of the labels currently on the issue
       # @see https://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue
@@ -93,7 +93,7 @@ module Octokit
       # This removes the label from the Issue
       #
       # @param repo [Integer, String, Repository, Hash] A GitHub repository
-      # @param number [Fixnum] Number ID of the issue
+      # @param number [Integer] Number ID of the issue
       # @return [Boolean] Success of operation
       # @see https://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue
       # @example Remove all labels from Issue #23
@@ -105,7 +105,7 @@ module Octokit
       # List labels for a given issue
       #
       # @param repo [Integer, String, Repository, Hash] A GitHub repository
-      # @param number [Fixnum] Number ID of the issue
+      # @param number [Integer] Number ID of the issue
       # @return [Array<Sawyer::Resource>] A list of the labels currently on the issue
       # @see https://developer.github.com/v3/issues/labels/#list-labels-on-an-issue
       # @example List labels for octokit/octokit.rb, issue # 1
@@ -117,7 +117,7 @@ module Octokit
       # Add label(s) to an Issue
       #
       # @param repo [Integer, String, Repository, Hash] A Github repository
-      # @param number [Fixnum] Number ID of the issue
+      # @param number [Integer] Number ID of the issue
       # @param labels [Array] An array of labels to apply to this Issue
       # @return [Array<Sawyer::Resource>] A list of the labels currently on the issue
       # @see https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
@@ -130,7 +130,7 @@ module Octokit
       # Replace all labels on an Issue
       #
       # @param repo [Integer, String, Repository, Hash] A Github repository
-      # @param number [Fixnum] Number ID of the issue
+      # @param number [Integer] Number ID of the issue
       # @param labels [Array] An array of labels to use as replacement
       # @return [Array<Sawyer::Resource>] A list of the labels currently on the issue
       # @see https://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue
@@ -143,7 +143,7 @@ module Octokit
       # Get labels for every issue in a milestone
       #
       # @param repo [Integer, String, Repository, Hash] A GitHub repository
-      # @param number [Fixnum] Number ID of the milestone
+      # @param number [Integer] Number ID of the milestone
       # @return [Array<Sawyer::Resource>] A list of the labels across the milestone
       # @see  http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone
       # @example List all labels for milestone #2 on octokit/octokit.rb

--- a/lib/octokit/client/rate_limit.rb
+++ b/lib/octokit/client/rate_limit.rb
@@ -21,7 +21,7 @@ module Octokit
       # Get number of rate limted requests remaining
       #
       # @see https://developer.github.com/v3/rate_limit/#rate-limit
-      # @return [Fixnum] Number of requests remaining in this period
+      # @return [Integer] Number of requests remaining in this period
       def rate_limit_remaining(options = {})
         octokit_warn "Deprecated: Please use .rate_limit.remaining"
         rate_limit.remaining
@@ -41,7 +41,7 @@ module Octokit
       # Refresh rate limit info and get number of rate limted requests remaining
       #
       # @see https://developer.github.com/v3/rate_limit/#rate-limit
-      # @return [Fixnum] Number of requests remaining in this period
+      # @return [Integer] Number of requests remaining in this period
       def rate_limit_remaining!(options = {})
         octokit_warn "Deprecated: Please use .rate_limit!.remaining"
         rate_limit!.remaining

--- a/lib/octokit/client/search.rb
+++ b/lib/octokit/client/search.rb
@@ -12,8 +12,8 @@ module Octokit
       # @param options [Hash] Sort and pagination options
       # @option options [String] :sort Sort field
       # @option options [String] :order Sort order (asc or desc)
-      # @option options [Fixnum] :page Page of paginated results
-      # @option options [Fixnum] :per_page Number of items per page
+      # @option options [Integer] :page Page of paginated results
+      # @option options [Integer] :per_page Number of items per page
       # @return [Sawyer::Resource] Search results object
       # @see https://developer.github.com/v3/search/#search-code
       def search_code(query, options = {})
@@ -26,8 +26,8 @@ module Octokit
       # @param options [Hash] Sort and pagination options
       # @option options [String] :sort Sort field
       # @option options [String] :order Sort order (asc or desc)
-      # @option options [Fixnum] :page Page of paginated results
-      # @option options [Fixnum] :per_page Number of items per page
+      # @option options [Integer] :page Page of paginated results
+      # @option options [Integer] :per_page Number of items per page
       # @return [Sawyer::Resource] Search results object
       # @see https://developer.github.com/v3/search/#search-issues
       def search_issues(query, options = {})
@@ -40,8 +40,8 @@ module Octokit
       # @param options [Hash] Sort and pagination options
       # @option options [String] :sort Sort field
       # @option options [String] :order Sort order (asc or desc)
-      # @option options [Fixnum] :page Page of paginated results
-      # @option options [Fixnum] :per_page Number of items per page
+      # @option options [Integer] :page Page of paginated results
+      # @option options [Integer] :per_page Number of items per page
       # @return [Sawyer::Resource] Search results object
       # @see https://developer.github.com/v3/search/#search-repositories
       def search_repositories(query, options = {})
@@ -55,8 +55,8 @@ module Octokit
       # @param options [Hash] Sort and pagination options
       # @option options [String] :sort Sort field
       # @option options [String] :order Sort order (asc or desc)
-      # @option options [Fixnum] :page Page of paginated results
-      # @option options [Fixnum] :per_page Number of items per page
+      # @option options [Integer] :page Page of paginated results
+      # @option options [Integer] :per_page Number of items per page
       # @return [Sawyer::Resource] Search results object
       # @see https://developer.github.com/v3/search/#search-users
       def search_users(query, options = {})

--- a/lib/octokit/client/source_import.rb
+++ b/lib/octokit/client/source_import.rb
@@ -132,7 +132,7 @@ module Octokit
       #
       # @param repo [Integer, String, Hash, Repository] A GitHub repository.
       # @param options [Hash]
-      # @option options [Fixnum] :page Page of paginated results
+      # @option options [Integer] :page Page of paginated results
       # @return [Array<Sawyer::Resource>] Array of hashes representing files over 100MB.
       # @see https://developer.github.com/v3/migration/source_imports/#get-large-files
       #

--- a/lib/octokit/default.rb
+++ b/lib/octokit/default.rb
@@ -118,7 +118,7 @@ module Octokit
       end
 
       # Default pagination page size from ENV
-      # @return [Fixnum] Page size
+      # @return [Integer] Page size
       def per_page
         page_size = ENV['OCTOKIT_PER_PAGE']
 

--- a/lib/octokit/gist.rb
+++ b/lib/octokit/gist.rb
@@ -15,7 +15,7 @@ module Octokit
 
     def initialize(gist)
       case gist
-      when Fixnum, String
+      when Integer, String
         @id = gist.to_s
       end
     end

--- a/lib/octokit/middleware/follow_redirects.rb
+++ b/lib/octokit/middleware/follow_redirects.rb
@@ -49,7 +49,7 @@ module Octokit
       # Public: Initialize the middleware.
       #
       # options - An options Hash (default: {}):
-      #           :limit               - A Fixnum redirect limit (default: 3).
+      #           :limit               - A Integer redirect limit (default: 3).
       def initialize(app, options = {})
         super(app)
         @options = options

--- a/lib/octokit/rate_limit.rb
+++ b/lib/octokit/rate_limit.rb
@@ -3,13 +3,13 @@ module Octokit
   # Class for API Rate Limit info
   #
   # @!attribute [w] limit
-  #   @return [Fixnum] Max tries per rate limit period
+  #   @return [Integer] Max tries per rate limit period
   # @!attribute [w] remaining
-  #   @return [Fixnum] Remaining tries per rate limit period
+  #   @return [Integer] Remaining tries per rate limit period
   # @!attribute [w] resets_at
   #   @return [Time] Indicates when rate limit resets
   # @!attribute [w] resets_in
-  #   @return [Fixnum] Number of seconds when rate limit resets
+  #   @return [Integer] Number of seconds when rate limit resets
   #
   # @see https://developer.github.com/v3/#rate-limiting
   class RateLimit < Struct.new(:limit, :remaining, :resets_at, :resets_in)

--- a/spec/octokit/client/rate_limit_spec.rb
+++ b/spec/octokit/client/rate_limit_spec.rb
@@ -9,8 +9,8 @@ describe Octokit::Client do
     context "with no last response" do
       it "makes a response", :vcr => { cassette_name: "rate_limit" } do
         rate = client.rate_limit
-        expect(rate.limit).to be_kind_of Fixnum
-        expect(rate.remaining).to be_kind_of Fixnum
+        expect(rate.limit).to be_kind_of Integer
+        expect(rate.remaining).to be_kind_of Integer
       end # #rate_limit
     end
 
@@ -23,10 +23,10 @@ describe Octokit::Client do
 
       it "checks the rate limit from the last response", :vcr => { cassette_name: "rate_limit" } do
         rate = client.rate_limit
-        expect(rate.limit).to be_kind_of Fixnum
-        expect(rate.remaining).to be_kind_of Fixnum
+        expect(rate.limit).to be_kind_of Integer
+        expect(rate.remaining).to be_kind_of Integer
         expect(rate.resets_at).to be_kind_of Time
-        expect(rate.resets_in).to be_kind_of Fixnum
+        expect(rate.resets_in).to be_kind_of Integer
       end
     end
   end
@@ -34,10 +34,10 @@ describe Octokit::Client do
   describe "#rate_limit!", :vcr => { cassette_name: "rate_limit" } do
     it "makes a web request to check the rate limit" do
       rate = client.rate_limit!
-      expect(rate.limit).to be_kind_of Fixnum
-      expect(rate.remaining).to be_kind_of Fixnum
+      expect(rate.limit).to be_kind_of Integer
+      expect(rate.remaining).to be_kind_of Integer
       expect(rate.resets_at).to be_kind_of Time
-      expect(rate.resets_in).to be_kind_of Fixnum
+      expect(rate.resets_in).to be_kind_of Integer
     end
   end # #rate_limit!
 

--- a/spec/octokit/client/search_spec.rb
+++ b/spec/octokit/client/search_spec.rb
@@ -14,7 +14,7 @@ describe Octokit::Client::Search do
         :order => 'asc'
 
       assert_requested :get, github_url('/search/code?q=code%20user:github%20in:file%20extension:gemspec%20-repo:octokit/octokit.rb&sort=indexed&order=asc')
-      expect(results.total_count).to be_kind_of Fixnum
+      expect(results.total_count).to be_kind_of Integer
       expect(results.items).to be_kind_of Array
     end
   end # .search_code
@@ -26,7 +26,7 @@ describe Octokit::Client::Search do
         :order => 'desc'
 
       assert_requested :get, github_url('/search/issues?q=http%20author:jasonrudolph&sort=created&order=desc')
-      expect(results.total_count).to be_kind_of Fixnum
+      expect(results.total_count).to be_kind_of Integer
       expect(results.items).to be_kind_of Array
     end
   end # .search_issues
@@ -38,7 +38,7 @@ describe Octokit::Client::Search do
         :order => 'desc'
 
       assert_requested :get, github_url('/search/repositories?q=tetris%20language:assembly&sort=stars&order=desc')
-      expect(results.total_count).to be_kind_of Fixnum
+      expect(results.total_count).to be_kind_of Integer
       expect(results.items).to be_kind_of Array
     end
   end # .search_repositories
@@ -50,7 +50,7 @@ describe Octokit::Client::Search do
         :order => 'desc'
 
       assert_requested :get, github_url('/search/users?q=mike%20followers:%3E10&sort=joined&order=desc')
-      expect(results.total_count).to be_kind_of Fixnum
+      expect(results.total_count).to be_kind_of Integer
       expect(results.items).to be_kind_of Array
     end
 

--- a/spec/octokit/enterprise_admin_client/admin_stats_spec.rb
+++ b/spec/octokit/enterprise_admin_client/admin_stats_spec.rb
@@ -11,16 +11,16 @@ describe Octokit::EnterpriseAdminClient::AdminStats do
     it "returns all available enterprise stats" do
       admin_stats = @admin_client.admin_stats
 
-      expect(admin_stats.issues.total_issues).to be_kind_of Fixnum
-      expect(admin_stats.hooks.total_hooks).to be_kind_of Fixnum
-      expect(admin_stats.milestones.closed_milestones).to be_kind_of Fixnum
-      expect(admin_stats.orgs.total_team_members).to be_kind_of Fixnum
-      expect(admin_stats.comments.total_gist_comments).to be_kind_of Fixnum
-      expect(admin_stats.pages.total_pages).to be_kind_of Fixnum
-      expect(admin_stats.users.total_users).to be_kind_of Fixnum
-      expect(admin_stats.gists.private_gists).to be_kind_of Fixnum
-      expect(admin_stats.pulls.mergeable_pulls).to be_kind_of Fixnum
-      expect(admin_stats.repos.fork_repos).to be_kind_of Fixnum
+      expect(admin_stats.issues.total_issues).to be_kind_of Integer
+      expect(admin_stats.hooks.total_hooks).to be_kind_of Integer
+      expect(admin_stats.milestones.closed_milestones).to be_kind_of Integer
+      expect(admin_stats.orgs.total_team_members).to be_kind_of Integer
+      expect(admin_stats.comments.total_gist_comments).to be_kind_of Integer
+      expect(admin_stats.pages.total_pages).to be_kind_of Integer
+      expect(admin_stats.users.total_users).to be_kind_of Integer
+      expect(admin_stats.gists.private_gists).to be_kind_of Integer
+      expect(admin_stats.pulls.mergeable_pulls).to be_kind_of Integer
+      expect(admin_stats.repos.fork_repos).to be_kind_of Integer
 
       assert_requested :get, github_enterprise_url("enterprise/stats/all")
     end
@@ -30,12 +30,12 @@ describe Octokit::EnterpriseAdminClient::AdminStats do
     it "returns only repository-related stats" do
       admin_repository_stats = @admin_client.admin_repository_stats
 
-      expect(admin_repository_stats.fork_repos).to be_kind_of Fixnum
-      expect(admin_repository_stats.root_repos).to be_kind_of Fixnum
-      expect(admin_repository_stats.total_repos).to be_kind_of Fixnum
-      expect(admin_repository_stats.total_pushes).to be_kind_of Fixnum
-      expect(admin_repository_stats.org_repos).to be_kind_of Fixnum
-      expect(admin_repository_stats.total_wikis).to be_kind_of Fixnum
+      expect(admin_repository_stats.fork_repos).to be_kind_of Integer
+      expect(admin_repository_stats.root_repos).to be_kind_of Integer
+      expect(admin_repository_stats.total_repos).to be_kind_of Integer
+      expect(admin_repository_stats.total_pushes).to be_kind_of Integer
+      expect(admin_repository_stats.org_repos).to be_kind_of Integer
+      expect(admin_repository_stats.total_wikis).to be_kind_of Integer
 
       assert_requested :get, github_enterprise_url("enterprise/stats/repos")
     end
@@ -45,9 +45,9 @@ describe Octokit::EnterpriseAdminClient::AdminStats do
     it "returns only hooks-related stats" do
       admin_hooks_stats = @admin_client.admin_hooks_stats
 
-      expect(admin_hooks_stats.total_hooks).to be_kind_of Fixnum
-      expect(admin_hooks_stats.active_hooks).to be_kind_of Fixnum
-      expect(admin_hooks_stats.inactive_hooks).to be_kind_of Fixnum
+      expect(admin_hooks_stats.total_hooks).to be_kind_of Integer
+      expect(admin_hooks_stats.active_hooks).to be_kind_of Integer
+      expect(admin_hooks_stats.inactive_hooks).to be_kind_of Integer
 
       assert_requested :get, github_enterprise_url("enterprise/stats/hooks")
     end
@@ -57,7 +57,7 @@ describe Octokit::EnterpriseAdminClient::AdminStats do
     it "returns only pages-related stats" do
       admin_pages_stats = @admin_client.admin_pages_stats
 
-      expect(admin_pages_stats.total_pages).to be_kind_of Fixnum
+      expect(admin_pages_stats.total_pages).to be_kind_of Integer
 
       assert_requested :get, github_enterprise_url("enterprise/stats/pages")
     end
@@ -67,10 +67,10 @@ describe Octokit::EnterpriseAdminClient::AdminStats do
     it "returns only organization-related stats" do
       admin_organization_stats = @admin_client.admin_organization_stats
 
-      expect(admin_organization_stats.total_team_members).to be_kind_of Fixnum
-      expect(admin_organization_stats.disabled_orgs).to be_kind_of Fixnum
-      expect(admin_organization_stats.total_orgs).to be_kind_of Fixnum
-      expect(admin_organization_stats.total_teams).to be_kind_of Fixnum
+      expect(admin_organization_stats.total_team_members).to be_kind_of Integer
+      expect(admin_organization_stats.disabled_orgs).to be_kind_of Integer
+      expect(admin_organization_stats.total_orgs).to be_kind_of Integer
+      expect(admin_organization_stats.total_teams).to be_kind_of Integer
 
       assert_requested :get, github_enterprise_url("enterprise/stats/orgs")
     end
@@ -80,9 +80,9 @@ describe Octokit::EnterpriseAdminClient::AdminStats do
     it "returns only user-related stats" do
       admin_users_stats = @admin_client.admin_users_stats
 
-      expect(admin_users_stats.suspended_users).to be_kind_of Fixnum
-      expect(admin_users_stats.admin_users).to be_kind_of Fixnum
-      expect(admin_users_stats.total_users).to be_kind_of Fixnum
+      expect(admin_users_stats.suspended_users).to be_kind_of Integer
+      expect(admin_users_stats.admin_users).to be_kind_of Integer
+      expect(admin_users_stats.total_users).to be_kind_of Integer
 
       assert_requested :get, github_enterprise_url("enterprise/stats/users")
     end
@@ -92,10 +92,10 @@ describe Octokit::EnterpriseAdminClient::AdminStats do
     it "returns only pull request-related stats" do
       admin_pull_requests_stats = @admin_client.admin_pull_requests_stats
 
-      expect(admin_pull_requests_stats.mergeable_pulls).to be_kind_of Fixnum
-      expect(admin_pull_requests_stats.merged_pulls).to be_kind_of Fixnum
-      expect(admin_pull_requests_stats.unmergeable_pulls).to be_kind_of Fixnum
-      expect(admin_pull_requests_stats.total_pulls).to be_kind_of Fixnum
+      expect(admin_pull_requests_stats.mergeable_pulls).to be_kind_of Integer
+      expect(admin_pull_requests_stats.merged_pulls).to be_kind_of Integer
+      expect(admin_pull_requests_stats.unmergeable_pulls).to be_kind_of Integer
+      expect(admin_pull_requests_stats.total_pulls).to be_kind_of Integer
 
       assert_requested :get, github_enterprise_url("enterprise/stats/pulls")
     end
@@ -105,9 +105,9 @@ describe Octokit::EnterpriseAdminClient::AdminStats do
     it "returns only issue-related stats" do
       admin_issues_stats = @admin_client.admin_issues_stats
 
-      expect(admin_issues_stats.total_issues).to be_kind_of Fixnum
-      expect(admin_issues_stats.closed_issues).to be_kind_of Fixnum
-      expect(admin_issues_stats.open_issues).to be_kind_of Fixnum
+      expect(admin_issues_stats.total_issues).to be_kind_of Integer
+      expect(admin_issues_stats.closed_issues).to be_kind_of Integer
+      expect(admin_issues_stats.open_issues).to be_kind_of Integer
 
       assert_requested :get, github_enterprise_url("enterprise/stats/issues")
     end
@@ -117,9 +117,9 @@ describe Octokit::EnterpriseAdminClient::AdminStats do
     it "returns only milestone-related stats" do
       admin_milestones_stats = @admin_client.admin_milestones_stats
 
-      expect(admin_milestones_stats.closed_milestones).to be_kind_of Fixnum
-      expect(admin_milestones_stats.open_milestones).to be_kind_of Fixnum
-      expect(admin_milestones_stats.total_milestones).to be_kind_of Fixnum
+      expect(admin_milestones_stats.closed_milestones).to be_kind_of Integer
+      expect(admin_milestones_stats.open_milestones).to be_kind_of Integer
+      expect(admin_milestones_stats.total_milestones).to be_kind_of Integer
 
       assert_requested :get, github_enterprise_url("enterprise/stats/milestones")
     end
@@ -129,9 +129,9 @@ describe Octokit::EnterpriseAdminClient::AdminStats do
     it "returns only gist-related stats" do
       admin_gists_stats = @admin_client.admin_gists_stats
 
-      expect(admin_gists_stats.private_gists).to be_kind_of Fixnum
-      expect(admin_gists_stats.public_gists).to be_kind_of Fixnum
-      expect(admin_gists_stats.total_gists).to be_kind_of Fixnum
+      expect(admin_gists_stats.private_gists).to be_kind_of Integer
+      expect(admin_gists_stats.public_gists).to be_kind_of Integer
+      expect(admin_gists_stats.total_gists).to be_kind_of Integer
 
       assert_requested :get, github_enterprise_url("enterprise/stats/gists")
     end
@@ -141,10 +141,10 @@ describe Octokit::EnterpriseAdminClient::AdminStats do
     it "returns only comment-related stats" do
       admin_comments_stats = @admin_client.admin_comments_stats
 
-      expect(admin_comments_stats.total_gist_comments).to be_kind_of Fixnum
-      expect(admin_comments_stats.total_commit_comments).to be_kind_of Fixnum
-      expect(admin_comments_stats.total_pull_request_comments).to be_kind_of Fixnum
-      expect(admin_comments_stats.total_issue_comments).to be_kind_of Fixnum
+      expect(admin_comments_stats.total_gist_comments).to be_kind_of Integer
+      expect(admin_comments_stats.total_commit_comments).to be_kind_of Integer
+      expect(admin_comments_stats.total_pull_request_comments).to be_kind_of Integer
+      expect(admin_comments_stats.total_issue_comments).to be_kind_of Integer
 
       assert_requested :get, github_enterprise_url("enterprise/stats/comments")
     end

--- a/spec/octokit/enterprise_admin_client/license_spec.rb
+++ b/spec/octokit/enterprise_admin_client/license_spec.rb
@@ -11,9 +11,9 @@ describe Octokit::EnterpriseAdminClient::License do
     it "returns information about the license" do
       license = @admin_client.license_info
 
-      expect(license.seats_used).to be_kind_of Fixnum
+      expect(license.seats_used).to be_kind_of Integer
       expect(license.kind).to be_kind_of String
-      expect(license.days_until_expiration).to be_kind_of Fixnum
+      expect(license.days_until_expiration).to be_kind_of Integer
       expect(license.expire_at).to be_kind_of Time
 
       assert_requested :get, github_enterprise_url("enterprise/settings/license")

--- a/spec/octokit/gist_spec.rb
+++ b/spec/octokit/gist_spec.rb
@@ -28,7 +28,7 @@ describe Octokit::Gist do
     end
   end
 
-  context "when passed a Fixnum ID" do
+  context "when passed a Integer ID" do
     before do
       @gist = Octokit::Gist.new(12345)
     end


### PR DESCRIPTION
Fix deprecated `constant ::Fixnum`.

Ruby 2.4 unifies Fixnum and Bignum into Integer: https://bugs.ruby-lang.org/issues/12005

When I ran the following code in Ruby 2.4.0, `warning: constant ::Fixnum is deprecated` was displayed.

* ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-darwin14], MacOSX 10.10.5
```
irb(main):001:0> Octokit::Gist.from_url('https://api.github.com/gists/7e09512c9d4477d474e4')
=> /Users/aikyo/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/octokit-4.6.2/lib/octokit/gist.rb:18: warning: constant ::Fixnum is deprecated
#<Octokit::Gist:0x007ff611dd23b8 @id="gists/7e09512c9d4477d474e4">
```

This cause is that Fixnum is deprecated. So, I fixed it.

I confirmed this fixes work well on Ruby 2.4.0 and Ruby 2.3.2.
```
irb(main):001:0> Octokit::Gist.from_url('https://api.github.com/gists/7e09512c9d4477d474e4')
=> #<Octokit::Gist:0x007fe139da3e60 @id="gists/7e09512c9d4477d474e4">
```

This fix has compatibility.