### PR TITLE
Get rid of preview warnings when running the tests

### DIFF
--- a/spec/octokit/client/apps_spec.rb
+++ b/spec/octokit/client/apps_spec.rb
@@ -24,7 +24,7 @@ describe Octokit::Client::Apps do
 
   describe ".find_app_installations", :vcr do
     it "returns installations for an app" do
-      installations = @jwt_client.find_app_installations
+      installations = @jwt_client.find_app_installations(accept: preview_header)
       expect(installations).to be_kind_of Array
       assert_requested :get, github_url("/app/installations")
     end
@@ -32,7 +32,7 @@ describe Octokit::Client::Apps do
 
   describe ".find_user_installations", :vcr do
     it "returns installations for a user" do
-      response = @client.find_user_installations
+      response = @client.find_user_installations(accept: preview_header)
 
       expect(response.total_count).not_to be_nil
       expect(response.installations).to be_kind_of(Array)
@@ -45,7 +45,7 @@ describe Octokit::Client::Apps do
 
     describe ".installation" do
       it "returns the installation" do
-        response = @jwt_client.installation(installation)
+        response = @jwt_client.installation(installation, accept: preview_header)
         expect(response).to be_kind_of Sawyer::Resource
         assert_requested :get, github_url("/app/installations/#{installation}")
       end
@@ -53,7 +53,7 @@ describe Octokit::Client::Apps do
 
     describe ".find_installation_repositories_for_user" do
       it "returns repositories for a user" do
-        response = @client.find_installation_repositories_for_user(installation)
+        response = @client.find_installation_repositories_for_user(installation, accept: preview_header)
         expect(response.total_count).not_to be_nil
         expect(response.repositories).to be_kind_of(Array)
         assert_requested :get, github_url("/user/installations/#{installation}/repositories")
@@ -63,7 +63,7 @@ describe Octokit::Client::Apps do
     describe ".create_integration_installation_access_token" do
       it "creates an access token for the installation" do
         allow(@jwt_client).to receive(:octokit_warn)
-        response = @jwt_client.create_integration_installation_access_token(installation)
+        response = @jwt_client.create_integration_installation_access_token(installation, accept: preview_header)
 
         expect(response).to be_kind_of(Sawyer::Resource)
         expect(response.token).not_to be_nil
@@ -76,7 +76,7 @@ describe Octokit::Client::Apps do
 
     describe ".create_app_installation_access_token" do
       it "creates an access token for the installation" do
-        response = @jwt_client.create_app_installation_access_token(installation)
+        response = @jwt_client.create_app_installation_access_token(installation, accept: preview_header)
 
         expect(response).to be_kind_of(Sawyer::Resource)
         expect(response.token).not_to be_nil
@@ -88,7 +88,7 @@ describe Octokit::Client::Apps do
 
     context "with app installation access token" do
       let(:installation_client) do
-        token = @jwt_client.create_app_installation_access_token(installation).token
+        token = @jwt_client.create_app_installation_access_token(installation, accept: preview_header).token
         use_vcr_placeholder_for(token, '<INTEGRATION_INSTALLATION_TOKEN>')
         Octokit::Client.new(:access_token => token)
       end
@@ -96,7 +96,7 @@ describe Octokit::Client::Apps do
       describe ".list_integration_installation_repositories" do
         it "lists the installations repositories" do
           allow(installation_client).to receive(:octokit_warn)
-          response = installation_client.list_integration_installation_repositories
+          response = installation_client.list_integration_installation_repositories(accept: preview_header)
           expect(response.total_count).not_to be_nil
           expect(response.repositories).to be_kind_of(Array)
           expect(installation_client).to have_received(:octokit_warn).with(/Deprecated/)
@@ -105,7 +105,7 @@ describe Octokit::Client::Apps do
 
       describe ".list_app_installation_repositories" do
         it "lists the installations repositories" do
-          response = installation_client.list_app_installation_repositories
+          response = installation_client.list_app_installation_repositories(accept: preview_header)
           expect(response.total_count).not_to be_nil
           expect(response.repositories).to be_kind_of(Array)
         end
@@ -129,7 +129,7 @@ describe Octokit::Client::Apps do
       describe ".add_repository_to_integration_installation" do
         it "adds the repository to the installation" do
           allow(@client).to receive(:octokit_warn)
-          response = @client.add_repository_to_integration_installation(installation, @repo.id)
+          response = @client.add_repository_to_integration_installation(installation, @repo.id, accept: preview_header)
           expect(response).to be_truthy
           expect(@client).to have_received(:octokit_warn).with(/Deprecated/)
         end
@@ -137,20 +137,20 @@ describe Octokit::Client::Apps do
 
       describe ".add_repository_to_app_installation" do
         it "adds the repository to the installation" do
-          response = @client.add_repository_to_app_installation(installation, @repo.id)
+          response = @client.add_repository_to_app_installation(installation, @repo.id, accept: preview_header)
           expect(response).to be_truthy
         end
       end # .add_repository_to_app_installation
 
       context 'with installed repository on installation' do
         before(:each) do
