### PR TITLE
Fix Superclass of RedirectLimitReached

### DIFF
--- a/lib/octokit/middleware/follow_redirects.rb
+++ b/lib/octokit/middleware/follow_redirects.rb
@@ -11,7 +11,7 @@ module Octokit
   module Middleware
 
     # Public: Exception thrown when the maximum amount of requests is exceeded.
-    class RedirectLimitReached < Faraday::Error::ClientError
+    class RedirectLimitReached < Faraday::ClientError
       attr_reader :response
 
       def initialize(response)


### PR DESCRIPTION
I am currently getting this error

```
irb(main):001:0> require 'faraday'
=> true
irb(main):002:0> Faraday::VERSION
=> "0.16.1"
irb(main):003:0> class Hoge < Faraday::Error::ClientError; end
TypeError: superclass must be a Class (Faraday::DeprecatedConstant given)
	from (irb):3
	from /usr/bin/irb:11:in `<main>'
```

This is probably because Faraday :: Error :: ClientError is deprecated.

Use the following class to see faraday.
@see https://github.com/lostisland/faraday/blob/master/lib/faraday/error.rb#L41

```
irb(main):004:0> require 'faraday'
=> true
irb(main):005:0> class Hoge < Faraday::ClientError; end
=> nil
```