### PR TITLE
Remove preview warning for marketplace API

### DIFF
--- a/lib/octokit/preview.rb
+++ b/lib/octokit/preview.rb
@@ -17,7 +17,6 @@ module Octokit
       :projects               => 'application/vnd.github.inertia-preview+json'.freeze,
       :traffic                => 'application/vnd.github.spiderman-preview'.freeze,
       :integrations           => 'application/vnd.github.machine-man-preview+json'.freeze,
-      :marketplace            => 'application/vnd.github.valkyrie-preview+json'.freeze,
       :topics                 => 'application/vnd.github.mercy-preview+json'.freeze
     }
 


### PR DESCRIPTION
Marketplace is [out of preview](https://developer.github.com/changes/2018-05-22-marketplace-api/). 🎉 