### PR TITLE
Update required option for `protect_branch` method

### DIFF
--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -515,7 +515,7 @@ module Octokit
       # @param repo [Integer, String, Hash, Repository] A GitHub repository.
       # @param branch [String] Branch name
       # @option options [Hash] :required_status_checks If not null, the following keys are required:  
-      #   <tt>:include_admins [boolean] Enforce required status checks for repository administrators.</tt>  
+      #   <tt>:enforce_admins [boolean] Enforce required status checks for repository administrators.</tt>  
       #   <tt>:strict [boolean] Require branches to be up to date before merging.</tt>  
       #   <tt>:contexts [Array] The list of status checks to require in order to merge into this branch</tt>  
       #


### PR DESCRIPTION
This documentation seems to be out of date as of our latest upgrade to Github Enterprise. 

Based on these docs (https://developer.github.com/enterprise/2.11/v3/repos/branches/#update-branch-protection) and local testing the required option is now called `enforce_admins`.

### Latest Docs
<img width="650" alt="screen shot 2017-10-05 at 11 29 29 am" src="https://user-images.githubusercontent.com/48065/31245878-863aeaa6-a9c0-11e7-81b6-9c699d1cbc47.png">

### Our Error
```
[Execute release_branch:create_and_push] Octokit::UnprocessableEntity: PUT https://git.musta.ch/api/v3/repos/airbnb/apps/branches/ios-release-17.41/protection: 422 - Invalid request.

"enforce_admins" wasn't supplied. // See: https://developer.github.com/enterprise/2.11/v3/repos/branches/#update-branch-protection

Stacktrace:
/mnt/TeamCity/agents/buildAgent/work/8e63ecc810b1f294/android/vendor/bundle/ruby/2.3.0/gems/octokit-4.7.0/lib/octokit/response/raise_error.rb:16:in `on_complete'
/mnt/TeamCity/agents/buildAgent/work/8e63ecc810b1f294/android/vendor/bundle/ruby/2.3.0/gems/faraday-0.13.1/lib/faraday/response.rb:9:in `block in call'
/mnt/TeamCity/agents/buildAgent/work/8e63ecc810b1f294/android/vendor/bundle/ruby/2.3.0/gems/faraday-0.13.1/lib/faraday/response.rb:61:in `on_complete'
/mnt/TeamCity/agents/buildAgent/work/8e63ecc810b1f294/android/vendor/bundle/ruby/2.3.0/gems/faraday-0.13.1/lib/faraday/response.rb:8:in `call'
/mnt/TeamCity/agents/buildAgent/work/8e63ecc810b1f294/android/vendor/bundle/ruby/2.3.0/gems/octokit-4.7.0/lib/octokit/middleware/follow_redirects.rb:73:in `perform_with_redirection'
/mnt/TeamCity/agents/buildAgent/work/8e63ecc810b1f294/android/vendor/bundle/ruby/2.3.0/gems/octokit-4.7.0/lib/octokit/middleware/follow_redirects.rb:61:in `call'
/mnt/TeamCity/agents/buildAgent/work/8e63ecc810b1f294/android/vendor/bundle/ruby/2.3.0/gems/faraday-0.13.1/lib/faraday/rack_builder.rb:141:in `build_response'
/mnt/TeamCity/agents/buildAgent/work/8e63ecc810b1f294/android/vendor/bundle/ruby/2.3.0/gems/faraday-0.13.1/lib/faraday/connection.rb:387:in `run_request'
/mnt/TeamCity/agents/buildAgent/work/8e63ecc810b1f294/android/vendor/bundle/ruby/2.3.0/gems/faraday-0.13.1/lib/faraday/connection.rb:174:in `put'
/mnt/TeamCity/agents/buildAgent/work/8e63ecc810b1f294/android/vendor/bundle/ruby/2.3.0/gems/sawyer-0.8.1/lib/sawyer/agent.rb:94:in `call'
/mnt/TeamCity/agents/buildAgent/work/8e63ecc810b1f294/android/vendor/bundle/ruby/2.3.0/gems/octokit-4.7.0/lib/octokit/connection.rb:156:in `request'
/mnt/TeamCity/agents/buildAgent/work/8e63ecc810b1f294/android/vendor/bundle/ruby/2.3.0/gems/octokit-4.7.0/lib/octokit/connection.rb:37:in `put'
/mnt/TeamCity/agents/buildAgent/work/8e63ecc810b1f294/android/vendor/bundle/ruby/2.3.0/gems/octokit-4.7.0/lib/octokit/client/repositories.rb:536:in `protect_branch'
```
