### PR TITLE
fix undefined values reference on delete_pull_request_review_request

### DIFF
--- a/lib/octokit/client/reviews.rb
+++ b/lib/octokit/client/reviews.rb
@@ -179,7 +179,7 @@ module Octokit
       # @return [Sawyer::Resource>] Hash representing the pull request
       def delete_pull_request_review_request(repo, id, reviewers, options = {})
         # "reviewers" has to be an array otherwise "422 - Invalid request"
-        options = options.merge(reviewers: reviewers.values.flatten)
+        options = options.merge(reviewers: reviewers.flatten)
         delete "#{Repository.path repo}/pulls/#{id}/requested_reviewers", options
       end
     end


### PR DESCRIPTION
I opened an issue #1028 about the documentation, but then checked out master.

I found that everything seems to be working fine except for how reviewers are referenced when deleting.

When using this on master, I receive:

```
`undefined method values' for ["olingern"]:Array
Did you mean?  values_at`
```

And a backtrace that points to:
```
gems/octokit.rb-5ba66ae2fb38/lib/octokit/client/reviews.rb:182:in `delete_pull_request_review_request'"
```

The code in question at 182 is referencing property on the array that does not exist. It's also unclear why `flatten` is being used here, since the documentation says the passed param, `reviewers`, should be an array -- though, not an array of arrays as this code would imply.

[Reference
](https://github.com/octokit/octokit.rb/blob/master/lib/octokit/client/reviews.rb#L164)

```ruby
  # Delete a review request
      #
      # @param repo [Integer, String, Hash, Repository] A GitHub repository
      # @param id [Integer] The id of the pull request
      # @param reviewers [Hash] A hash including "reviewers" which is an array of user
      #                         logins and "team_reviewers" which is an array of team slug
      # @see https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request
      #
      # @example
      #   reviewers = {
      #     "reviewers" => [ "octocat", "hubot", "other_user" ],
      #     "team_reviewers" => [ "justice-league" ]
      #   }
      #   @client.delete_request_pull_request_review('octokit/octokit.rb', 2, reviewers)
      #
      # @return [Sawyer::Resource>] Hash representing the pull request
      def delete_pull_request_review_request(repo, id, reviewers, options = {})
        # "reviewers" has to be an array otherwise "422 - Invalid request"
        options = options.merge(reviewers: reviewers.flatten)
        delete "#{Repository.path repo}/pulls/#{id}/requested_reviewers", options
      end
```

