### PR TITLE
Add support for find team by name

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -324,6 +324,20 @@ module Octokit
         get "teams/#{team_id}", options
       end
 
+      # Get team by name and org
+      #
+      # Requires authenticated organization member.
+      #
+      # @param org [String, Integer] Organization GitHub login or id.
+      # @param team_slug [String] Team slug.
+      # @return [Sawyer::Resource] Hash representing team.
+      # @see https://developer.github.com/v3/teams/#get-team-by-name
+      # @example
+      #   @client.team("github", "justice-league")
+      def team_by_name(org, team_slug, options = {})
+        get "/orgs/#{org}/teams/#{team_slug}", options
+      end
+
       # List child teams
       #
       # Requires authenticated organization member.

--- a/spec/octokit/client/organizations_spec.rb
+++ b/spec/octokit/client/organizations_spec.rb
@@ -147,6 +147,14 @@ describe Octokit::Client::Organizations do
       end
     end # .team
 
+    describe ".team_by_name", :vcr do
+      it "returns a team found by name" do
+        team = @client.team_by_name(test_github_org, @team.slug)
+        expect(team.id).to eq(@team.id)
+        assert_requested :get, github_url("/orgs/#{test_github_org}/teams/#{@team.slug}")
+      end
+    end # .team_by_name
+
     describe ".update_team", :vcr do
       it "updates a team" do
         @client.update_team(@team.id, :name => "API Jedi")


### PR DESCRIPTION
I noticed that octokit.rb lets one find a team by its id, but that it doesn't currently have the functionality to find a team by name, like the [API does](https://developer.github.com/v3/teams/#get-team-by-name).

So, here's a PR to add that. Thanks!