-          @client.add_repository_to_app_installation(installation, @repo.id)
+          @client.add_repository_to_app_installation(installation, @repo.id, accept: preview_header)
         end
 
         describe ".remove_repository_from_integration_installation" do
           it "removes the repository from the installation" do
             allow(@client).to receive(:octokit_warn)
-            response = @client.remove_repository_from_integration_installation(installation, @repo.id)
+            response = @client.remove_repository_from_integration_installation(installation, @repo.id, accept: preview_header)
             expect(response).to be_truthy
             expect(@client).to have_received(:octokit_warn).with(/Deprecated/)
           end
@@ -158,11 +158,17 @@ describe Octokit::Client::Apps do
 
         describe ".remove_repository_from_app_installation" do
           it "removes the repository from the installation" do
-            response = @client.remove_repository_from_app_installation(installation, @repo.id)
+            response = @client.remove_repository_from_app_installation(installation, @repo.id, accept: preview_header)
             expect(response).to be_truthy
           end
         end # .remove_repository_from_app_installation
       end # with installed repository on installation
     end # with repository
   end # with app installation
+
+  private
+
+  def preview_header
+    Octokit::Preview::PREVIEW_TYPES[:integrations]
+  end
 end

--- a/spec/octokit/client/issues_spec.rb
+++ b/spec/octokit/client/issues_spec.rb
@@ -198,7 +198,7 @@ describe Octokit::Client::Issues do
 
       describe ".issue_timeline", :vcr do
         it "returns an issue timeline" do
-          timeline = @client.issue_timeline(@repo.full_name, @issue.number)
+          timeline = @client.issue_timeline(@repo.full_name, @issue.number, accept: Octokit::Preview::PREVIEW_TYPES[:issue_timelines])
           expect(timeline).to be_kind_of Array
           assert_requested :get, github_url("/repos/#{@repo.full_name}/issues/#{@issue.number}/timeline")
         end

--- a/spec/octokit/client/marketplace_spec.rb
+++ b/spec/octokit/client/marketplace_spec.rb
@@ -14,7 +14,7 @@ describe Octokit::Client::Marketplace do
 
   describe ".list_plans", :vcr do
     it "returns plans for a marketplace listing" do
-      plans = @jwt_client.list_plans
+      plans = @jwt_client.list_plans(accept: preview_header)
       expect(plans).to be_kind_of Array
       assert_requested :get, github_url("/marketplace_listing/plans")
     end
@@ -22,7 +22,7 @@ describe Octokit::Client::Marketplace do
 
   describe ".list_accounts_for_plan", :vcr do
     it "returns accounts for a given plan" do
-      plans = @jwt_client.list_accounts_for_plan(7)
+      plans = @jwt_client.list_accounts_for_plan(7, accept: preview_header)
       expect(plans).to be_kind_of Array
       assert_requested :get, github_url("/marketplace_listing/plans/7/accounts")
     end
@@ -30,7 +30,7 @@ describe Octokit::Client::Marketplace do
 
   describe ".plan_for_account", :vcr do
     it "returns the plan for a given account" do
-      plans = @jwt_client.plan_for_account(1)
+      plans = @jwt_client.plan_for_account(1, accept: preview_header)
       expect(plans).to be_kind_of Sawyer::Resource
       assert_requested :get, github_url("/marketplace_listing/accounts/1")
     end
@@ -38,9 +38,15 @@ describe Octokit::Client::Marketplace do
 
   describe ".marketplace_purchases", :vcr do
     it "returns marketplace purchases for user" do
-      plans = @client.marketplace_purchases
+      plans = @client.marketplace_purchases(accept: preview_header)
       expect(plans).to be_kind_of Array
       assert_requested :get, github_url("/user/marketplace_purchases")
     end
   end # .marketplace_purchases
+
+  private
+
+  def preview_header
+    Octokit::Preview::PREVIEW_TYPES[:marketplace]
+  end
 end

--- a/spec/octokit/client/organizations_spec.rb
+++ b/spec/octokit/client/organizations_spec.rb
@@ -149,10 +149,7 @@ describe Octokit::Client::Organizations do
 
     describe ".child_teams", :vcr do
       it "returns all child teams for the team" do
-        child_teams = @client.child_teams(
-          @team.id,
-          :accept => "application/vnd.github.hellcat-preview+json"
-        )
+        child_teams = @client.child_teams(@team.id, accept: preview_header)
         expect(child_teams).to be_kind_of Array
         assert_requested :get, github_url("/teams/#{@team.id}/teams")
       end
@@ -363,33 +360,39 @@ describe Octokit::Client::Organizations do
 
   describe ".migrations", :vcr do
     it "starts a migration for an organization" do
-      result = @client.start_migration(test_github_org, ["github-api/api-playground"])
+      result = @client.start_migration(test_github_org, ["github-api/api-playground"], accept: preview_header)
       expect(result).to be_kind_of Sawyer::Resource
       assert_requested :post, github_url("/orgs/#{test_github_org}/migrations")
     end
 
     it "lists migrations for an organization" do
