### PR TITLE
Use auto pagination when retrieving statuses

### DIFF
--- a/lib/octokit/client/statuses.rb
+++ b/lib/octokit/client/statuses.rb
@@ -13,7 +13,7 @@ module Octokit
       # @return [Array<Sawyer::Resource>] A list of statuses
       # @see https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
       def statuses(repo, sha, options = {})
-        get "#{Repository.path repo}/statuses/#{sha}", options
+        paginate "#{Repository.path repo}/statuses/#{sha}", options
       end
       alias :list_statuses :statuses
 


### PR DESCRIPTION
Allowing auto_paginate option to work when retrieving git status checks. Currently auto pagination is already in use for retrieving pull requests, commits etc. but not for statuses.

Closes https://github.com/octokit/octokit.rb/issues/1031 