### PR TITLE
Fix client stats on empty repos

### DIFF
--- a/lib/octokit/client/stats.rb
+++ b/lib/octokit/client/stats.rb
@@ -94,7 +94,7 @@ module Octokit
         end
         loop do
           data = get("#{Repository.path repo}/stats/#{metric}", options)
-          return data if last_response.status == 200
+          return data if %w[200 204].include? last_response.status
           return nil unless retry_timeout
           return nil if Time.now >= timeout
           sleep retry_wait if retry_wait

--- a/lib/octokit/client/stats.rb
+++ b/lib/octokit/client/stats.rb
@@ -95,7 +95,7 @@ module Octokit
         loop do
           data = get("#{Repository.path repo}/stats/#{metric}", options)
           return data if last_response.status == 200
-          return 0 if last_response.status == 204
+          return [] if last_response.status == 204
           return nil unless retry_timeout
           return nil if Time.now >= timeout
           sleep retry_wait if retry_wait

--- a/lib/octokit/client/stats.rb
+++ b/lib/octokit/client/stats.rb
@@ -94,7 +94,8 @@ module Octokit
         end
         loop do
           data = get("#{Repository.path repo}/stats/#{metric}", options)
-          return data if %w[200 204].include? last_response.status
+          return data if last_response.status == 200
+          return 0 if last_response.status == 204
           return nil unless retry_timeout
           return nil if Time.now >= timeout
           sleep retry_wait if retry_wait

--- a/spec/octokit/client/stats_spec.rb
+++ b/spec/octokit/client/stats_spec.rb
@@ -16,6 +16,7 @@ describe Octokit::Client::Stats do
           { :status => 202 }, # Cold request
           { :status => 202 }, # Cold request
           { :status => 200, :body => [].to_json }, # Warm request
+          { :status => 204, :body => [].to_json }, # Warm request
         )
     end
 


### PR DESCRIPTION
Fix #912 

After pairing with @d12 we've been encountering some issues on Classroom because of the `204`.

This is just a first shot as I think I need help about the tests ✋ 
Is it better to add more tests to check the return value for both 200 and 204 ?
Is the 0 value still ok ? It's based on @kytrinyx 's words:
> I would prefer to provide a good zero value that the client code wouldn't have to check

Should it be something else ?

Thank you 🙏 