### PR TITLE
Add Octopoller section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Upgrading? Check the [Upgrade Guide](#upgrading-guide) before bumping to a new
     1. [Running and writing new tests](#running-and-writing-new-tests)
 15. [Supported Ruby Versions](#supported-ruby-versions)
 16. [Versioning](#versioning)
-17. [License](#license)
+17. [Making Repeating Requests](#making-repeating-requests)
+18. [License](#license)
 
 ## Philosophy
 
@@ -726,6 +727,8 @@ The changes made between versions can be seen on the [project releases page][rel
 [semver]: http://semver.org/
 [pvc]: http://guides.rubygems.org/patterns/#pessimistic-version-constraint
 [releases]: https://github.com/octokit/octokit.rb/releases
+
+## Making Repeating Requests
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -729,6 +729,19 @@ The changes made between versions can be seen on the [project releases page][rel
 [releases]: https://github.com/octokit/octokit.rb/releases
 
 ## Making Repeating Requests
+Sometimes one might need to poll for progress or retry a request on failure. For these circumstances we designed [Octopoller](https://github.com/octokit/octopoller.rb), a micro gem perfect for making repeating requests.
+
+```ruby
+Octopoller.poll(timeout: 15.seconds) do
+  begin
+    client.request_progress # ex. request a long running job's status
+  rescue Error
+    :re_poll
+  end
+end
+```
+
+This is useful when making requests such as a [Source Import's progress](https://developer.github.com/v3/migrations/source_imports/#get-import-progress).
 
 ## License
 


### PR DESCRIPTION
This PR proposes a new section be added to the readme to show off Octopoller's use case and usability. 

Closes: https://github.com/octokit/octopoller.rb/issues/4
CC: @octokit/octopoller 