### PR TITLE
Fix apps client for GitHub Enterprise installs

### DIFF
--- a/lib/octokit/client/apps.rb
+++ b/lib/octokit/client/apps.rb
@@ -13,7 +13,7 @@ module Octokit
       # @return [Array<Sawyer::Resource>] A list of installations
       def find_app_installations(options = {})
         opts = ensure_api_media_type(:integrations, options)
-        paginate "/app/installations", opts
+        paginate "app/installations", opts
       end
       alias find_installations find_app_installations
 
@@ -36,7 +36,7 @@ module Octokit
       # @return [Array<Sawyer::Resource>] A list of installations
       def find_user_installations(options = {})
         opts = ensure_api_media_type(:integrations, options)
-        paginate "/user/installations", opts
+        paginate "user/installations", opts
       end
 
       # Get a single installation
@@ -48,7 +48,7 @@ module Octokit
       # @return [Sawyer::Resource] Installation information
       def installation(id, options = {})
         opts = ensure_api_media_type(:integrations, options)
-        get "/app/installations/#{id}", opts
+        get "app/installations/#{id}", opts
       end
 
       # Create a new installation token
@@ -61,7 +61,7 @@ module Octokit
       # @return [<Sawyer::Resource>] An installation token
       def create_app_installation_access_token(installation, options = {})
         opts = ensure_api_media_type(:integrations, options)
-        post "/installations/#{installation}/access_tokens", opts
+        post "installations/#{installation}/access_tokens", opts
       end
       alias create_installation_access_token create_app_installation_access_token
 
@@ -83,7 +83,7 @@ module Octokit
       # @return [Array<Sawyer::Resource>] A list of repositories
       def list_app_installation_repositories(options = {})
         opts = ensure_api_media_type(:integrations, options)
-        paginate "/installation/repositories", opts
+        paginate "installation/repositories", opts
       end
       alias list_installation_repos list_app_installation_repositories
 
@@ -108,7 +108,7 @@ module Octokit
       # @return [Boolean] Success
       def add_repository_to_app_installation(installation, repo, options = {})
         opts = ensure_api_media_type(:integrations, options)
-        boolean_from_response :put, "/user/installations/#{installation}/repositories/#{repo}", opts
+        boolean_from_response :put, "user/installations/#{installation}/repositories/#{repo}", opts
       end
       alias add_repo_to_installation add_repository_to_app_installation
 
@@ -133,7 +133,7 @@ module Octokit
       # @return [Boolean] Success
       def remove_repository_from_app_installation(installation, repo, options = {})
         opts = ensure_api_media_type(:integrations, options)
-        boolean_from_response :delete, "/user/installations/#{installation}/repositories/#{repo}", opts
+        boolean_from_response :delete, "user/installations/#{installation}/repositories/#{repo}", opts
       end
       alias remove_repo_from_installation remove_repository_from_app_installation
 
@@ -157,7 +157,7 @@ module Octokit
       # @return [Array<Sawyer::Resource>] A list of repositories
       def find_installation_repositories_for_user(installation, options = {})
         opts = ensure_api_media_type(:integrations, options)
-        paginate "/user/installations/#{installation}/repositories", opts
+        paginate "user/installations/#{installation}/repositories", opts
       end
     end
   end


### PR DESCRIPTION
This shows and fixes the fact that the client doesn't work correctly for the app endpoints documented at https://developer.github.com/v3/apps/ when used in a GitHub Enterprise environment.

Without this change requests like `POST https://ghe.localhost/installations/:installation_id/access_tokens` are being made instead of `POST https://ghe.localhost/api/v3/installations/:installation_id/access_tokens`, for example.

I had to manually patch the client to work with Octokit.rb using these endpoints on a GitHub Enterprise install.

Seems similar to https://github.com/octokit/octokit.rb/issues/831 + https://github.com/octokit/octokit.rb/pull/851.

