### PR TITLE
Add missing remove_org_membership alias

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -699,6 +699,7 @@ module Octokit
         user = options.delete(:user)
         user && boolean_from_response(:delete, "orgs/#{org}/memberships/#{user}", options)
       end
+      alias :remove_org_membership :remove_organization_membership
 
       # Initiates the generation of a migration archive.
       #


### PR DESCRIPTION
No tests added because these "org" short-form aliases are not tested in the suite.