### PR TITLE
Fix contributors endpoint for empty repos

### DIFF
--- a/lib/octokit/client/stats.rb
+++ b/lib/octokit/client/stats.rb
@@ -96,7 +96,7 @@ module Octokit
         loop do
           data = get("#{Repository.path repo}/stats/#{metric}", options)
           return data if last_response.status == 200
-          return 0 if last_response.status == 204
+          return [] if last_response.status == 204
           return nil unless retry_timeout
           return nil if Time.now >= timeout
           sleep retry_wait if retry_wait

--- a/lib/octokit/client/stats.rb
+++ b/lib/octokit/client/stats.rb
@@ -95,7 +95,8 @@ module Octokit
         end
         loop do
           data = get("#{Repository.path repo}/stats/#{metric}", options)
-          return data if %w[200 204].include? last_response.status
+          return data if last_response.status == 200
+          return 0 if last_response.status == 204
           return nil unless retry_timeout
           return nil if Time.now >= timeout
           sleep retry_wait if retry_wait

--- a/lib/octokit/client/stats.rb
+++ b/lib/octokit/client/stats.rb
@@ -95,7 +95,7 @@ module Octokit
         end
         loop do
           data = get("#{Repository.path repo}/stats/#{metric}", options)
-          return data if last_response.status == 200
+          return data if %w[200 204].include? last_response.status
           return nil unless retry_timeout
           return nil if Time.now >= timeout
           sleep retry_wait if retry_wait

--- a/spec/octokit/client/stats_spec.rb
+++ b/spec/octokit/client/stats_spec.rb
@@ -15,6 +15,7 @@ describe Octokit::Client::Stats do
           { :status => 202 }, # Cold request
           { :status => 202 }, # Cold request
           { :status => 204, :body => [].to_json }, # Warm request
+          { :status => 204, :body => [].to_json } # Warm request
         )
     end
 
@@ -28,7 +29,10 @@ describe Octokit::Client::Stats do
       it "returns [] when GitHub returns 204" do
         stats = @client.contributors_stats("octokit/octokit.rb", :retry_timeout => 3)
         expect(stats).to eq([])
+      end
 
+      it "doesn't retry when GitHub returns 204" do
+        stats = @client.contributors_stats("octokit/octokit.rb", :retry_timeout => 4)
         assert_requested :get, github_url("/repos/octokit/octokit.rb/stats/contributors"), :times => 3
       end
 

--- a/spec/octokit/client/stats_spec.rb
+++ b/spec/octokit/client/stats_spec.rb
@@ -48,6 +48,7 @@ describe Octokit::Client::Stats do
           { :status => 202 }, # Cold request
           { :status => 202 }, # Cold request
           { :status => 200, :body => [].to_json }, # Warm request
+          { :status => 204, :body => [].to_json }, # Warm request
         )
     end
 

--- a/spec/octokit/client/stats_spec.rb
+++ b/spec/octokit/client/stats_spec.rb
@@ -56,7 +56,6 @@ describe Octokit::Client::Stats do
           { :status => 202 }, # Cold request
           { :status => 202 }, # Cold request
           { :status => 200, :body => [].to_json }, # Warm request
-          { :status => 204, :body => [].to_json }, # Warm request
         )
     end
 

--- a/spec/octokit/client/stats_spec.rb
+++ b/spec/octokit/client/stats_spec.rb
@@ -19,6 +19,10 @@ describe Octokit::Client::Stats do
         )
     end
 
+    after do
+      VCR.turn_on!
+    end
+
     describe ".contributors_stats" do
       it "returns nil when statistics are not ready" do
         stats = @client.contributors_stats("octokit/octokit.rb")


### PR DESCRIPTION
Fixes https://github.com/octokit/octokit.rb/issues/912
Closes https://github.com/octokit/octokit.rb/pull/994

Me, @srinjoym and @benemdon finished up @Kadaaran 's work from #994, fixing the timeout bug in the contributors endpoint.

GitHub returns a 204 when asking for statistics on empty repos. Previously, Octokit would continue to retry until the retry timeout was reached.

This PR just returns `[]` when a 204 is returned.

Also wrote a few tests showing we don't retry when a 204 is returned, and that octokit returns `[]` when GitHub returns a 204.

cc @tarebyte @kytrinyx for review