### PR TITLE
CI against Ruby 2.2.9, 2.3.6, 2.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ rvm:
   - jruby-19mode
   - 2.0
   - 2.1
-  - 2.2
-  - 2.3.4
-  - 2.4.1
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
 
 bundler_args: --without development
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-2-9-released/
https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-3-6-released/
https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-4-3-released/