### PR TITLE
Duplicate option to prevent to break argument

### DIFF
--- a/lib/octokit/client/authorizations.rb
+++ b/lib/octokit/client/authorizations.rb
@@ -231,11 +231,11 @@ module Octokit
         if app_id.to_s.empty?
           raise Octokit::ApplicationCredentialsRequired.new "client_id required"
         end
-        authorize_url = options.delete(:endpoint) || Octokit.web_endpoint
+        authorize_url = opts.delete(:endpoint) || Octokit.web_endpoint
         authorize_url << "login/oauth/authorize?client_id=#{app_id}"
 
         require 'cgi'
-        options.each do |key, value|
+        opts.each do |key, value|
           authorize_url << "&#{key}=#{CGI.escape value}"
         end
 


### PR DESCRIPTION
Problem
===


`authorize_url` method call `options.dup`, but it does not use the duplicated option. So the method breaks the option that is received as an argument.

I notice this problem with `ruby -w`. For example:


```bash
$ ruby -w -roctokit -e '()'
/path/to/gems/2.6.0/gems/octokit-4.9.0/lib/octokit/client/authorizations.rb:230: warning: assigned but unused variable - opts
```


Solution
===

Use duplicated options.