-      result = @client.migrations(test_github_org)
+      result = @client.migrations(test_github_org, accept: preview_header)
       expect(result).to be_kind_of Array
       assert_requested :get, github_url("/orgs/#{test_github_org}/migrations")
     end
 
     it "gets the status of a migration" do
-      result = @client.migration_status(test_github_org, 97)
+      result = @client.migration_status(test_github_org, 97, accept: preview_header)
       expect(result).to be_kind_of Sawyer::Resource
       assert_requested :get, github_url("/orgs/#{test_github_org}/migrations/97")
     end
 
     it "downloads a migration archive" do
-      result = @client.migration_archive_url(test_github_org, 97)
+      result = @client.migration_archive_url(test_github_org, 97, accept: preview_header)
       expect(result).to be_kind_of String
       assert_requested :get, github_url("/orgs/#{test_github_org}/migrations/97/archive")
     end
 
     it "unlocks a migrated repository" do
-      @client.unlock_repository(test_github_org, 97, 'api-playground')
+      @client.unlock_repository(test_github_org, 97, 'api-playground', accept: preview_header)
       expect(@client.last_response.status).to eq(204)
       assert_requested :delete, github_url("/orgs/#{test_github_org}/migrations/97/repos/api-playground/lock")
     end
   end # .migrations
+
+  private
+
+  def preview_header
+    Octokit::Preview::PREVIEW_TYPES[:migrations]
+  end
 end

--- a/spec/octokit/client/pages_spec.rb
+++ b/spec/octokit/client/pages_spec.rb
@@ -18,7 +18,7 @@ describe Octokit::Client::Pages do
   describe ".pages_build", :vcr do
     # Grabbed this build ID manually from pages_builds
     it "lists a specific page build" do
-      build = @client.pages_build(@test_repo, 40071035)
+      build = @client.pages_build(@test_repo, 40071035, accept: preview_header)
       expect(build.status).not_to be_nil
       assert_requested :get, github_url("/repos/#{@test_repo}/pages/builds/40071035")
     end
@@ -46,9 +46,15 @@ describe Octokit::Client::Pages do
     # This test requires some manual setup in your test repository,
     # ensure it has pages site enabled and setup.
     it "requests a build for the latest revision" do
-      request = @client.request_page_build(@test_repo)
+      request = @client.request_page_build(@test_repo, accept: preview_header)
       expect(request.status).not_to be_nil
       assert_requested :post, github_url("/repos/#{@test_repo}/pages/builds")
     end
   end # .request_page_build
+
+  private
+
+  def preview_header
+    Octokit::Preview::PREVIEW_TYPES[:pages]
+  end
 end

--- a/spec/octokit/client/projects_spec.rb
+++ b/spec/octokit/client/projects_spec.rb
@@ -4,7 +4,7 @@ describe Octokit::Client::Projects do
 
   describe ".projects", :vcr do
     it "returns a list of projects for a repository" do
-      projects = oauth_client.projects('octokit/octokit.rb')
+      projects = oauth_client.projects('octokit/octokit.rb', accept: preview_header)
       expect(projects).to be_kind_of Array
       assert_requested :get, github_url("/repos/octokit/octokit.rb/projects")
     end
@@ -12,7 +12,7 @@ describe Octokit::Client::Projects do
 
   describe ".create_project", :vcr do
     it "returns the newly created project" do
-      project = oauth_client.create_project(@test_repo, "api kpi")
+      project = oauth_client.create_project(@test_repo, "api kpi", accept: preview_header)
       expect(project.name).to eq("api kpi")
       assert_requested :post, github_url("/repos/#{@test_repo}/projects")
     end
@@ -20,7 +20,7 @@ describe Octokit::Client::Projects do
 
   describe ".org_projects", :vcr do
     it "returns the projects for an organization" do
-      projects = oauth_client.org_projects(test_github_org)
+      projects = oauth_client.org_projects(test_github_org, accept: preview_header)
       expect(projects).to be_kind_of Array
       assert_requested :get, github_url("/orgs/#{test_github_org}/projects")
     end
@@ -28,7 +28,7 @@ describe Octokit::Client::Projects do
 
   describe ".create_org_project", :vcr do
     it "returns the new org project" do
-      project = oauth_client.create_org_project(test_github_org, "synergy", body: "do it")
+      project = oauth_client.create_org_project(test_github_org, "synergy", body: "do it", accept: preview_header)
       expect(project.name).to eq "synergy"
       expect(project.body).to eq "do it"
       assert_requested :post, github_url("/orgs/#{test_github_org}/projects")
@@ -46,12 +46,12 @@ describe Octokit::Client::Projects do
 
     context "with project" do
       before(:each) do
-        @project = oauth_client.create_project(@test_repo, "implement apis")
+        @project = oauth_client.create_project(@test_repo, "implement apis", accept: preview_header)
       end
 
       describe ".project", :vcr do
         it "returns a project" do
-          project = oauth_client.project(@project.id)
+          project = oauth_client.project(@project.id, accept: preview_header)
           expect(project.name).not_to be_nil
           assert_requested :get, github_url("/projects/#{@project.id}")
         end
