### PR TITLE
add # frozen_string_literal: true all files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'jruby-openssl', :platforms => :jruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler'
 Bundler::GemHelper.install_tasks
 

--- a/lib/ext/sawyer/relation.rb
+++ b/lib/ext/sawyer/relation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sawyer'
 
 patch = Module.new do

--- a/lib/octokit.rb
+++ b/lib/octokit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'octokit/client'
 require 'octokit/enterprise_admin_client'
 require 'octokit/enterprise_management_console_client'

--- a/lib/octokit/arguments.rb
+++ b/lib/octokit/arguments.rb
@@ -1,5 +1,6 @@
-module Octokit
+# frozen_string_literal: true
 
+module Octokit
   # Extracts options from method arguments
   # @private
   class Arguments < Array

--- a/lib/octokit/authentication.rb
+++ b/lib/octokit/authentication.rb
@@ -1,5 +1,6 @@
-module Octokit
+# frozen_string_literal: true
 
+module Octokit
   # Authentication methods for {Octokit::Client}
   module Authentication
 

--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'octokit/connection'
 require 'octokit/warnable'
 require 'octokit/arguments'

--- a/lib/octokit/client/apps.rb
+++ b/lib/octokit/client/apps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/authorizations.rb
+++ b/lib/octokit/client/authorizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/checks.rb
+++ b/lib/octokit/client/checks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/commit_comments.rb
+++ b/lib/octokit/client/commit_comments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/commits.rb
+++ b/lib/octokit/client/commits.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'date'
 
 module Octokit

--- a/lib/octokit/client/community_profile.rb
+++ b/lib/octokit/client/community_profile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/contents.rb
+++ b/lib/octokit/client/contents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Octokit

--- a/lib/octokit/client/deployments.rb
+++ b/lib/octokit/client/deployments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/downloads.rb
+++ b/lib/octokit/client/downloads.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/emojis.rb
+++ b/lib/octokit/client/emojis.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/events.rb
+++ b/lib/octokit/client/events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/feeds.rb
+++ b/lib/octokit/client/feeds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/gists.rb
+++ b/lib/octokit/client/gists.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/gitignore.rb
+++ b/lib/octokit/client/gitignore.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/hooks.rb
+++ b/lib/octokit/client/hooks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/issues.rb
+++ b/lib/octokit/client/issues.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/labels.rb
+++ b/lib/octokit/client/labels.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 
 module Octokit

--- a/lib/octokit/client/legacy_search.rb
+++ b/lib/octokit/client/legacy_search.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/licenses.rb
+++ b/lib/octokit/client/licenses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/markdown.rb
+++ b/lib/octokit/client/markdown.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/marketplace.rb
+++ b/lib/octokit/client/marketplace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/meta.rb
+++ b/lib/octokit/client/meta.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/milestones.rb
+++ b/lib/octokit/client/milestones.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/notifications.rb
+++ b/lib/octokit/client/notifications.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/objects.rb
+++ b/lib/octokit/client/objects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/pages.rb
+++ b/lib/octokit/client/pages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/projects.rb
+++ b/lib/octokit/client/projects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/pub_sub_hubbub.rb
+++ b/lib/octokit/client/pub_sub_hubbub.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/pull_requests.rb
+++ b/lib/octokit/client/pull_requests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/rate_limit.rb
+++ b/lib/octokit/client/rate_limit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/reactions.rb
+++ b/lib/octokit/client/reactions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/refs.rb
+++ b/lib/octokit/client/refs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/releases.rb
+++ b/lib/octokit/client/releases.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/repositories.rb
+++ b/lib/octokit/client/repositories.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/repository_invitations.rb
+++ b/lib/octokit/client/repository_invitations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/reviews.rb
+++ b/lib/octokit/client/reviews.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/say.rb
+++ b/lib/octokit/client/say.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/search.rb
+++ b/lib/octokit/client/search.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/service_status.rb
+++ b/lib/octokit/client/service_status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/source_import.rb
+++ b/lib/octokit/client/source_import.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/stats.rb
+++ b/lib/octokit/client/stats.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/statuses.rb
+++ b/lib/octokit/client/statuses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/traffic.rb
+++ b/lib/octokit/client/traffic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/client/users.rb
+++ b/lib/octokit/client/users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
 

--- a/lib/octokit/configurable.rb
+++ b/lib/octokit/configurable.rb
@@ -1,5 +1,6 @@
-module Octokit
+# frozen_string_literal: true
 
+module Octokit
   # Configuration options for {Client}, defaulting to values
   # in {Default}
   module Configurable

--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sawyer'
 require 'octokit/authentication'
 module Octokit

