### PR TITLE
Refactor and fix path segments escaping

### DIFF
--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -237,5 +237,11 @@ module Octokit
 
       conn
     end
+
+    private
+
+    def http_escape(string)
+      Addressable::URI.escape(string)
+    end
   end
 end

--- a/lib/octokit/client/labels.rb
+++ b/lib/octokit/client/labels.rb
@@ -28,7 +28,7 @@ module Octokit
       # @example Get the "V3 Addition" label from octokit/octokit.rb
       #   Octokit.labels("octokit/octokit.rb", "V3 Addition")
       def label(repo, name, options = {})
-        get "#{Repository.path repo}/labels/#{name}", options
+        get "#{Repository.path repo}/labels/#{http_escape(name)}", options
       end
 
       # Add a label to a repository
@@ -56,7 +56,7 @@ module Octokit
       # @example Update the label "Version 1.0" with new color "#cceeaa"
       #   Octokit.update_label("octokit/octokit.rb", "Version 1.0", {:color => "cceeaa"})
       def update_label(repo, label, options = {})
-        patch "#{Repository.path repo}/labels/#{label}", options
+        patch "#{Repository.path repo}/labels/#{http_escape(label)}", options
       end
 
       # Delete a label from a repository.
@@ -70,7 +70,7 @@ module Octokit
       # @example Delete the label "Version 1.0" from the repository.
       #   Octokit.delete_label!("octokit/octokit.rb", "Version 1.0")
       def delete_label!(repo, label, options = {})
-        boolean_from_response :delete, "#{Repository.path repo}/labels/#{label}", options
+        boolean_from_response :delete, "#{Repository.path repo}/labels/#{http_escape(label)}", options
       end
 
       # Remove a label from an Issue
@@ -85,7 +85,7 @@ module Octokit
       # @example Remove the label "Version 1.0" from the repository.
       #   Octokit.remove_label("octokit/octokit.rb", 23, "Version 1.0")
       def remove_label(repo, number, label, options = {})
-        delete "#{Repository.path repo}/issues/#{number}/labels/#{label}", options
+        delete "#{Repository.path repo}/issues/#{number}/labels/#{http_escape(label)}", options
       end
 
       # Remove all label from an Issue

--- a/lib/octokit/client/legacy_search.rb
+++ b/lib/octokit/client/legacy_search.rb
@@ -12,7 +12,7 @@ module Octokit
       # @param q [String] Search keyword
       # @return [Array<Sawyer::Resource>] List of repositories found
       def legacy_search_repositories(q, options = {})
-        get("legacy/repos/search/#{q}", options)['repositories']
+        get("legacy/repos/search/#{http_escape(q)}", options)['repositories']
       end
 
       # Legacy search issues within a repository
@@ -24,7 +24,7 @@ module Octokit
       # @example Search for 'test' in the open issues for sferik/rails_admin
       #   Octokit.search_issues("sferik/rails_admin", 'test', 'open')
       def legacy_search_issues(repo, search_term, state='open', options = {})
-        get("legacy/issues/search/#{Repository.new(repo)}/#{state}/#{search_term}", options)['issues']
+        get("legacy/issues/search/#{Repository.new(repo)}/#{state}/#{http_escape(search_term)}", options)['issues']
       end
 
       # Search for user.
@@ -35,7 +35,7 @@ module Octokit
       # @example
       #   Octokit.search_users('pengwynn')
       def legacy_search_users(search, options = {})
-        get("legacy/user/search/#{search}", options)['users']
+        get("legacy/user/search/#{http_escape(search)}", options)['users']
       end
     end
   end

--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -153,7 +153,7 @@ module Octokit
         end
       end
 
-      @last_response = response = agent.call(method, URI::Parser.new.escape(path.to_s), data, options)
+      @last_response = response = agent.call(method, path.to_s, data, options)
       response.data
     end
 

--- a/lib/octokit/user.rb
+++ b/lib/octokit/user.rb
@@ -8,7 +8,7 @@ module Octokit
     def self.path user
       case user
       when String
-        "users/#{user}"
+        "users/#{Addressable::URI.escape(user)}"
       when Integer
         "user/#{user}"
       else

--- a/spec/octokit/user_spec.rb
+++ b/spec/octokit/user_spec.rb
@@ -14,6 +14,11 @@ describe Octokit::User do
         path = Octokit::User.path 'pengwynn'
         expect(path).to eq 'users/pengwynn'
       end
+
+      it "escapes the login" do
+        path = Octokit::User.path 'hu[bot]'
+        expect(path).to eq 'users/hu%5Bbot%5D'
+      end
     end # with login
 
     context "with id" do


### PR DESCRIPTION
Fix: https://github.com/octokit/octokit.rb/issues/1004

Using this branch:

```ruby
>> Octokit.user('shipit[bot]')
=> {:login=>"shipit[bot]", :id=>32029183,  ...}
>> Octokit.get("https://api.github.com/users/shipit%5Bbot%5D")
=> {:login=>"shipit[bot]", :id=>32029183, ...}
```

So there was several problems here.

First `Octokit.user('shipit[bot]')` wasn't working because `URI::Parser.new.escape` follows RFC2396 which doesn't consider `[]` as invalid characters whereas `URI.parse` follows RFC3986 which does consider `[]` as invalid characters that need to be escaped (see [MRI Issue 9990](https://bugs.ruby-lang.org/issues/9990)).

The solution here is to use `Addressable::URI.escape`, which does a proper `RFC3986` escaping. It doesn't add any dependency since `addressable` is already a faraday dependency. However it might be a problem in the future if Faraday was to drop addressable.

Then `Octokit.get("https://api.github.com/users/shipit%5Bbot%5D")` wasn't working either (even though it's an URL returned by the API) because `Connection#request` was escaping everything, which IMHO isn't a good idea.

Instead this refactor only escape specific path segments known to be able to include special characters. The downside is that I have no way to be 100% sure I haven't missed some segments which might cause regressions.

ping @tarebyte do you think this would be an acceptable patch?