### PR TITLE
Make to understandable error message when `Octokit::Repository.new`is failed

### DIFF
--- a/lib/octokit/repository.rb
+++ b/lib/octokit/repository.rb
@@ -31,10 +31,10 @@ module Octokit
         @name = repo[:repo] || repo[:name]
         @owner = repo[:owner] || repo[:user] || repo[:username]
       else
-        raise_invalid_repository!
+        raise_invalid_repository!(repo)
       end
       if @owner && @name
-        validate_owner_and_name!
+        validate_owner_and_name!(repo)
       end
     end
 
@@ -80,14 +80,14 @@ module Octokit
 
     private
 
-      def validate_owner_and_name!
+      def validate_owner_and_name!(repo)
         if @owner.include?('/') || @name.include?('/') || !url.match(URI::ABS_URI)
-          raise_invalid_repository!
+          raise_invalid_repository!(repo)
         end
       end
 
-      def raise_invalid_repository!
-        raise Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+      def raise_invalid_repository!(repo)
+        raise Octokit::InvalidRepository, "#{repo.inspect} is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
       end
   end
 end

--- a/lib/octokit/repository.rb
+++ b/lib/octokit/repository.rb
@@ -87,7 +87,9 @@ module Octokit
       end
 
       def raise_invalid_repository!(repo)
-        raise Octokit::InvalidRepository, "#{repo.inspect} is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
+        msg = "#{repo.inspect} is invalid as a repository identifier. " +
+              "Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys."
+        raise Octokit::InvalidRepository, msg
       end
   end
 end

--- a/spec/octokit/repository_spec.rb
+++ b/spec/octokit/repository_spec.rb
@@ -30,42 +30,42 @@ describe Octokit::Repository do
   context "when passed a string without a slash" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new('raise-error') }.
-        to raise_error Octokit::InvalidRepository, '"raise-error" is invalid as a repository identifier. Use repo/user, an Integer or a Hash.'
+        to raise_error Octokit::InvalidRepository, '"raise-error" is invalid as a repository identifier. Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys.'
     end
   end
 
   context "when passed a string with more than 1 slash" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new('more_than/one/slash') }.
-        to raise_error Octokit::InvalidRepository, '"more_than/one/slash" is invalid as a repository identifier. Use repo/user, an Integer or a Hash.'
+        to raise_error Octokit::InvalidRepository, '"more_than/one/slash" is invalid as a repository identifier. Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys.'
     end
   end
 
   context "when passed an invalid path" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new('invalid / path') }.
-        to raise_error Octokit::InvalidRepository, '"invalid / path" is invalid as a repository identifier. Use repo/user, an Integer or a Hash.'
+        to raise_error Octokit::InvalidRepository, '"invalid / path" is invalid as a repository identifier. Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys.'
     end
   end
 
   context "when passed a boolean true" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new(true) }.
-        to raise_error Octokit::InvalidRepository, "true is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
+        to raise_error Octokit::InvalidRepository, "true is invalid as a repository identifier. Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys."
     end
   end
 
   context "when passed a boolean false" do
     it "false raises ArgumentError" do
       expect { Octokit::Repository.new(false) }.
-        to raise_error Octokit::InvalidRepository, "false is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
+        to raise_error Octokit::InvalidRepository, "false is invalid as a repository identifier. Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys."
     end
   end
 
   context "when passed nil" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new(nil) }.
-        to raise_error Octokit::InvalidRepository, "nil is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
+        to raise_error Octokit::InvalidRepository, "nil is invalid as a repository identifier. Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys."
     end
   end
 
@@ -118,28 +118,28 @@ describe Octokit::Repository do
   context "when passed a hash with invalid username" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new({:username => 'invalid username!', :name => 'octokit'}) }.
-        to raise_error Octokit::InvalidRepository, "#{{:username => 'invalid username!', :name => 'octokit'}.inspect} is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
+        to raise_error Octokit::InvalidRepository, "#{{:username => 'invalid username!', :name => 'octokit'}.inspect} is invalid as a repository identifier. Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys."
     end
   end
 
   context "when passed a hash with a username that contains a slash" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new({:username => 'invalid/username', :name => 'octokit'}) }.
-        to raise_error Octokit::InvalidRepository, "#{{:username => 'invalid/username', :name => 'octokit'}.inspect} is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
+        to raise_error Octokit::InvalidRepository, "#{{:username => 'invalid/username', :name => 'octokit'}.inspect} is invalid as a repository identifier. Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys."
     end
   end
 
   context "when passed a hash with invalid repo" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new({:username => 'sferik', :name => 'invalid repo!'}) }.
