### PR TITLE
[CI] Add 4-stable branch to CI config

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,9 +4,11 @@ on:
    push:
      branches:
      - master
+     - 4-stable
    pull_request:
      branches:
      - master
+     - 4-stable
 
 jobs:
   test:


### PR DESCRIPTION
This should fix the issue where folks who are opening PRs against the `4-stable` branch aren't being built.