### PR TITLE
[Backport] "Update Pagination section of README to use client.get"

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ link relations](#hypermedia-agent).
 
 ```ruby
 issues = client.issues 'rails/rails'
-issues.concat client.last_response.rels[:next].get.data
+issues.concat client.get(client.last_response.rels[:next].href)
 ```
 
 ### Auto pagination


### PR DESCRIPTION
> Based on https://github.com/octokit/octokit.rb/issues/517, the docs are somewhat misleading because the pagination method only works for 1 additional page. Since that's a somewhat rare use-case, it would save some readers confusion to not have to face this bug