-        to raise_error Octokit::InvalidRepository, "#{{:username => 'sferik', :name => 'invalid repo!'}.inspect} is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
+        to raise_error Octokit::InvalidRepository, "#{{:username => 'sferik', :name => 'invalid repo!'}.inspect} is invalid as a repository identifier. Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys."
     end
   end
 
   context "when passed a hash with a repo that contains a slash" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new({:username => 'sferik', :name => 'invalid/repo'}) }.
-        to raise_error Octokit::InvalidRepository, "#{{:username => 'sferik', :name => 'invalid/repo'}.inspect} is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
+        to raise_error Octokit::InvalidRepository, "#{{:username => 'sferik', :name => 'invalid/repo'}.inspect} is invalid as a repository identifier. Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys."
     end
   end
 
@@ -173,7 +173,7 @@ describe Octokit::Repository do
 
     it "raises InvalidRepository error for unsupported url" do
       expect { Octokit::Repository.new("https://api.github.com/gists/0083ae") }.
-        to raise_error Octokit::InvalidRepository, '"https://api.github.com/gists/0083ae" is invalid as a repository identifier. Use repo/user, an Integer or a Hash.'
+        to raise_error Octokit::InvalidRepository, '"https://api.github.com/gists/0083ae" is invalid as a repository identifier. Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys.'
     end
   end
 end

--- a/spec/octokit/repository_spec.rb
+++ b/spec/octokit/repository_spec.rb
@@ -30,42 +30,42 @@ describe Octokit::Repository do
   context "when passed a string without a slash" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new('raise-error') }.
-        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, '"raise-error" is invalid as a repository identifier. Use repo/user, an Integer or a Hash.'
     end
   end
 
   context "when passed a string with more than 1 slash" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new('more_than/one/slash') }.
-        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, '"more_than/one/slash" is invalid as a repository identifier. Use repo/user, an Integer or a Hash.'
     end
   end
 
   context "when passed an invalid path" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new('invalid / path') }.
-        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, '"invalid / path" is invalid as a repository identifier. Use repo/user, an Integer or a Hash.'
     end
   end
 
   context "when passed a boolean true" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new(true) }.
-        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, "true is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
     end
   end
 
   context "when passed a boolean false" do
     it "false raises ArgumentError" do
       expect { Octokit::Repository.new(false) }.
-        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, "false is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
     end
   end
 
   context "when passed nil" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new(nil) }.
-        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, "nil is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
     end
   end
 
@@ -118,28 +118,28 @@ describe Octokit::Repository do
   context "when passed a hash with invalid username" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new({:username => 'invalid username!', :name => 'octokit'}) }.
-        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, "#{{:username => 'invalid username!', :name => 'octokit'}.inspect} is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
     end
   end
 
   context "when passed a hash with a username that contains a slash" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new({:username => 'invalid/username', :name => 'octokit'}) }.
-        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, "#{{:username => 'invalid/username', :name => 'octokit'}.inspect} is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
     end
   end
 
   context "when passed a hash with invalid repo" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new({:username => 'sferik', :name => 'invalid repo!'}) }.
-        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, "#{{:username => 'sferik', :name => 'invalid repo!'}.inspect} is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
     end
   end
 
   context "when passed a hash with a repo that contains a slash" do
     it "raises ArgumentError" do
       expect { Octokit::Repository.new({:username => 'sferik', :name => 'invalid/repo'}) }.
-        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, "#{{:username => 'sferik', :name => 'invalid/repo'}.inspect} is invalid as a repository identifier. Use repo/user, an Integer or a Hash."
     end
   end
 
@@ -173,7 +173,7 @@ describe Octokit::Repository do
 
     it "raises InvalidRepository error for unsupported url" do
       expect { Octokit::Repository.new("https://api.github.com/gists/0083ae") }.
-        to raise_error Octokit::InvalidRepository, "Invalid Repository. Use user/repo format."
+        to raise_error Octokit::InvalidRepository, '"https://api.github.com/gists/0083ae" is invalid as a repository identifier. Use repo/user, an Integer or a Hash.'
     end
   end
 end


### PR DESCRIPTION


Note: Test cases for this PR is failed now. It will be fixed if #876 was merged.

Currently, an error message of `Octokit::Repository.new` is unkind.

For example:

```ruby
Octokit::Repository.new(nil) # => Octokit::InvalidRepository: Invalid Repository. Use user/repo format.
```

If an user want to pass an id(Integer), this message is wrong for the user. Because the user doesn't expect the `user/repo` format.

This change improves the error message.
So, this change makes debugging easier.