### PR TITLE
Document the steps necessary to cut a release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,28 @@
+# Releasing a new version of octokit.rb
+
+1. Create a list of all the changes since the prior release
+    1. Compare the latest release to master using https://github.com/octokit/octokit.rb/compare/`${latest}`...master
+    1. Open the linked pull requests from all the `Merge pull request #...` commits
+    1. For all non-documentation PRs, copy title (including pull request number) into markdown list items
+    1. (optional, but nice) Sort into logical buckets, like "support for additional endpoints", "enhancements", "bugfixes"
+    1. Reorganize to put the pull request number at the start of the line
+1. Ensure there are no breaking changes _(if there are breaking changes you'll need to create a release branch without those changes or bump the major version)_
+1. Update the version
+    1. Update the constant in `lib/octokit/version.rb`
+    1. Commit and push directly to master
+1. Run the `script/release` script to cut a release
+1. Draft a new release at https://github.com/octokit/octokit.rb/releases/new containing the curated changelog
+
+## Prerequisites
+
+In order to create a release, you will need to be an owner of the octokit gem on Rubygems.
+
+Verify with:
+```
+gem owner octokit
+```
+
+An existing owner can add new owners with:
+```
+gem owner octokit --add EMAIL
+```


### PR DESCRIPTION
This is nothing new or special, but it should provide a handy checklist for cutting new releases,
which in turn might cause us to do this more often.

The gap between the v4.7.0 and v4.8.0 releases was about 8 months, mostly because we had some
turnover in maintainers, and the new maintainers had never cut a release, so it loomed as a somewhat uncomfortable unknown.

Documenting this should make it easier for new maintainers to whip up a release when it makes sense to do so.

[View rendered checklist](https://github.com/octokit/octokit.rb/blob/kytrinyx/release-docs/RELEASE.md)

@pengwynn since you've probably done most of the releases until now, would you have 5 minutes to glance through this checklist and make sure I'm not missing anything?

/cc @bkeepers as unofficial cat-herder of the octokit libraries