### PR TITLE
Add app user endpoints

### DIFF
--- a/lib/octokit/client/apps.rb
+++ b/lib/octokit/client/apps.rb
@@ -134,6 +134,31 @@ module Octokit
         )
         remove_repository_from_app_installation(installation, repo, options)
       end
+
+      # List installations for user
+      #
+      # @param options [Hash] An customizable set of options
+      #
+      # @see https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/identifying-users-for-github-apps/
+      #
+      # @return [Array<Sawyer::Resource>] A list of installations
+      def find_installations_for_user(options = {})
+        opts = ensure_api_media_type(:integrations, options)
+        paginate "/user/installations", opts
+      end
+
+      # List repositories accessible to the user for an installation
+      #
+      # @param installation [Integer] The id of a a GitHub App Installation
+      # @param options [Hash] An customizable set of options
+      #
+      # @see https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/identifying-users-for-github-apps/
+      #
+      # @return [Array<Sawyer::Resource>] A list of repositories
+      def find_installation_repositories_for_user(installation, options = {})
+        opts = ensure_api_media_type(:integrations, options)
+        paginate "/user/installations/#{installation}/repositories", opts
+      end
     end
   end
 end

--- a/spec/octokit/client/apps_spec.rb
+++ b/spec/octokit/client/apps_spec.rb
@@ -30,6 +30,15 @@ describe Octokit::Client::Apps do
     end
   end # .find_app_installations
 
+  describe ".find_installations_for_user", :vcr do
+    it "returns installations for a user" do
+      pending
+      installations = @jwt_client.find_installations_for_user
+      expect(installations).to be_kind_of Array
+      assert_requested :get, github_url("/user/installations")
+    end
+  end # .find_installations_for_user
+
   context "with app installation", :vcr do
     let(:installation) { test_github_integration_installation }
 
@@ -40,6 +49,15 @@ describe Octokit::Client::Apps do
         assert_requested :get, github_url("/app/installations/#{installation}")
       end
     end # .installation
+
+    describe ".find_installation_repositories_for_user", :vcr do
+      it "returns repositories for a user" do
+        pending
+        repositories = @jwt_client.find_installation_repositories_for_user(installation)
+        expect(repositories).to be_kind_of Array
+        assert_requested :get, github_url("/user/installations")
+      end
+    end # .find_installation_repositories_for_user
 
     describe ".create_integration_installation_access_token" do
       it "creates an access token for the installation" do


### PR DESCRIPTION
I debated putting these into a new `client/app_user`, but wanted to see what others thought first.

Will add VCR once we're settled, since it requires a lot of setup as far as I can see.