### PR TITLE
Expose response_headers and response_body on error objects

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -103,6 +103,20 @@ module Octokit
       @response[:status]
     end
 
+    # Headers returned by the GitHub server.
+    #
+    # @return [Hash]
+    def response_headers
+      @response[:response_headers]
+    end
+
+    # Body returned by the GitHub server.
+    #
+    # @return [String]
+    def response_body
+      @response[:body]
+    end
+
     private
 
     def data

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -918,6 +918,36 @@ describe Octokit::Client do
         expect(e.response_status).to eql 422
       end
     end
+
+    it "exposes the response headers" do
+      stub_get('/boom').
+        to_return \
+        :status => 422,
+        :headers => {
+          :content_type => "application/json",
+        },
+        :body => {:error => "No repository found for hubtopic"}.to_json
+      begin
+        Octokit.get('/boom')
+      rescue Octokit::UnprocessableEntity => e
+        expect(e.response_headers).to eql({ "content-type" => "application/json" })
+      end
+    end
+
+    it "exposes the response body" do
+      stub_get('/boom').
+        to_return \
+        :status => 422,
+        :headers => {
+          :content_type => "application/json",
+        },
+        :body => {:error => "No repository found for hubtopic"}.to_json
+      begin
+        Octokit.get('/boom')
+      rescue Octokit::UnprocessableEntity => e
+        expect(e.response_body).to eql({:error => "No repository found for hubtopic"}.to_json)
+      end
+    end
   end
 
   it "knows the difference between unauthorized and needs OTP" do


### PR DESCRIPTION
Previously, the only way to get at these was with `error.instance_variable_get(:@response)`, which is grim.