### PR TITLE
Update docs to indicate Ruby < 2.2 not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,8 +653,6 @@ when writing new specs.
 This library aims to support and is [tested against][travis] the following Ruby
 implementations:
 
-* Ruby 2.0
-* Ruby 2.1
 * Ruby 2.2
 * Ruby 2.3
 * Ruby 2.4


### PR DESCRIPTION
#924 dropped testing against Ruby 2.0 and 2.1, but the README still claimed that these versions were supported. In fact, a project I was building on Travis with Ruby 2.0.0 stopped working:

```
$ gem install octokit netrc
YAML safe loading is not available. Please upgrade psych to a version that supports safe loading (>= 2.0).
Fetching: multipart-post-2.0.0.gem (100%)
Successfully installed multipart-post-2.0.0
Fetching: faraday-0.13.1.gem (100%)
Successfully installed faraday-0.13.1
Fetching: public_suffix-3.0.0.gem (100%)
ERROR:  Error installing octokit:
	public_suffix requires Ruby version >= 2.1.
```

Question: Should `required_ruby_version` in `octokit.gemspec` be bumped too? It's currently set to 2.0.0.

/cc @tarebyte 