### PR TITLE
Remove preview warning for Repository Invitations API

### DIFF
--- a/lib/octokit/client/repository_invitations.rb
+++ b/lib/octokit/client/repository_invitations.rb
@@ -15,7 +15,6 @@ module Octokit
       # @return [Sawyer::Resource] The repository invitation
       # @see https://developer.github.com/v3/repos/invitations/#invite-a-user-to-a-repository
       def invite_user_to_repository(repo, user, options = {})
-        options = ensure_api_media_type(:repository_invitations, options)
         put "#{Repository.path repo}/collaborators/#{user}", options
       end
       alias invite_user_to_repo invite_user_to_repository
@@ -28,7 +27,6 @@ module Octokit
       # @return [Array<Sawyer::Resource>] A list of invitations
       # @see https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository
       def repository_invitations(repo, options = {})
-        options = ensure_api_media_type(:repository_invitations, options)
         paginate "#{Repository.path repo}/invitations", options
       end
       alias repo_invitations repository_invitations
@@ -42,7 +40,6 @@ module Octokit
       # @return [Boolean] True if the invitation was successfully deleted
       # @see https://developer.github.com/v3/repos/invitations/#delete-a-repository-invitation
       def delete_repository_invitation(repo, invitation_id, options = {})
-        options = ensure_api_media_type(:repository_invitations, options)
         boolean_from_response :delete, "#{Repository.path repo}/invitations/#{invitation_id}", options
       end
       alias delete_repo_invitation delete_repository_invitation
@@ -56,7 +53,6 @@ module Octokit
       # @return [Sawyer::Resource] The updated repository invitation
       # @see https://developer.github.com/v3/repos/invitations/#update-a-repository-invitation
       def update_repository_invitation(repo, invitation_id, options = {})
-        options = ensure_api_media_type(:repository_invitations, options)
         patch "#{Repository.path repo}/invitations/#{invitation_id}", options
       end
       alias update_repo_invitation update_repository_invitation
@@ -68,7 +64,6 @@ module Octokit
       # @return [Array<Sawyer::Resource>] The users repository invitations
       # @see https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations
       def user_repository_invitations(options = {})
-        options = ensure_api_media_type(:repository_invitations, options)
         paginate "/user/repository_invitations", options
       end
       alias user_repo_invitations user_repository_invitations
@@ -81,7 +76,6 @@ module Octokit
       # @return [Boolean] True if the acceptance of the invitation was successful
       # @see https://developer.github.com/v3/repos/invitations/#accept-a-repository-invitation
       def accept_repository_invitation(invitation_id, options = {})
-        options = ensure_api_media_type(:repository_invitations, options)
         patch "/user/repository_invitations/#{invitation_id}", options
       end
       alias accept_repo_invitation accept_repository_invitation
@@ -94,7 +88,6 @@ module Octokit
       # @return [Boolean] True if the acceptance of the invitation was successful
       # @see https://developer.github.com/v3/repos/invitations/#decline-a-repository-invitation
       def decline_repository_invitation(invitation_id, options = {})
-        options = ensure_api_media_type(:repository_invitations, options)
         boolean_from_response :delete, "/user/repository_invitations/#{invitation_id}", options
       end
       alias decline_invitation decline_repository_invitation

--- a/lib/octokit/preview.rb
+++ b/lib/octokit/preview.rb
@@ -10,7 +10,6 @@ module Octokit
       :licenses               => 'application/vnd.github.drax-preview+json'.freeze,
       :source_imports         => 'application/vnd.github.barred-rock-preview'.freeze,
       :reactions              => 'application/vnd.github.squirrel-girl-preview'.freeze,
-      :repository_invitations => 'application/vnd.github.swamp-thing-preview+json'.freeze,
       :issue_timelines        => 'application/vnd.github.mockingbird-preview+json'.freeze,
       :nested_teams           => 'application/vnd.github.hellcat-preview+json'.freeze,
       :pages                  => 'application/vnd.github.mister-fantastic-preview+json'.freeze,

--- a/spec/octokit/client/repository_invitations_spec.rb
+++ b/spec/octokit/client/repository_invitations_spec.rb
@@ -20,14 +20,14 @@ describe Octokit::Client::RepositoryInvitations do
 
     describe ".invite_user_to_repository", :vcr do
       it "invites a user to a repository" do
-        @client.invite_user_to_repository(@repo.id, "tarebyte", accept: preview_header)
+        @client.invite_user_to_repository(@repo.id, "tarebyte")
         assert_requested :put, github_url("/repositories/#{@repo.id}/collaborators/tarebyte")
       end
     end
 
     describe ".repository_invitations", :vcr do
       it "lists the repositories outstanding invitations" do
-        invitations = @client.repository_invitations(@repo.id, accept: preview_header)
+        invitations = @client.repository_invitations(@repo.id)
         expect(invitations).to be_kind_of(Array)
         assert_requested :get, github_url("/repositories/#{@repo.id}/invitations")
       end
@@ -35,7 +35,7 @@ describe Octokit::Client::RepositoryInvitations do
 
     describe ".user_repository_invitations", :vcr do
       it "lists the users repository invitations" do
-        invitations = @client.user_repository_invitations(accept: preview_header)
+        invitations = @client.user_repository_invitations
         expect(invitations).to be_kind_of(Array)
         assert_requested :get, github_url("/user/repository_invitations")
       end
@@ -49,7 +49,7 @@ describe Octokit::Client::RepositoryInvitations do
       describe ".accept_repository_invitation", :vcr do
         it "accepts the repository invitation on behalf of the user" do
           request = stub_patch("/user/repository_invitations/#{@invitation_id}")
-          @client.accept_repository_invitation(@invitation_id, accept: preview_header)
+          @client.accept_repository_invitation(@invitation_id)
           assert_requested request
         end
       end
@@ -57,7 +57,7 @@ describe Octokit::Client::RepositoryInvitations do
       describe ".decline_repository_invitation", :vcr do
         it "declines the repository invitation on behalf of the user" do
           request = stub_delete("/user/repository_invitations/#{@invitation_id}")
-          @client.decline_repository_invitation(@invitation_id, accept: preview_header)
+          @client.decline_repository_invitation(@invitation_id)
           assert_requested request
         end
       end
@@ -65,28 +65,22 @@ describe Octokit::Client::RepositoryInvitations do
 
     context "with repository invitation" do
       before(:each) do
-        @invitation = @client.invite_user_to_repository(@repo.id, "tarebyte", accept: preview_header)
+        @invitation = @client.invite_user_to_repository(@repo.id, "tarebyte")
       end
 
       describe ".delete_repository_invitation", :vcr do
         it "deletes the repository invitation" do
-          @client.delete_repository_invitation(@repo.id, @invitation.id, accept: preview_header)
+          @client.delete_repository_invitation(@repo.id, @invitation.id)
           assert_requested :delete, github_url("/repositories/#{@repo.id}/invitations/#{@invitation.id}")
         end
       end
 
       describe ".update_repository_invitation", :vcr do
         it "updates the repository invitation" do
-          @client.update_repository_invitation(@repo.id, @invitation.id, :permissions => "read", accept: preview_header)
+          @client.update_repository_invitation(@repo.id, @invitation.id, :permissions => "read")
           assert_requested :patch, github_url("/repositories/#{@repo.id}/invitations/#{@invitation.id}")
         end
       end
     end
-  end
-
-  private
-
-  def preview_header
-    Octokit::Preview::PREVIEW_TYPES[:repository_invitations]
   end
 end


### PR DESCRIPTION
The swamp-thing preview was graduated on July 2, 2018.