--- a/lib/octokit/default.rb
+++ b/lib/octokit/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'octokit/middleware/follow_redirects'
 require 'octokit/response/raise_error'
 require 'octokit/response/feed_parser'

--- a/lib/octokit/enterprise_admin_client.rb
+++ b/lib/octokit/enterprise_admin_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'octokit/connection'
 require 'octokit/configurable'
 require 'octokit/warnable'

--- a/lib/octokit/enterprise_admin_client/admin_stats.rb
+++ b/lib/octokit/enterprise_admin_client/admin_stats.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class EnterpriseAdminClient
 

--- a/lib/octokit/enterprise_admin_client/license.rb
+++ b/lib/octokit/enterprise_admin_client/license.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class EnterpriseAdminClient
 

--- a/lib/octokit/enterprise_admin_client/orgs.rb
+++ b/lib/octokit/enterprise_admin_client/orgs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class EnterpriseAdminClient
 

--- a/lib/octokit/enterprise_admin_client/search_indexing.rb
+++ b/lib/octokit/enterprise_admin_client/search_indexing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class EnterpriseAdminClient
 

--- a/lib/octokit/enterprise_admin_client/users.rb
+++ b/lib/octokit/enterprise_admin_client/users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class EnterpriseAdminClient
 

--- a/lib/octokit/enterprise_management_console_client.rb
+++ b/lib/octokit/enterprise_management_console_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'octokit/configurable'
 require 'octokit/connection'
 require 'octokit/warnable'

--- a/lib/octokit/enterprise_management_console_client/management_console.rb
+++ b/lib/octokit/enterprise_management_console_client/management_console.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class EnterpriseManagementConsoleClient
 

--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   # Custom error class for rescuing from all GitHub errors
   class Error < StandardError

--- a/lib/octokit/gist.rb
+++ b/lib/octokit/gist.rb
@@ -1,5 +1,6 @@
-module Octokit
+# frozen_string_literal: true
 
+module Octokit
   # Class to parse and create Gist URLs
   class Gist
 

--- a/lib/octokit/middleware/follow_redirects.rb
+++ b/lib/octokit/middleware/follow_redirects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'faraday'
 require 'set'
 

--- a/lib/octokit/organization.rb
+++ b/lib/octokit/organization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   # GitHub organization class to generate API path urls
   class Organization

--- a/lib/octokit/preview.rb
+++ b/lib/octokit/preview.rb
@@ -1,5 +1,6 @@
-module Octokit
+# frozen_string_literal: true
 
+module Octokit
   # Default setup options for preview features
   module Preview
 

--- a/lib/octokit/rate_limit.rb
+++ b/lib/octokit/rate_limit.rb
@@ -1,5 +1,6 @@
-module Octokit
+# frozen_string_literal: true
 
+module Octokit
   # Class for API Rate Limit info
   #
   # @!attribute [w] limit

--- a/lib/octokit/repo_arguments.rb
+++ b/lib/octokit/repo_arguments.rb
@@ -1,9 +1,9 @@
-module Octokit
+# frozen_string_literal: true
 
+module Octokit
   # Class to extract options from Ruby arguments for
   # Repository-related methods
   class RepoArguments < Arguments
-
     # !@attribute [r] repo
     #   @return [Repository]
     attr_reader :repo

--- a/lib/octokit/repository.rb
+++ b/lib/octokit/repository.rb
@@ -1,5 +1,6 @@
-module Octokit
+# frozen_string_literal: true
 
+module Octokit
   # Class to parse GitHub repository owner and name from
   # URLs and to generate URLs
   class Repository

--- a/lib/octokit/response/feed_parser.rb
+++ b/lib/octokit/response/feed_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'faraday'
 
 module Octokit

--- a/lib/octokit/response/raise_error.rb
+++ b/lib/octokit/response/raise_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'faraday'
 require 'octokit/error'
 

--- a/lib/octokit/user.rb
+++ b/lib/octokit/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   # GitHub user class to generate API path urls
   class User

--- a/lib/octokit/version.rb
+++ b/lib/octokit/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   # Current major release.
   # @return [Integer]

--- a/lib/octokit/warnable.rb
+++ b/lib/octokit/warnable.rb
@@ -1,5 +1,6 @@
-module Octokit
+# frozen_string_literal: true
 
+module Octokit
   # Allows warnings to be suppressed via environment variable.
   module Warnable
 

--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'octokit/version'

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if RUBY_ENGINE == 'ruby'
   require 'simplecov'
   require 'coveralls'

--- a/spec/octokit/client/apps_spec.rb
+++ b/spec/octokit/client/apps_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Apps do

--- a/spec/octokit/client/authorizations_spec.rb
+++ b/spec/octokit/client/authorizations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Authorizations do