@@ -61,7 +61,7 @@ describe Octokit::Client::Projects do
         it "updates the project name and body then returns the updated project" do
           name = "new name"
           body = "new body"
-          project = oauth_client.update_project(@project.id, {name: name, body: body})
+          project = oauth_client.update_project(@project.id, {name: name, body: body, accept: preview_header})
           expect(project.name).to eq name
           expect(project.body).to eq body
           assert_requested :patch, github_url("/projects/#{@project.id}")
@@ -70,7 +70,7 @@ describe Octokit::Client::Projects do
 
       describe ".delete_project", :vcr do
         it "returns the result of deleting a project" do
-          result = oauth_client.delete_project(@project.id)
+          result = oauth_client.delete_project(@project.id, accept: preview_header)
           expect(result).to eq true
           assert_requested :delete, github_url("/projects/#{@project.id}")
         end
@@ -78,7 +78,7 @@ describe Octokit::Client::Projects do
 
       describe ".project_columns", :vcr do
         it "returns the columns for a project" do
-          columns = oauth_client.project_columns(@project.id)
+          columns = oauth_client.project_columns(@project.id, accept: preview_header)
           expect(columns).to be_kind_of Array
           assert_requested :get, github_url("/projects/#{@project.id}/columns")
         end
@@ -86,7 +86,7 @@ describe Octokit::Client::Projects do
 
       describe ".create_project_column", :vcr do
         it "returns the newly created project column" do
-          column = oauth_client.create_project_column(@project.id, "Todos")
+          column = oauth_client.create_project_column(@project.id, "Todos", accept: preview_header)
           expect(column.name).to eq "Todos"
           assert_requested :post, github_url("/projects/#{@project.id}/columns")
         end
@@ -94,12 +94,12 @@ describe Octokit::Client::Projects do
 
       context "with project column" do
         before(:each) do
-          @column = oauth_client.create_project_column(@project.id, "Todos #{Time.now.to_f}")
+          @column = oauth_client.create_project_column(@project.id, "Todos #{Time.now.to_f}", accept: preview_header)
         end
 
         describe ".project_column", :vcr do
           it "returns a project column by id" do
-            column = oauth_client.project_column(@column.id)
+            column = oauth_client.project_column(@column.id, accept: preview_header)
             expect(column.name).to be_kind_of String
             assert_requested :get, github_url("/projects/columns/#{@column.id}")
           end
@@ -107,7 +107,7 @@ describe Octokit::Client::Projects do
 
         describe ".update_project_column", :vcr do
           it "updates the project column and returns the updated column" do
-            column = oauth_client.update_project_column(@column.id, "new name")
+            column = oauth_client.update_project_column(@column.id, "new name", accept: preview_header)
             expect(column.name).to eq "new name"
             assert_requested :patch, github_url("/projects/columns/#{@column.id}")
           end
@@ -115,7 +115,7 @@ describe Octokit::Client::Projects do
 
         describe ".move_project_column", :vcr do
           it "moves the project column" do
-            result = oauth_client.move_project_column(@column.id, "last")
+            result = oauth_client.move_project_column(@column.id, "last", accept: preview_header)
             expect(result).not_to be_nil
             assert_requested :post, github_url("/projects/columns/#{@column.id}/moves")
           end
@@ -123,7 +123,7 @@ describe Octokit::Client::Projects do
 
         describe ".delete_project_column", :vcr do
           it "deletes the project column" do
-            result = oauth_client.delete_project_column(@column.id)
+            result = oauth_client.delete_project_column(@column.id, accept: preview_header)
             expect(result).to eq true
             assert_requested :delete, github_url("/projects/columns/#{@column.id}")
           end
@@ -131,7 +131,7 @@ describe Octokit::Client::Projects do
 
         describe ".column_cards", :vcr do
           it "returns a list of the cards in a project column" do
-            cards = oauth_client.column_cards(@column.id)
+            cards = oauth_client.column_cards(@column.id, accept: preview_header)
             expect(cards).to be_kind_of Array
             assert_requested :get, github_url("/projects/columns/#{@column.id}/cards")
           end
@@ -139,7 +139,7 @@ describe Octokit::Client::Projects do
 
         describe ".create_project_card", :vcr do
           it "creates a new card with a note" do
-            card = oauth_client.create_project_card(@column.id, note: 'thing')
+            card = oauth_client.create_project_card(@column.id, note: 'thing', accept: preview_header)
             expect(card.note).to eq 'thing'
             assert_requested :post, github_url("/projects/columns/#{@column.id}/cards")
           end
@@ -147,12 +147,12 @@ describe Octokit::Client::Projects do
 
         context "with project card" do
           before(:each) do
-            @card = oauth_client.create_project_card(@column.id, note: 'octocard')
+            @card = oauth_client.create_project_card(@column.id, note: 'octocard', accept: preview_header)
           end
 
           describe ".project_card", :vcr do
             it "returns a project card by id" do
-              card = oauth_client.project_card(@card.id)
+              card = oauth_client.project_card(@card.id, accept: preview_header)
               expect(card.note).to be_kind_of String
               assert_requested :get, github_url("/projects/columns/cards/#{@card.id}")
             end
