### PR TITLE
Remove marketplace preview warnings

### DIFF
--- a/lib/octokit/client/marketplace.rb
+++ b/lib/octokit/client/marketplace.rb
@@ -14,8 +14,7 @@ module Octokit
       #
       # @return [Array<Sawyer::Resource>] A list of plans
       def list_plans(options = {})
-        opts = ensure_api_media_type(:marketplace, options)
-        paginate "/marketplace_listing/plans", opts
+        paginate "/marketplace_listing/plans", options
       end
 
       # List all GitHub accounts on a specific plan
@@ -27,8 +26,7 @@ module Octokit
       #
       # @return [Array<Sawyer::Resource>] A list of accounts
       def list_accounts_for_plan(plan_id, options = {})
-        opts = ensure_api_media_type(:marketplace, options)
-        paginate "/marketplace_listing/plans/#{plan_id}/accounts", opts
+        paginate "/marketplace_listing/plans/#{plan_id}/accounts", options
       end
 
       # Get the plan associated with a given GitHub account
@@ -40,8 +38,7 @@ module Octokit
       #
       # @return <Sawyer::Resource> Account with plan details, or nil
       def plan_for_account(account_id, options = {})
-        opts = ensure_api_media_type(:marketplace, options)
-        get "/marketplace_listing/accounts/#{account_id}", opts
+        get "/marketplace_listing/accounts/#{account_id}", options
       end
 
       # Get user's Marketplace purchases
@@ -52,8 +49,7 @@ module Octokit
       #
       # @return [Array<Sawyer::Resource>] A list of Marketplace purchases
       def marketplace_purchases(options = {})
-        opts = ensure_api_media_type(:marketplace, options)
-        get "/user/marketplace_purchases", opts
+        get "/user/marketplace_purchases", options
       end
     end
   end

--- a/spec/octokit/client/marketplace_spec.rb
+++ b/spec/octokit/client/marketplace_spec.rb
@@ -14,7 +14,7 @@ describe Octokit::Client::Marketplace do
 
   describe ".list_plans", :vcr do
     it "returns plans for a marketplace listing" do
-      plans = @jwt_client.list_plans(accept: preview_header)
+      plans = @jwt_client.list_plans
       expect(plans).to be_kind_of Array
       assert_requested :get, github_url("/marketplace_listing/plans")
     end
@@ -22,7 +22,7 @@ describe Octokit::Client::Marketplace do
 
   describe ".list_accounts_for_plan", :vcr do
     it "returns accounts for a given plan" do
-      plans = @jwt_client.list_accounts_for_plan(7, accept: preview_header)
+      plans = @jwt_client.list_accounts_for_plan(7)
       expect(plans).to be_kind_of Array
       assert_requested :get, github_url("/marketplace_listing/plans/7/accounts")
     end
@@ -30,7 +30,7 @@ describe Octokit::Client::Marketplace do
 
   describe ".plan_for_account", :vcr do
     it "returns the plan for a given account" do
-      plans = @jwt_client.plan_for_account(1, accept: preview_header)
+      plans = @jwt_client.plan_for_account(1)
       expect(plans).to be_kind_of Sawyer::Resource
       assert_requested :get, github_url("/marketplace_listing/accounts/1")
     end
@@ -38,15 +38,9 @@ describe Octokit::Client::Marketplace do
 
   describe ".marketplace_purchases", :vcr do
     it "returns marketplace purchases for user" do
-      plans = @client.marketplace_purchases(accept: preview_header)
+      plans = @client.marketplace_purchases
       expect(plans).to be_kind_of Array
       assert_requested :get, github_url("/user/marketplace_purchases")
     end
   end # .marketplace_purchases
-
-  private
-
-  def preview_header
-    Octokit::Preview::PREVIEW_TYPES[:marketplace]
-  end
 end


### PR DESCRIPTION
This is a follow-up to https://github.com/octokit/octokit.rb/pull/1020

I didn't think that through entirely when I reviewed it. We need to remove the call to `ensure...` as well as the calls in the tests.