### PR TITLE
Remove Ruby 2.0 and 2.1 from Travis CI Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ language: ruby
 rvm:
   - jruby
   - rbx-2
-  - 2.0
-  - 2.1
   - 2.2
-  - 2.3.3
+  - 2.3.4
   - 2.4.1
 
 bundler_args: --without development


### PR DESCRIPTION
Currently [Rubies 2.2 - 2.4 are currently supported](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/) in any capacity, so I removed non supported ruby versions from the test matrix.