### PR TITLE
Add Ruby 2.0 and 2.1 back into the Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 rvm:
   - jruby
   - rbx-2
+  - 2.0
+  - 2.1
   - 2.2
   - 2.3.4
   - 2.4.1


### PR DESCRIPTION
This reverts https://github.com/octokit/octokit.rb/pull/924 so that we have compatibility for the upcoming [4.8.0 release](https://github.com/octokit/octokit.rb/issues/952#issuecomment-344950058).

When we ship 5.0 we are going to officially remove support for these old versions 😄 