### PR TITLE
Look preview header up in preview types hash

### DIFF
--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -14,7 +14,7 @@ describe Octokit::Client::Repositories do
     end
 
     it "returns the repository, including topics" do
-      repository = @client.repository("github/linguist", :accept => 'application/vnd.github.mercy-preview+json')
+      repository = @client.repository("github/linguist", :accept => Octokit::Preview::PREVIEW_TYPES[:topic])
       expect(repository.topics).to be_kind_of Array
       expect(repository.topics).to include("syntax-highlighting")
     end


### PR DESCRIPTION
This avoids typos, and makes it easier to detect cleanup that needs to happen when previews are graduated.