### PR TITLE
Delete docs for defunct options for marking thread as read

### DIFF
--- a/lib/octokit/client/notifications.rb
+++ b/lib/octokit/client/notifications.rb
@@ -108,10 +108,6 @@ module Octokit
       # Mark thread as read
       #
       # @param thread_id [Integer] Id of the thread to update.
-      # @param options [Hash] Optional parameters.
-      # @option options [Boolean] :unread Changes the unread status of the
-      #   threads.
-      # @option options [Boolean] :read Inverse of 'unread'.
       # @return [Boolean] True if updated, false otherwise.
       # @see https://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read
       # @example


### PR DESCRIPTION
As per the [https://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read](https://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read), this endpoint no longer recognises any options passed to it.

@andrew and I attempted to change a notification's unread status, via the optional argument, but this was not possible.