### PR TITLE
[Backport] Remove the user of client_id and client_secret as query parameters

### DIFF
--- a/lib/octokit/authentication.rb
+++ b/lib/octokit/authentication.rb
@@ -43,21 +43,12 @@ module Octokit
     # requests at a higher rate limit
     #
     # @see https://developer.github.com/v3/#unauthenticated-rate-limited-requests
-    # @return Boolean
+    # @return [Boolean]
     def application_authenticated?
-      !!application_authentication
+      @client_id && @client_secret
     end
 
     private
-
-    def application_authentication
-      if @client_id && @client_secret
-        {
-          :client_id     => @client_id,
-          :client_secret => @client_secret
-        }
-      end
-    end
 
     def login_from_netrc
       return unless netrc?

--- a/lib/octokit/client/users.rb
+++ b/lib/octokit/client/users.rb
@@ -54,7 +54,16 @@ module Octokit
           }
         })
 
-        post "#{web_endpoint}login/oauth/access_token", options
+        # In the event that someone passed in the client_id
+        # and client_secret as part of the Octokit::Client
+        # initialization, we need to clear them out.
+        #
+        # This is because the client_id and client_secret
+        # are now used as part of Basic Authentication.
+        client = self.dup
+        client.client_id = client.client_secret = nil
+
+        client.post "#{web_endpoint}login/oauth/access_token", options
       end
 
       # Validate user username and password

--- a/lib/octokit/client/users.rb
+++ b/lib/octokit/client/users.rb
@@ -54,16 +54,7 @@ module Octokit
           }
         })
 
-        # In the event that someone passed in the client_id
-        # and client_secret as part of the Octokit::Client
-        # initialization, we need to clear them out.
-        #
-        # This is because the client_id and client_secret
-        # are now used as part of Basic Authentication.
-        client = self.dup
-        client.client_id = client.client_secret = nil
-
-        client.post "#{web_endpoint}login/oauth/access_token", options
+        post "#{web_endpoint}login/oauth/access_token", options
       end
 
       # Validate user username and password

--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -113,7 +113,7 @@ module Octokit
         elsif bearer_authenticated?
           http.authorization 'Bearer', @bearer_token
         elsif application_authenticated?
-          http.params = http.params.merge application_authentication
+          http.basic_auth(@client_id, @client_secret)
         end
       end
     end

--- a/spec/octokit/client/users_spec.rb
+++ b/spec/octokit/client/users_spec.rb
@@ -232,11 +232,25 @@ describe Octokit::Client::Users do
   describe ".exchange_code_for_token" do
     context "with application authenticated client" do
       it "returns the access_token" do
-        client = Octokit::Client.new({client_id: '123', client_secret: '345'})
+        request_body = {
+          code: "code",
+          client_id: "123",
+          client_secret: "345"
+        }
+
+        client = Octokit::Client.new(
+          client_id: request_body[:client_id],
+          client_secret: request_body[:client_secret]
+        )
+
         request = stub_post("https://github.com/login/oauth/access_token").
-          with(:body => {:code=>"code", :client_id=>"123", :client_secret=>"345"}.to_json).
-          to_return(json_response("web_flow_token.json"))
+          with(
+            basic_auth: [request_body[:client_id], request_body[:client_secret]],
+            body: request_body.to_json
+          ).to_return(json_response("web_flow_token.json"))
+
         response = client.exchange_code_for_token("code")
+
         expect(response.access_token).to eq "this_be_ye_token/use_it_wisely"
         assert_requested request
       end

--- a/spec/octokit/client/users_spec.rb
+++ b/spec/octokit/client/users_spec.rb
@@ -233,7 +233,7 @@ describe Octokit::Client::Users do
     context "with application authenticated client" do
       it "returns the access_token" do
         client = Octokit::Client.new({client_id: '123', client_secret: '345'})
-        request = stub_post("https://github.com/login/oauth/access_token?client_id=123&client_secret=345").
+        request = stub_post("https://github.com/login/oauth/access_token").
           with(:body => {:code=>"code", :client_id=>"123", :client_secret=>"345"}.to_json).
           to_return(json_response("web_flow_token.json"))
         response = client.exchange_code_for_token("code")

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -293,11 +293,14 @@ describe Octokit::Client do
 
     describe "when application authenticated" do
       it "makes authenticated calls" do
-        client = Octokit.client
-        client.client_id     = '97b4937b385eb63d1f46'
-        client.client_secret = 'd255197b4937b385eb63d1f4677e3ffee61fbaea'
+        client = Octokit::Client.new(
+          client_id: '97b4937b385eb63d1f46',
+          client_secret: 'd255197b4937b385eb63d1f4677e3ffee61fbaea'
+        )
 
-        root_request = stub_get("/?client_id=97b4937b385eb63d1f46&client_secret=d255197b4937b385eb63d1f4677e3ffee61fbaea")
+        root_request = stub_request(:get, github_url("/"))
+          .with(basic_auth: ["97b4937b385eb63d1f46", "d255197b4937b385eb63d1f4677e3ffee61fbaea"])
+
         client.get("/")
         assert_requested root_request
       end
@@ -327,7 +330,8 @@ describe Octokit::Client do
     end
 
     it "passes app creds in the query string" do
-      root_request = stub_get("/?client_id=97b4937b385eb63d1f46&client_secret=d255197b4937b385eb63d1f4677e3ffee61fbaea")
+      root_request = stub_request(:get, github_url("/"))
+          .with(basic_auth: ['97b4937b385eb63d1f46', 'd255197b4937b385eb63d1f4677e3ffee61fbaea'])
       client = Octokit.client
       client.client_id     = '97b4937b385eb63d1f46'
       client.client_secret = 'd255197b4937b385eb63d1f4677e3ffee61fbaea'
@@ -464,7 +468,7 @@ describe Octokit::Client do
       client = Octokit::Client.new
       client.client_id     = key = '97b4937b385eb63d1f46'
       client.client_secret = secret = 'd255197b4937b385eb63d1f4677e3ffee61fbaea'
-      root_request = stub_get "/?client_id=#{key}&client_secret=#{secret}"
+      root_request = stub_request(:get, github_url("/")).with(basic_auth: [key, secret])
 
       client.get("/")
       assert_requested root_request


### PR DESCRIPTION
This backports https://github.com/octokit/octokit.rb/pull/1192 to master