@@ -160,7 +160,7 @@ describe Octokit::Client::Projects do
 
           describe ".update_project_card", :vcr do
             it "updates the project card" do
-              card = oauth_client.update_project_card(@card.id, note: 'new note')
+              card = oauth_client.update_project_card(@card.id, note: 'new note', accept: preview_header)
               expect(card.note).to eq 'new note'
               assert_requested :patch, github_url("/projects/columns/cards/#{@card.id}")
             end
@@ -168,7 +168,7 @@ describe Octokit::Client::Projects do
 
           describe ".move_project_card", :vcr do
             it "moves the project card" do
-              result = oauth_client.move_project_card(@card.id, 'bottom')
+              result = oauth_client.move_project_card(@card.id, 'bottom', accept: preview_header)
               expect(result).not_to be_nil
               assert_requested :post, github_url("/projects/columns/cards/#{@card.id}/moves")
             end
@@ -176,7 +176,7 @@ describe Octokit::Client::Projects do
 
           describe ".delete_project_card", :vcr do
             it "deletes the project card" do
-              success = oauth_client.delete_project_card(@card.id)
+              success = oauth_client.delete_project_card(@card.id, accept: preview_header)
               expect(success).to eq true
               assert_requested :delete, github_url("/projects/columns/cards/#{@card.id}")
             end
@@ -186,4 +186,10 @@ describe Octokit::Client::Projects do
       end # with project column
     end # with project
   end # with repository
+
+  private
+
+  def preview_header
+    Octokit::Preview::PREVIEW_TYPES[:projects]
+  end
 end # Octokit::Client::Projects

--- a/spec/octokit/client/reactions_spec.rb
+++ b/spec/octokit/client/reactions_spec.rb
@@ -29,7 +29,7 @@ describe Octokit::Client::Reactions do
 
       describe ".commit_comment_reactions" do
         it "returns an Array of reactions" do
-          reactions = @client.commit_comment_reactions(@repo.full_name, @commit_comment.id)
+          reactions = @client.commit_comment_reactions(@repo.full_name, @commit_comment.id, accept: preview_header)
           expect(reactions).to be_kind_of Array
           assert_requested :get, github_url("/repos/#{@repo.full_name}/comments/#{@commit_comment.id}/reactions")
         end
@@ -37,7 +37,7 @@ describe Octokit::Client::Reactions do
 
       describe ".create_commit_comment_reaction" do
         it "creates a reaction" do
-          reaction = @client.create_commit_comment_reaction(@repo.full_name, @commit_comment.id, "+1")
+          reaction = @client.create_commit_comment_reaction(@repo.full_name, @commit_comment.id, "+1", accept: preview_header)
           expect(reaction.content).to eql("+1")
           assert_requested :post, github_url("/repos/#{@repo.full_name}/comments/#{@commit_comment.id}/reactions")
         end
@@ -51,7 +51,7 @@ describe Octokit::Client::Reactions do
 
       describe ".issue_reactions" do
         it "returns an Array of reactions" do
-          reactions = @client.issue_reactions(@repo.full_name, @issue.number)
+          reactions = @client.issue_reactions(@repo.full_name, @issue.number, accept: preview_header)
           expect(reactions).to be_kind_of Array
           assert_requested :get, github_url("/repos/#{@repo.full_name}/issues/#{@issue.number}/reactions")
         end
@@ -59,7 +59,7 @@ describe Octokit::Client::Reactions do
 
       describe ".create_issue_reaction" do
         it "creates a reaction" do
-          reaction = @client.create_issue_reaction(@repo.full_name, @issue.number, "+1")
+          reaction = @client.create_issue_reaction(@repo.full_name, @issue.number, "+1", accept: preview_header)
           expect(reaction.content).to eql("+1")
           assert_requested :post, github_url("/repos/#{@repo.full_name}/issues/#{@issue.number}/reactions")
         end
@@ -72,7 +72,7 @@ describe Octokit::Client::Reactions do
 
         describe ".issue_comment_reactions" do
           it "returns an Array of reactions" do
-            reactions = @client.issue_comment_reactions(@repo.full_name, @issue_comment.id)
+            reactions = @client.issue_comment_reactions(@repo.full_name, @issue_comment.id, accept: preview_header)
             expect(reactions).to be_kind_of Array
             assert_requested :get, github_url("/repos/#{@repo.full_name}/issues/comments/#{@issue_comment.id}/reactions")
           end
@@ -80,7 +80,7 @@ describe Octokit::Client::Reactions do
 
         describe ".create_issue_comment_reaction" do
           it "creates a reaction" do
-            reaction = @client.create_issue_comment_reaction(@repo.full_name, @issue_comment.id, "+1")
+            reaction = @client.create_issue_comment_reaction(@repo.full_name, @issue_comment.id, "+1", accept: preview_header)
             expect(reaction.content).to eql("+1")
             assert_requested :post, github_url("/repos/#{@repo.full_name}/issues/comments/#{@issue_comment.id}/reactions")
           end
