### PR TITLE
Convert OCTOKIT_SSL_VERIFY_MODE environment variable to integer

### DIFF
--- a/lib/octokit/default.rb
+++ b/lib/octokit/default.rb
@@ -143,7 +143,7 @@ module Octokit
         # 0 is OpenSSL::SSL::VERIFY_NONE
         # 1 is OpenSSL::SSL::SSL_VERIFY_PEER
         # the standard default for SSL is SSL_VERIFY_PEER which requires a server certificate check on the client
-        ENV['OCTOKIT_SSL_VERIFY_MODE'] || 1 
+        ENV.fetch('OCTOKIT_SSL_VERIFY_MODE', 1).to_i
       end
 
       # Default User-Agent header string from ENV or {USER_AGENT}


### PR DESCRIPTION
Currently, setting OCTOKIT_SSL_VERIFY_MODE causes Octokit to fail because environment variables are strings and ssl_verify_mode returns an integer:
```
06:05 $ export OCTOKIT_SSL_VERIFY_MODE=1
✔ ~/git/octokit.rb [master|✔] 
06:06 $ bundle exec irb
irb(main):002:0> client = Octokit::Client.new()
...
irb(main):003:0> client.user
Traceback (most recent call last):
       16: from /home/chris/git/octokit.rb/.bundle/gems/faraday-0.15.1/lib/faraday/rack_builder.rb:143:in 
...
...
        1: from /usr/share/ruby/net/http.rb:973:in `initialize'
TypeError (no implicit conversion of String into Integer)
```
The change in this PR returns the string as an integer.