### PR TITLE
Fix update_pull_request

### DIFF
--- a/spec/octokit/client/pull_requests_spec.rb
+++ b/spec/octokit/client/pull_requests_spec.rb
@@ -62,8 +62,12 @@ describe Octokit::Client::PullRequests do
 
     describe ".update_pull_request", :vcr do
       it "updates a pull request" do
-        @client.update_pull_request(@test_repo, @pull.number, 'New title', 'Updated body')
+        expected_body = 'Updated body'
+        expected_title = 'New title'
+        pull = @client.update_pull_request(@test_repo, @pull.number, expected_title, expected_body)
         assert_requested :patch, github_url("/repos/#{@test_repo}/pulls/#{@pull.number}")
+        expect(pull.body).to eq(expected_body)
+        expect(pull.title).to eq(expected_title)
       end
     end # .update_pull_request
 


### PR DESCRIPTION
```
Coverage report generated for RSpec to /Users/fchazal/flochaz/octokit.rb/coverage. 1303 / 2330 LOC (55.92%) covered.
[Coveralls] Outside the CI environment, not sending data.
15159-fchazal:octokit.rb fchazal$ rspec spec/octokit/client/pull_requests_spec.rb

Randomized with seed 46315
...............F...

Failures:

  1) Octokit::Client::PullRequests methods that require a new pull .update_pull_request updates a pull request
     Failure/Error: expect(pull.body).to eq(expected_body)

       expected: "Updated body"
            got: "The Body"

       (compared using ==)
     # ./spec/octokit/client/pull_requests_spec.rb:69:in `block (4 levels) in <top (required)>'

Finished in 1.07 seconds (files took 0.6772 seconds to load)
19 examples, 1 failure

Failed examples:

rspec ./spec/octokit/client/pull_requests_spec.rb:64 # Octokit::Client::PullRequests methods that require a new pull .update_pull_request updates a pull request

Randomized with seed 46315

Coverage report generated for RSpec to /Users/fchazal/flochaz/octokit.rb/coverage. 1303 / 2330 LOC (55.92%) covered.
[Coveralls] Outside the CI environment, not sending data.
```