### PR TITLE
Add 4-stable brach to CI config

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,9 +4,11 @@ on:
    push:
      branches:
      - master
+     - 4-stable
    pull_request:
      branches:
      - master
+     - 4-stable
 
 jobs:
   test:


### PR DESCRIPTION
This allows CI to run on PRs that are open against `master` and `4-stable`