### PR TITLE
fixes contents method example on README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ When passing additional parameters to GET based request use the following syntax
 
  # Example: Get contents of a repository by ref
  # https://api.github.com/repos/octokit/octokit.rb/contents/path/to/file.rb?ref=some-other-branch
- client.contents(repo: 'octokit/octokit.rb', path: 'path/to/file.rb', query: {ref: 'some-other-branch'})
+ client.contents('octokit/octokit.rb', path: 'path/to/file.rb', query: {ref: 'some-other-branch'})
 
 ```
 


### PR DESCRIPTION
`contents` example seems wrong on README. 
When I try the example it gives this error;

```ruby
client.contents(repo: "octokit/octokit.rb", :path => 'lib/octokit.rb')
Octokit::NotFound: GET https://api.github.com/contents/: 404 - Not Found // See: https://developer.github.com/v3
```

As documentation indicates it should take repo as first argument.
http://www.rubydoc.info/gems/octokit/Octokit/Client/Contents#contents-instance_method

Also documentation says `options` hash should include  `path` and `ref` but example still includes `query: { ref: 'some-other-branch' }`.  Example works as it is but it is kind of inconsistent with the documentation. I am not sure which one should be fixed documentation or example, so I didn't touch.