@@ -89,12 +89,12 @@ describe Octokit::Client::Reactions do
 
       context "with reaction" do
         before do
-          @reaction = @client.create_issue_reaction(@repo.full_name, @issue.number, "+1")
+          @reaction = @client.create_issue_reaction(@repo.full_name, @issue.number, "+1", accept: preview_header)
         end
 
         describe ".delete_reaction" do
           it "deletes the reaction" do
-            @client.delete_reaction(@reaction.id)
+            @client.delete_reaction(@reaction.id, accept: preview_header)
             assert_requested :delete, github_url("/reactions/#{@reaction.id}")
           end
         end # .delete_reaction
@@ -131,7 +131,7 @@ describe Octokit::Client::Reactions do
 
         describe ".pull_request_review_comment_reactions" do
           it "returns an Array of reactions" do
-            reactions = @client.pull_request_review_comment_reactions(@repo.full_name, @pull_request_review_comment.id)
+            reactions = @client.pull_request_review_comment_reactions(@repo.full_name, @pull_request_review_comment.id, accept: preview_header)
             expect(reactions).to be_kind_of Array
             assert_requested :get, github_url("/repos/#{@repo.full_name}/pulls/comments/#{@pull_request_review_comment.id}/reactions")
           end
@@ -139,7 +139,7 @@ describe Octokit::Client::Reactions do
 
         describe ".create_pull_request_review_comment_reaction" do
           it "creates a reaction" do
-            reaction = @client.create_pull_request_review_comment_reaction(@repo.full_name, @pull_request_review_comment.id, "+1")
+            reaction = @client.create_pull_request_review_comment_reaction(@repo.full_name, @pull_request_review_comment.id, "+1", accept: preview_header)
             expect(reaction.content).to eql("+1")
             assert_requested :post, github_url("/repos/#{@repo.full_name}/pulls/comments/#{@pull_request_review_comment.id}/reactions")
           end
@@ -147,4 +147,10 @@ describe Octokit::Client::Reactions do
       end # with pull request review comment
     end # with pull request
   end # with repository
+
+  private
+
+  def preview_header
+    Octokit::Preview::PREVIEW_TYPES[:reactions]
+  end
 end

--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -183,18 +183,18 @@ describe Octokit::Client::Repositories do
 
     describe ".branch_protection", :vcr do
       it "returns nil for an unprotected branch" do
-        branch_protection = @client.branch_protection(@repo.full_name, "master")
+        branch_protection = @client.branch_protection(@repo.full_name, "master", accept: preview_header)
         expect(branch_protection).to be_nil
         assert_requested :get, github_url("/repos/#{@repo.full_name}/branches/master/protection")
       end
 
       context "with protected branch" do
         before(:each) do
-          @client.protect_branch(@repo.full_name, "master")
+          @client.protect_branch(@repo.full_name, "master", accept: preview_header)
         end
 
         it "returns branch protection summary" do
-          branch_protection = @client.branch_protection(@repo.full_name, "master")
+          branch_protection = @client.branch_protection(@repo.full_name, "master", accept: preview_header)
           expect(branch_protection).not_to be_nil
           assert_requested :get, github_url("/repos/#{@repo.full_name}/branches/master/protection")
         end
@@ -361,7 +361,7 @@ describe Octokit::Client::Repositories do
 
     describe ".protect_branch", :vcr do
       it "protects a single branch" do
-        branch = @client.protect_branch(@repo.full_name, "master")
+        branch = @client.protect_branch(@repo.full_name, "master", accept: preview_header)
         expect(branch.url).not_to be_nil
         assert_requested :put, github_url("/repos/#{@repo.full_name}/branches/master/protection")
       end
@@ -375,7 +375,7 @@ describe Octokit::Client::Repositories do
           },
           restrictions: nil
         }
-        branch = @client.protect_branch(@repo.full_name, "master", rules)
+        branch = @client.protect_branch(@repo.full_name, "master", rules.merge(accept: preview_header))
 
         expect(branch.required_status_checks.include_admins).to be true
         expect(branch.restrictions).to be_nil
@@ -385,12 +385,12 @@ describe Octokit::Client::Repositories do
 
     context "with protected branch" do
       before(:each) do
-        @client.protect_branch(@repo.full_name, "master")
+        @client.protect_branch(@repo.full_name, "master", accept: preview_header)
       end
 
       describe ".unprotect_branch", :vcr do
         it "unprotects a single branch" do
-          branch = @client.unprotect_branch(@repo.full_name, "master")
+          branch = @client.unprotect_branch(@repo.full_name, "master", accept: preview_header)
           expect(branch).to eq true
           assert_requested :delete, github_url("/repos/#{@repo.full_name}/branches/master/protection")
         end
@@ -463,4 +463,10 @@ describe Octokit::Client::Repositories do
       expect(result).to be false
     end
   end # .repository?
+
+  private
+
+  def preview_header
+    Octokit::Preview::PREVIEW_TYPES[:branch_protection]
+  end
 end

