### PR TITLE
Remove the :name key from #add_team_repository request

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -524,7 +524,7 @@ module Octokit
       # @example Add a team with admin permissions
       #   @client.add_team_repository(100000, 'github/developer.github.com', permission: 'admin')
       def add_team_repository(team_id, repo, options = {})
-        boolean_from_response :put, "teams/#{team_id}/repos/#{Repository.new(repo)}", options.merge(:name => Repository.new(repo))
+        boolean_from_response :put, "teams/#{team_id}/repos/#{Repository.new(repo)}", options
       end
       alias :add_team_repo :add_team_repository
 


### PR DESCRIPTION
## What
It appears the API began validating the presence of parameters on the request `teams/:team_id/repos/:org/:repo_name`. When a request contained the parameter key `name` it would be rejected by the API with a status of `422`. 

Using the method `#add_team_repository` would yield a `422` status with the message:
```js
"name" is not a permitted key. // See: https://developer.github.com/v3/teams/#add-or-update-team-repository
```

This PR proposes a fix to drop the extra param `:name` which no longer serves a purpose.

API reference [`https://developer.github.com/v3/teams/#add-or-update-team-repository`](https://developer.github.com/v3/teams/#add-or-update-team-repository)

---
Fixes #1051 closes #1053 