### PR TITLE
Update deprecated `version` for `ruby-version`

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        version: ${{ matrix.ruby_version }}
+        ruby-version: ${{ matrix.ruby_version }}
     - name: Setup .netrc
       run: |
         chmod 600 spec/fixtures/.netrc


### PR DESCRIPTION
A fix for the warning on [our CI builds](https://github.com/octokit/octokit.rb/pull/1138/checks?check_run_id=230322184#step:3:1):
```
##[warning]Input 'version' has been deprecated with message: The version property will not be supported after October 1, 2019. Use ruby-version instead
```
Note: support is dropping for it in about a week and a half.