### PR TITLE
Do not add an empty commit_message in the merge_pull_request api call

### DIFF
--- a/lib/octokit/client/pull_requests.rb
+++ b/lib/octokit/client/pull_requests.rb
@@ -282,7 +282,8 @@ module Octokit
       # @param commit_message [String] Optional commit message for the merge commit
       # @return [Array<Sawyer::Resource>] Merge commit info if successful
       def merge_pull_request(repo, number, commit_message='', options = {})
-        put "#{Repository.path repo}/pulls/#{number}/merge", options.merge({:commit_message => commit_message})
+        options = options.merge(commit_message: commit_message) unless commit_message.nil?
+        put "#{Repository.path repo}/pulls/#{number}/merge", options
       end
 
       # Check pull request merge status

--- a/spec/octokit/client/pull_requests_spec.rb
+++ b/spec/octokit/client/pull_requests_spec.rb
@@ -142,8 +142,14 @@ describe Octokit::Client::PullRequests do
   # stub this so we don't have to set up new fixture data
   describe ".merge_pull_request" do
     it "merges the pull request" do
-      request = stub_put(github_url("/repos/api-playground/api-sandbox/pulls/123/merge"))
+      request = stub_put(github_url("/repos/api-playground/api-sandbox/pulls/123/merge")).with(:body => {:commit_message=>''})
       @client.merge_pull_request("api-playground/api-sandbox", 123)
+      assert_requested request
+    end
+
+    it "merges the pull request without commit_message" do
+      request = stub_put(github_url("/repos/api-playground/api-sandbox/pulls/123/merge")).with(:body => {})
+      @client.merge_pull_request("api-playground/api-sandbox", 123, nil)
       assert_requested request
     end
   end # .merge_pull_request


### PR DESCRIPTION
If you want to squash a PR the default commit message set by GitHub is no being set because octokit always put a custom commit_message.

This patch removes the commit_message from the body if the commit message is nil.