### PR TITLE
Fix incorrect mimetype for integrations in PREVIEW_TYPES

### DIFF
--- a/lib/octokit/preview.rb
+++ b/lib/octokit/preview.rb
@@ -16,7 +16,7 @@ module Octokit
       :traffic                => 'application/vnd.github.spiderman-preview'.freeze,
       :org_membership         => 'application/vnd.github.korra-preview'.freeze,
       :reviews                => 'application/vnd.github.black-cat-preview'.freeze,
-      :integrations           => 'Accept: application/vnd.github.machine-man-preview+json'.freeze
+      :integrations           => 'application/vnd.github.machine-man-preview+json'.freeze
     }
 
     def ensure_api_media_type(type, options)


### PR DESCRIPTION
Just a small fix related to the new *Integrations*.