### PR TITLE
Test against Ruby 2.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ rvm:
   - jruby-19mode
   - 2.0
   - 2.1
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 
 bundler_args: --without development
 


### PR DESCRIPTION
This Pull Request add Ruby 2.5.1 to test matrix and update other existing Rubies to [latest stable](https://github.com/postmodern/ruby-versions/blob/master/ruby/stable.txt).
