### PR TITLE
Add Ruby 2.5 to Supported Ruby Versions [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ implementations:
 * Ruby 2.2
 * Ruby 2.3
 * Ruby 2.4
+* Ruby 2.5
 
 If something doesn't work on one of these Ruby versions, it's a bug.
 


### PR DESCRIPTION
Follow up of 24673aaa3981c724540a1634fdfb7cbd7b6c3479