### PR TITLE
Add SAML enforcement error to list of possible 403 reasons

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -75,6 +75,8 @@ module Octokit
         Octokit::AccountSuspended
       elsif body =~ /billing issue/i
         Octokit::BillingIssue
+      elsif body =~ /Resource protected by organization SAML enforcement/i
+        Octokit::SAMLProtected
       else
         Octokit::Forbidden
       end

--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -261,6 +261,10 @@ module Octokit
   # and body matches 'billing issue'
   class BillingIssue < Forbidden; end
 
+  # Raised when GitHub returns a 403 HTTP status code
+  # and body matches 'Resource protected by organization SAML enforcement'
+  class SAMLProtected < Forbidden; end
+
   # Raised when GitHub returns a 404 HTTP status code
   class NotFound < ClientError; end
 

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -891,13 +891,13 @@ describe Octokit::Client do
         :body => {:message => "The repository has been disabled due to a billing issue with the owner account."}.to_json
       expect { Octokit.post("/user/repos") }.to raise_error Octokit::BillingIssue
 
-      stub_post('/teams/8675309').to_return \
+      stub_get('/teams/8675309').to_return \
         :status => 403,
         :headers => {
             :content_type => "application/json",
         },
         :body => {:message => "Resource protected by organization SAML enforcement. You must grant your personal token access to this organization."}.to_json
-      expect { Octokit.post("/teams/8675309") }.to raise_error Octokit::SAMLProtected
+      expect { Octokit.get("/teams/8675309") }.to raise_error Octokit::SAMLProtected
 
       stub_get('/torrentz').to_return \
         :status => 451,

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -891,6 +891,14 @@ describe Octokit::Client do
         :body => {:message => "The repository has been disabled due to a billing issue with the owner account."}.to_json
       expect { Octokit.post("/user/repos") }.to raise_error Octokit::BillingIssue
 
+      stub_post('/teams/8675309').to_return \
+        :status => 403,
+        :headers => {
+            :content_type => "application/json",
+        },
+        :body => {:message => "Resource protected by organization SAML enforcement. You must grant your personal token access to this organization."}.to_json
+      expect { Octokit.post("/teams/8675309") }.to raise_error Octokit::SAMLProtected
+
       stub_get('/torrentz').to_return \
         :status => 451,
         :headers => {


### PR DESCRIPTION
This adds a custom error class for `403` responses when the resource is SAML protected.

This makes error handling much easier 😄 