### PR TITLE
Use Organization.path for organization membership method

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -641,14 +641,14 @@ module Octokit
 
       # Get an organization membership
       #
-      # @param org [String] Organization GitHub login.
+      # @param org [Integer, String] The GitHub Organization.
       # @option options [String] :user  The login of the user, otherwise authenticated user.
       # @return [Sawyer::Resource] Hash representing the organization membership.
       # @see https://developer.github.com/v3/orgs/members/#get-your-organization-membership
       # @see https://developer.github.com/v3/orgs/members/#get-organization-membership
       def organization_membership(org, options = {})
         if user = options.delete(:user)
-          get "orgs/#{org}/memberships/#{user}", options
+          get "#{Organization.path(org)}/memberships/#{user}", options
         else
           get "user/memberships/orgs/#{org}", options
         end

--- a/spec/octokit/client/organizations_spec.rb
+++ b/spec/octokit/client/organizations_spec.rb
@@ -318,6 +318,17 @@ describe Octokit::Client::Organizations do
       )
       assert_requested :get, github_url("/orgs/#{test_github_org}/memberships/#{test_github_login}")
     end
+
+    it "returns an organization membership for a given user by the orgs id" do
+      org_id = 42
+      stub_get github_url("organizations/42/memberships/#{test_github_login}")
+      @client.organization_membership(
+        org_id,
+        :user => test_github_login,
+        :accept => "application/vnd.github.moondragon+json"
+      )
+      assert_requested :get, github_url("/organizations/#{org_id}/memberships/#{test_github_login}")
+    end
   end # .organization_membership
 
   describe ".update_organization_membership", :vcr do

--- a/spec/octokit/client/organizations_spec.rb
+++ b/spec/octokit/client/organizations_spec.rb
@@ -321,7 +321,7 @@ describe Octokit::Client::Organizations do
 
     it "returns an organization membership for a given user by the orgs id" do
       org_id = 42
-      stub_get github_url("organizations/42/memberships/#{test_github_login}")
+      stub_get github_url("organizations/#{org_id}/memberships/#{test_github_login}")
       @client.organization_membership(
         org_id,
         :user => test_github_login,


### PR DESCRIPTION
Fixes the issue described by @jules2689 in https://github.com/octobox/octobox/pull/314#issuecomment-281495851.

This method uses the `Organization.path` instead of just hard coding `orgs` so that we can use the ID of an organization instead of just the login.