### PR TITLE
Don't add name key in API call

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -524,7 +524,7 @@ module Octokit
       # @example Add a team with admin permissions
       #   @client.add_team_repository(100000, 'github/developer.github.com', permission: 'admin')
       def add_team_repository(team_id, repo, options = {})
-        boolean_from_response :put, "teams/#{team_id}/repos/#{Repository.new(repo)}", options.merge(:name => Repository.new(repo))
+        boolean_from_response :put, "teams/#{team_id}/repos/#{Repository.new(repo)}", options
       end
       alias :add_team_repo :add_team_repository
 


### PR DESCRIPTION
Fixes #1051 

When calling add_or_update_team_repository the "name" parameter is not only unnecessary but looks like recently GitHub API rejects the call
(see https://developer.github.com/v3/teams/#add-or-update-team-repository)