--- a/spec/octokit/client/repository_invitations_spec.rb
+++ b/spec/octokit/client/repository_invitations_spec.rb
@@ -20,14 +20,14 @@ describe Octokit::Client::RepositoryInvitations do
 
     describe ".invite_user_to_repository", :vcr do
       it "invites a user to a repository" do
-        @client.invite_user_to_repository(@repo.id, "tarebyte")
+        @client.invite_user_to_repository(@repo.id, "tarebyte", accept: preview_header)
         assert_requested :put, github_url("/repositories/#{@repo.id}/collaborators/tarebyte")
       end
     end
 
     describe ".repository_invitations", :vcr do
       it "lists the repositories outstanding invitations" do
-        invitations = @client.repository_invitations(@repo.id)
+        invitations = @client.repository_invitations(@repo.id, accept: preview_header)
         expect(invitations).to be_kind_of(Array)
         assert_requested :get, github_url("/repositories/#{@repo.id}/invitations")
       end
@@ -35,7 +35,7 @@ describe Octokit::Client::RepositoryInvitations do
 
     describe ".user_repository_invitations", :vcr do
       it "lists the users repository invitations" do
-        invitations = @client.user_repository_invitations
+        invitations = @client.user_repository_invitations(accept: preview_header)
         expect(invitations).to be_kind_of(Array)
         assert_requested :get, github_url("/user/repository_invitations")
       end
@@ -49,7 +49,7 @@ describe Octokit::Client::RepositoryInvitations do
       describe ".accept_repository_invitation", :vcr do
         it "accepts the repository invitation on behalf of the user" do
           request = stub_patch("/user/repository_invitations/#{@invitation_id}")
-          @client.accept_repository_invitation(@invitation_id)
+          @client.accept_repository_invitation(@invitation_id, accept: preview_header)
           assert_requested request
         end
       end
@@ -57,7 +57,7 @@ describe Octokit::Client::RepositoryInvitations do
       describe ".decline_repository_invitation", :vcr do
         it "declines the repository invitation on behalf of the user" do
           request = stub_delete("/user/repository_invitations/#{@invitation_id}")
-          @client.decline_repository_invitation(@invitation_id)
+          @client.decline_repository_invitation(@invitation_id, accept: preview_header)
           assert_requested request
         end
       end
@@ -65,22 +65,28 @@ describe Octokit::Client::RepositoryInvitations do
 
     context "with repository invitation" do
       before(:each) do
-        @invitation = @client.invite_user_to_repository(@repo.id, "tarebyte")
+        @invitation = @client.invite_user_to_repository(@repo.id, "tarebyte", accept: preview_header)
       end
 
       describe ".delete_repository_invitation", :vcr do
         it "deletes the repository invitation" do
-          @client.delete_repository_invitation(@repo.id, @invitation.id)
+          @client.delete_repository_invitation(@repo.id, @invitation.id, accept: preview_header)
           assert_requested :delete, github_url("/repositories/#{@repo.id}/invitations/#{@invitation.id}")
         end
       end
 
       describe ".update_repository_invitation", :vcr do
         it "updates the repository invitation" do
-          @client.update_repository_invitation(@repo.id, @invitation.id, :permissions => "read")
+          @client.update_repository_invitation(@repo.id, @invitation.id, :permissions => "read", accept: preview_header)
           assert_requested :patch, github_url("/repositories/#{@repo.id}/invitations/#{@invitation.id}")
         end
       end
     end
+  end
+
+  private
+
+  def preview_header
+    Octokit::Preview::PREVIEW_TYPES[:repository_invitations]
   end
 end

--- a/spec/octokit/client/source_import_spec.rb
+++ b/spec/octokit/client/source_import_spec.rb
@@ -33,7 +33,7 @@ describe Octokit::Client::SourceImport do
 
   describe "post deprecation" do
     before(:each) do
-      @client.start_source_import(@repo.full_name, "https://bitbucket.org/spraints/goboom", { :vcs => "hg" })
+      @client.start_source_import(@repo.full_name, "https://bitbucket.org/spraints/goboom", { :vcs => "hg", accept: preview_header })
     end
 
     describe ".start_source_import", :vcr do
@@ -44,7 +44,7 @@ describe Octokit::Client::SourceImport do
 
     describe ".source_import_progress", :vcr do
       it "returns the progress of the source import" do
-        result = @client.source_import_progress(@repo.full_name)
+        result = @client.source_import_progress(@repo.full_name, accept: preview_header)
         expect(result).to be_kind_of Sawyer::Resource
         assert_requested :get, github_url("/repos/#{@repo.full_name}/import")
       end
@@ -52,7 +52,7 @@ describe Octokit::Client::SourceImport do
 
     describe ".update_source_import", :vcr do
       it "restarts the source import" do
-        result = @client.update_source_import(@repo.full_name)
+        result = @client.update_source_import(@repo.full_name, accept: preview_header)
         expect(result).to be_kind_of Sawyer::Resource
         assert_requested :patch, github_url("/repos/#{@repo.full_name}/import")
       end
@@ -60,7 +60,7 @@ describe Octokit::Client::SourceImport do
 
     describe ".source_import_commit_authors", :vcr do
       it "lists the source imports commit authors" do
