### PR TITLE
Update ruby support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: ruby
 
 rvm:
   - jruby-19mode
-  - 2.0
-  - 2.1
-  - 2.2.10
   - 2.3.7
   - 2.4.4
   - 2.5.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: ruby
 rvm:
   - jruby-19mode
   - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.4.5
+  - 2.5.3
 
 bundler_args: --without development
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.3.7
   - 2.4.5
   - 2.5.3
+  - 2.6.0
 
 bundler_args: --without development
 

--- a/README.md
+++ b/README.md
@@ -712,6 +712,7 @@ implementations:
 * Ruby 2.3
 * Ruby 2.4
 * Ruby 2.5
+* Ruby 2.6
 
 If something doesn't work on one of these Ruby versions, it's a bug.
 

--- a/README.md
+++ b/README.md
@@ -709,9 +709,6 @@ when writing new specs.
 This library aims to support and is [tested against][travis] the following Ruby
 implementations:
 
-* Ruby 2.0
-* Ruby 2.1
-* Ruby 2.2
 * Ruby 2.3
 * Ruby 2.4
 * Ruby 2.5

--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'octokit/version'
 
 Gem::Specification.new do |spec|
-  spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_dependency 'sawyer', '>= 0.5.3', '~> 0.8.0'
   spec.authors = ["Wynn Netherland", "Erik Michaels-Ober", "Clint Shryock"]
   spec.description = %q{Simple wrapper for the GitHub API}

--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |spec|
   spec.licenses = ['MIT']
   spec.name = 'octokit'
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.0.0'
-  spec.required_rubygems_version = '>= 1.3.5'
+  spec.required_ruby_version = '>= 2.3.7'
+  spec.required_rubygems_version = '>= 2.5.2.3'
   spec.summary = "Ruby toolkit for working with the GitHub API"
   spec.version = Octokit::VERSION.dup
 end


### PR DESCRIPTION
Hi

With the release of bundler v2, the CI of ruby ​​2.3 was broken.

https://bundler.io/blog/2019/01/03/announcing-bundler-2.html

In order to fix this we need to use bundler v2, and as a result we need to finish support before ruby ​​2.2.
Since Ruby 2.2 is EOL, I think that there is no problem.

Thanx.