### PR TITLE
Fix example call to Octokit.label

### DIFF
--- a/lib/octokit/client/labels.rb
+++ b/lib/octokit/client/labels.rb
@@ -26,7 +26,7 @@ module Octokit
       # @return [Sawyer::Resource] A single label from the repository
       # @see https://developer.github.com/v3/issues/labels/#get-a-single-label
       # @example Get the "V3 Addition" label from octokit/octokit.rb
-      #   Octokit.labels("octokit/octokit.rb", "V3 Addition")
+      #   Octokit.label("octokit/octokit.rb", "V3 Addition")
       def label(repo, name, options = {})
         get "#{Repository.path repo}/labels/#{name}", options
       end


### PR DESCRIPTION
Before:

    Octokit.labels("octokit/octokit.rb", "V3 Addition")
    Traceback (most recent call last):
            7: from /usr/local/bin/irb:11:in `<main>'
            6: from (irb):6
            5: from /usr/local/lib/ruby/gems/2.5.0/gems/octokit-4.8.0/lib/octokit.rb:46:in `method_missing'
            4: from /usr/local/lib/ruby/gems/2.5.0/gems/octokit-4.8.0/lib/octokit/client/labels.rb:19:in `labels'
            3: from /usr/local/lib/ruby/gems/2.5.0/gems/octokit-4.8.0/lib/octokit/connection.rb:79:in `paginate'
            2: from /usr/local/lib/ruby/gems/2.5.0/gems/octokit-4.8.0/lib/octokit/connection.rb:185:in `parse_query_and_convenience_headers'
            1: from /usr/local/lib/ruby/gems/2.5.0/gems/octokit-4.8.0/lib/octokit/connection.rb:185:in `delete'
    TypeError (no implicit conversion of Symbol into String)

After:

    Octokit.label("octokit/octokit.rb", "V3 Addition")
    => {:id=>111852, :url=>"https://api.github.com/repos/octokit/octokit.rb/labels/v3%20addition", :name=>"v3 addition", :color=>"ededed", :default=>false}