--- a/spec/octokit/client/checks_spec.rb
+++ b/spec/octokit/client/checks_spec.rb
@@ -1,4 +1,6 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 describe Octokit::Client::Checks, :vcr do
   before do

--- a/spec/octokit/client/commit_comments_spec.rb
+++ b/spec/octokit/client/commit_comments_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::CommitComments do

--- a/spec/octokit/client/commits_spec.rb
+++ b/spec/octokit/client/commits_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Commits do

--- a/spec/octokit/client/community_profile_spec.rb
+++ b/spec/octokit/client/community_profile_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::CommunityProfile do

--- a/spec/octokit/client/contents_spec.rb
+++ b/spec/octokit/client/contents_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 require 'tempfile'
 

--- a/spec/octokit/client/deployments_spec.rb
+++ b/spec/octokit/client/deployments_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Deployments do

--- a/spec/octokit/client/downloads_spec.rb
+++ b/spec/octokit/client/downloads_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Downloads do

--- a/spec/octokit/client/emojis_spec.rb
+++ b/spec/octokit/client/emojis_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Emojis do

--- a/spec/octokit/client/events_spec.rb
+++ b/spec/octokit/client/events_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Events do

--- a/spec/octokit/client/feeds_spec.rb
+++ b/spec/octokit/client/feeds_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Feeds do

--- a/spec/octokit/client/gists_spec.rb
+++ b/spec/octokit/client/gists_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Gists do

--- a/spec/octokit/client/gitignore_spec.rb
+++ b/spec/octokit/client/gitignore_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Gitignore do

--- a/spec/octokit/client/hooks_spec.rb
+++ b/spec/octokit/client/hooks_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Hooks do

--- a/spec/octokit/client/issues_spec.rb
+++ b/spec/octokit/client/issues_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Issues do

--- a/spec/octokit/client/labels_spec.rb
+++ b/spec/octokit/client/labels_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Labels do

--- a/spec/octokit/client/legacy_search_spec.rb
+++ b/spec/octokit/client/legacy_search_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::LegacySearch do

--- a/spec/octokit/client/licenses_spec.rb
+++ b/spec/octokit/client/licenses_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Licenses do

--- a/spec/octokit/client/markdown_spec.rb
+++ b/spec/octokit/client/markdown_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Markdown do

--- a/spec/octokit/client/marketplace_spec.rb
+++ b/spec/octokit/client/marketplace_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Marketplace do

--- a/spec/octokit/client/meta_spec.rb
+++ b/spec/octokit/client/meta_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Meta do

--- a/spec/octokit/client/milestones_spec.rb
+++ b/spec/octokit/client/milestones_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Milestones do

--- a/spec/octokit/client/notifications_spec.rb
+++ b/spec/octokit/client/notifications_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Notifications do

--- a/spec/octokit/client/objects_spec.rb
+++ b/spec/octokit/client/objects_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Objects do

--- a/spec/octokit/client/organizations_spec.rb
+++ b/spec/octokit/client/organizations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Organizations do

--- a/spec/octokit/client/pages_spec.rb
+++ b/spec/octokit/client/pages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Pages do

--- a/spec/octokit/client/projects_spec.rb
+++ b/spec/octokit/client/projects_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Projects do

--- a/spec/octokit/client/pub_sub_hubbub_spec.rb
+++ b/spec/octokit/client/pub_sub_hubbub_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::PubSubHubbub do

--- a/spec/octokit/client/pull_requests_spec.rb
+++ b/spec/octokit/client/pull_requests_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::PullRequests do

--- a/spec/octokit/client/rate_limit_spec.rb
+++ b/spec/octokit/client/rate_limit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client do

--- a/spec/octokit/client/reactions_spec.rb
+++ b/spec/octokit/client/reactions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Reactions do

--- a/spec/octokit/client/refs_spec.rb
+++ b/spec/octokit/client/refs_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Refs do

--- a/spec/octokit/client/releases_spec.rb
+++ b/spec/octokit/client/releases_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Releases do

--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Repositories do

--- a/spec/octokit/client/repository_invitations_spec.rb
+++ b/spec/octokit/client/repository_invitations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::RepositoryInvitations do

--- a/spec/octokit/client/reviews_spec.rb
+++ b/spec/octokit/client/reviews_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 require 'securerandom'
 

--- a/spec/octokit/client/say_spec.rb
+++ b/spec/octokit/client/say_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Say do

--- a/spec/octokit/client/search_spec.rb
+++ b/spec/octokit/client/search_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Search do

--- a/spec/octokit/client/service_status_spec.rb
+++ b/spec/octokit/client/service_status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::ServiceStatus do

