### PR TITLE
Handle PR Review errors

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -138,8 +138,12 @@ module Octokit
       return nil unless data.is_a?(Hash) && !Array(data[:errors]).empty?
 
       summary = "\nError summary:\n"
-      summary << data[:errors].map do |hash|
-        hash.map { |k,v| "  #{k}: #{v}" }
+      summary << data[:errors].map do |error|
+        if error.is_a? Hash
+          error.map { |k,v| "  #{k}: #{v}" }
+        else
+          "  #{error}"
+        end
       end.join("\n")
 
       summary

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -754,6 +754,7 @@ describe Octokit::Client do
         :body => {
           :message => "Validation Failed",
           :errors => [
+            "Position is invalid",
             :resource => "Issue",
             :field    => "title",
             :code     => "missing_field"
@@ -763,6 +764,7 @@ describe Octokit::Client do
         Octokit.get('/boom')
       rescue Octokit::UnprocessableEntity => e
         expect(e.message).to include("GET https://api.github.com/boom: 422 - Validation Failed")
+        expect(e.message).to include("  Position is invalid")
         expect(e.message).to include("  resource: Issue")
         expect(e.message).to include("  field: title")
         expect(e.message).to include("  code: missing_field")


### PR DESCRIPTION
When using GitHub's Reviews via API, it seems that errors that are
returned are strings, rather than hashes.

For certain requests, we're seeing errors like:
```
undefined method `map' for "Position is invalid":String Did you mean? tap
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:142:in `block in response_error_summary'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:141:in `map'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:141:in `response_error_summary'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:156:in `build_error_message'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:39:in `initialize'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:33:in `new'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:33:in `from_response'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/response/raise_error.rb:15:in `on_complete'
/app/vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/response.rb:9:in `block in call'
/app/vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
/app/vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/response.rb:8:in `call'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/middleware/follow_redirects.rb:73:in `perform_with_redirection'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/middleware/follow_redirects.rb:61:in `call'
/app/vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/rack_builder.rb:139:in `build_response'
/app/vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/connection.rb:377:in `run_request'
/app/vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/connection.rb:177:in `post'
/app/vendor/bundle/ruby/2.3.0/gems/sawyer-0.8.1/lib/sawyer/agent.rb:94:in `call'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/connection.rb:154:in `request'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/connection.rb:28:in `post'
```

and

```
undefined method `map' for "Path is invalid":String Did you mean? tap
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:142:in `block in response_error_summary'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:141:in `map'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:141:in `response_error_summary'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:156:in `build_error_message'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:39:in `initialize'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:33:in `new'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/error.rb:33:in `from_response'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/response/raise_error.rb:15:in `on_complete'
/app/vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/response.rb:9:in `block in call'
/app/vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
/app/vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/response.rb:8:in `call'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/middleware/follow_redirects.rb:73:in `perform_with_redirection'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/middleware/follow_redirects.rb:61:in `call'
/app/vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/rack_builder.rb:139:in `build_response'
/app/vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/connection.rb:377:in `run_request'
/app/vendor/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday/connection.rb:177:in `post'
/app/vendor/bundle/ruby/2.3.0/gems/sawyer-0.8.1/lib/sawyer/agent.rb:94:in `call'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/connection.rb:154:in `request'
/app/vendor/bundle/ruby/2.3.0/gems/octokit-4.6.2/lib/octokit/connection.rb:28:in `post'
```