-        commit_authors = @client.source_import_commit_authors(@repo.full_name)
+        commit_authors = @client.source_import_commit_authors(@repo.full_name, accept: preview_header)
         expect(commit_authors).to be_kind_of Array
         assert_requested :get, github_url("/repos/#{@repo.full_name}/import/authors")
       end
@@ -69,14 +69,15 @@ describe Octokit::Client::SourceImport do
     describe ".map_source_import_commit_author", :vcr do
       it "updates the commit authors identity" do
         # We have to wait for the importer to load the authors before continuing
-        while(@client.source_import_commit_authors(@repo.full_name).empty?)
+        while(@client.source_import_commit_authors(@repo.full_name, accept: preview_header).empty?)
           sleep 1
         end
 
-        commit_author_url = @client.source_import_commit_authors(@repo.full_name).first.url
+        commit_author_url = @client.source_import_commit_authors(@repo.full_name, accept: preview_header).first.url
         commit_author = @client.map_source_import_commit_author(commit_author_url, {
           :email => "hubot@github.com",
-          :name => "Hubot the Robot"
+          :name => "Hubot the Robot",
+          accept: preview_header
         })
 
         expect(commit_author.email).to eql("hubot@github.com")
@@ -87,7 +88,7 @@ describe Octokit::Client::SourceImport do
 
     describe ".cancel_source_import", :vcr do
       it "cancels the source import" do
-        result = @client.cancel_source_import(@repo.full_name)
+        result = @client.cancel_source_import(@repo.full_name, accept: preview_header)
         expect(result).to be true
         assert_requested :delete, github_url("/repos/#{@repo.full_name}/import")
       end
@@ -95,7 +96,7 @@ describe Octokit::Client::SourceImport do
 
     describe ".source_import_large_files", :vcr do
       it "lists the source imports large files" do
-        large_files = @client.source_import_large_files(@repo.full_name)
+        large_files = @client.source_import_large_files(@repo.full_name, accept: preview_header)
         expect(large_files).to be_kind_of Array
         assert_requested :get, github_url("/repos/#{@repo.full_name}/import/large_files")
       end
@@ -103,10 +104,16 @@ describe Octokit::Client::SourceImport do
 
     describe ".set_source_import_lfs_preference", :vcr do
       it "sets use_lfs to opt_in for the import" do
-        result = @client.set_source_import_lfs_preference(@repo.full_name, "opt_in")
+        result = @client.set_source_import_lfs_preference(@repo.full_name, "opt_in", accept: preview_header)
         expect(result).to be_kind_of Sawyer::Resource
         assert_requested :patch, github_url("repos/#{@repo.full_name}/import/lfs")
       end
     end # .set_source_import_lfs_preference
+  end
+
+  private
+
+  def preview_header
+    Octokit::Preview::PREVIEW_TYPES[:source_imports]
   end
 end

--- a/spec/octokit/client/traffic_spec.rb
+++ b/spec/octokit/client/traffic_spec.rb
@@ -1,10 +1,9 @@
 require 'helper'
 
 describe Octokit::Client::Traffic do
-
   describe ".top_referrers", :vcr do
     it "returns the referrers stats for a repository" do
-      referrers = oauth_client.top_referrers(@test_repo)
+      referrers = oauth_client.top_referrers(@test_repo, accept: preview_header)
       expect(referrers).to be_kind_of Array
       assert_requested :get, github_url("/repos/#{@test_repo}/traffic/popular/referrers")
     end
@@ -12,7 +11,7 @@ describe Octokit::Client::Traffic do
 
   describe ".top_paths", :vcr do
     it "returns the top path statistics for a repository" do
-      top_paths = oauth_client.top_paths(@test_repo)
+      top_paths = oauth_client.top_paths(@test_repo, accept: preview_header)
       expect(top_paths).to be_kind_of Array
       assert_requested :get, github_url("/repos/#{@test_repo}/traffic/popular/paths")
     end
@@ -20,7 +19,7 @@ describe Octokit::Client::Traffic do
 
   describe ".views", :vcr do
     it "returns the views breakdown for a repository" do
-      views = oauth_client.views(@test_repo)
+      views = oauth_client.views(@test_repo, accept: preview_header)
       expect(views.count).to be_kind_of Integer
       assert_requested :get, github_url("/repos/#{@test_repo}/traffic/views")
     end
@@ -28,10 +27,15 @@ describe Octokit::Client::Traffic do
 
   describe ".clones", :vcr do
     it "returns the clone stats for a repository" do
-      clones = oauth_client.clones(@test_repo)
+      clones = oauth_client.clones(@test_repo, accept: preview_header)
       expect(clones.count).to be_kind_of Integer
       assert_requested :get, github_url("/repos/#{@test_repo}/traffic/clones")
     end
   end # .clones
 
+  private
+
+  def preview_header
+    Octokit::Preview::PREVIEW_TYPES[:traffic]
+  end
 end


### PR DESCRIPTION
This passes the preview header to any calls made from the specs in order to make the test run a bit less noisy.