--- a/spec/octokit/client/source_import_spec.rb
+++ b/spec/octokit/client/source_import_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::SourceImport do

--- a/spec/octokit/client/stats_spec.rb
+++ b/spec/octokit/client/stats_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Stats do

--- a/spec/octokit/client/statuses_spec.rb
+++ b/spec/octokit/client/statuses_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Statuses do

--- a/spec/octokit/client/traffic_spec.rb
+++ b/spec/octokit/client/traffic_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Traffic do

--- a/spec/octokit/client/users_spec.rb
+++ b/spec/octokit/client/users_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::Users do

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 require 'json'
 

--- a/spec/octokit/enterprise_admin_client/admin_stats_spec.rb
+++ b/spec/octokit/enterprise_admin_client/admin_stats_spec.rb
@@ -1,7 +1,8 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 describe Octokit::EnterpriseAdminClient::AdminStats do
-
   before do
     Octokit.reset!
     @admin_client = enterprise_admin_client

--- a/spec/octokit/enterprise_admin_client/license_spec.rb
+++ b/spec/octokit/enterprise_admin_client/license_spec.rb
@@ -1,7 +1,8 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 describe Octokit::EnterpriseAdminClient::License do
-
   before do
     Octokit.reset!
     @admin_client = enterprise_admin_client

--- a/spec/octokit/enterprise_admin_client/orgs_spec.rb
+++ b/spec/octokit/enterprise_admin_client/orgs_spec.rb
@@ -1,7 +1,8 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 describe Octokit::EnterpriseAdminClient::Orgs do
-
   before do
     Octokit.reset!
     @admin_client = enterprise_admin_client

--- a/spec/octokit/enterprise_admin_client/search_indexing_spec.rb
+++ b/spec/octokit/enterprise_admin_client/search_indexing_spec.rb
@@ -1,7 +1,8 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 describe Octokit::EnterpriseAdminClient::SearchIndexing do
-
   before do
     Octokit.reset!
     @admin_client = enterprise_admin_client

--- a/spec/octokit/enterprise_admin_client/users_spec.rb
+++ b/spec/octokit/enterprise_admin_client/users_spec.rb
@@ -1,7 +1,8 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 describe Octokit::EnterpriseAdminClient::Users do
-
   before do
     Octokit.reset!
     @admin_client = enterprise_admin_client

--- a/spec/octokit/enterprise_admin_client_spec.rb
+++ b/spec/octokit/enterprise_admin_client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::EnterpriseAdminClient do

--- a/spec/octokit/enterprise_management_console_client/management_console_spec.rb
+++ b/spec/octokit/enterprise_management_console_client/management_console_spec.rb
@@ -1,7 +1,8 @@
-require "helper"
+# frozen_string_literal: true
+
+require 'helper'
 
 describe Octokit::EnterpriseManagementConsoleClient::ManagementConsole do
-
   before do
     Octokit.reset!
     @enterprise_management_console_client = enterprise_management_console_client

--- a/spec/octokit/enterprise_management_console_spec.rb
+++ b/spec/octokit/enterprise_management_console_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::EnterpriseManagementConsoleClient do

--- a/spec/octokit/gist_spec.rb
+++ b/spec/octokit/gist_spec.rb
@@ -1,4 +1,5 @@
-# -*- encoding: utf-8 -*-
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Gist do

--- a/spec/octokit/organization_spec.rb
+++ b/spec/octokit/organization_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Organization do

--- a/spec/octokit/rate_limit_spec.rb
+++ b/spec/octokit/rate_limit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 require 'octokit/rate_limit'
 

--- a/spec/octokit/repository_spec.rb
+++ b/spec/octokit/repository_spec.rb
@@ -1,4 +1,5 @@
-# -*- encoding: utf-8 -*-
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Repository do

--- a/spec/octokit/user_spec.rb
+++ b/spec/octokit/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::User do

--- a/spec/octokit_spec.rb
+++ b/spec/octokit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit do

--- a/yard/default/layout/html/setup.rb
+++ b/yard/default/layout/html/setup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def diskfile
   @file.attributes[:markup] ||= markup_for_file('', @file.filename)
   data = htmlify(@file.contents, @file.attributes[:markup])


### PR DESCRIPTION
# background
In Ruby 3.x changed string default type will be immutable.
need to add frozen setting.

reference: https://stackoverflow.com/questions/37799296/what-does-the-comment-frozen-string-literal-true-do

# todo

- [x] add `frozen_string_literal: true` every files

# check script


```
`find . -type f | grep rb | grep -v vendor| xargs grep -l frozen_string_literal | tee wanko`
`find . -type f | grep rb | grep -v vendor| tee neko`
p `cat neko`.split("\n") == `cat wanko`.split("\n")
# => true
```