### PR TITLE
Add `Octokit::TooLargeContent` for relevant 403 status

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -63,6 +63,8 @@ module Octokit
         Octokit::TooManyRequests
       elsif body =~ /login attempts exceeded/i
         Octokit::TooManyLoginAttempts
+      elsif body =~ /returns blobs up to [0-9]+ MB/i
+        Octokit::TooLargeContent
       elsif body =~ /abuse/i
         Octokit::AbuseDetected
       elsif body =~ /repository access blocked/i
@@ -230,6 +232,10 @@ module Octokit
   # Raised when GitHub returns a 403 HTTP status code
   # and body matches 'login attempts exceeded'
   class TooManyLoginAttempts < Forbidden; end
+
+  # Raised when GitHub returns a 403 HTTP status code
+  # and body matches 'returns blobs up to [0-9]+ MB'
+  class TooLargeContent < Forbidden; end
 
   # Raised when GitHub returns a 403 HTTP status code
   # and body matches 'abuse'

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -848,6 +848,14 @@ describe Octokit::Client do
         :headers => {
           :content_type => "application/json",
         },
+        :body => {:message => "This API returns blobs up to 1 MB in size"}.to_json
+      expect { Octokit.get('/user') }.to raise_error Octokit::TooLargeContent
+
+      stub_get('/user').to_return \
+        :status => 403,
+        :headers => {
+          :content_type => "application/json",
+        },
         :body => {:message => "You have triggered an abuse detection mechanism and have been temporarily blocked from content creation. Please retry your request again later."}.to_json
       expect { Octokit.get('/user') }.to raise_error Octokit::AbuseDetected
 


### PR DESCRIPTION
I try adding the new exception class `Octokit::TooLargeContent`. Please give me any feedback. 🙏 

Fix #1104 
