### PR TITLE
Support auto pagination in org_projects

### DIFF
--- a/lib/octokit/client/projects.rb
+++ b/lib/octokit/client/projects.rb
@@ -51,7 +51,7 @@ module Octokit
       #   @client.org_projects("octokit")
       def org_projects(org, options = {})
         opts = ensure_api_media_type(:projects, options)
-        get "orgs/#{org}/projects", opts
+        paginate "orgs/#{org}/projects", opts
       end
       alias :organization_projects :org_projects
 


### PR DESCRIPTION
This allows the `auto_paginate` setting on the Client object to work with `org_projects` and prevents people from having to paginate manually even when using auto pagination.