### PR TITLE
Faraday retry middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ traffic:
 
 ```ruby
 stack = Faraday::RackBuilder.new do |builder|
+  builder.use Faraday::Request::Retry, exceptions: [Octokit::ServerError]
   builder.use Octokit::Middleware::FollowRedirects
   builder.use Octokit::Response::RaiseError
   builder.use Octokit::Response::FeedParser

--- a/lib/octokit/default.rb
+++ b/lib/octokit/default.rb
@@ -25,6 +25,7 @@ module Octokit
 
     # Default Faraday middleware stack
     MIDDLEWARE = RACK_BUILDER_CLASS.new do |builder|
+      builder.use Faraday::Request::Retry, exceptions: [Octokit::ServerError]
       builder.use Octokit::Middleware::FollowRedirects
       builder.use Octokit::Response::RaiseError
       builder.use Octokit::Response::FeedParser


### PR DESCRIPTION
Ref https://github.com/octokit/octokit.rb/issues/888

I think that is all the required changes to make everyone happy regarding intermittent Github 5xx error class errors that could be easily replayed.

🎩manually with the `Octokit::NotFound` error. 

Thoughts? I'm not super familiar with Octokit (it just work so I never had to look inside)