### PR TITLE
Add the ability to populate the review request with users

### DIFF
--- a/lib/octokit/client/pull_requests.rb
+++ b/lib/octokit/client/pull_requests.rb
@@ -130,6 +130,18 @@ module Octokit
       end
       alias :pull_commits :pull_request_commits
 
+      # Populate the requested reviewers on a pull request
+      #
+      # @see https://developer.github.com/v3/pulls/review_requests/#create-a-review-request
+      # @param repo [Integer, String, Hash, Repository] A GitHub repository
+      # @param number [Integer] Number of pull request
+      # @return [Sawyer::Resource] Hash representing the new review requests
+      # @example Create Pull Request Review Request
+      #   @client.create_pull_request_review_request('octokit/octokit.rb', 21, { :reviewers => ['octokit', 'github', 'anotheruser'] })
+      def create_pull_request_review_request(repo, number, options = {})
+        post "#{Repository.path repo}/pulls#{number}/requested_reviewers", options
+      end
+
       # List pull request comments for a repository
       #
       # By default, Review Comments are ordered by ascending ID.

--- a/lib/octokit/client/pull_requests.rb
+++ b/lib/octokit/client/pull_requests.rb
@@ -139,7 +139,7 @@ module Octokit
       # @example Create Pull Request Review Request
       #   @client.create_pull_request_review_request('octokit/octokit.rb', 21, { :reviewers => ['octokit', 'github', 'anotheruser'] })
       def create_pull_request_review_request(repo, number, options = {})
-        post "#{Repository.path repo}/pulls#{number}/requested_reviewers", options
+        post "#{Repository.path repo}/pulls/#{number}/requested_reviewers", options
       end
 
       # List pull request comments for a repository


### PR DESCRIPTION
I had the need to automatically assign review_requests when users missed it, in order to do that I added that one method to the client.

Not sure how to properly do a spec for this so I did leave that out if this is of interest to the maintainer(s).