### PR TITLE
Fix API search doc link

### DIFF
--- a/lib/octokit/client/search.rb
+++ b/lib/octokit/client/search.rb
@@ -44,7 +44,7 @@ module Octokit
       # @option options [Integer] :page Page of paginated results
       # @option options [Integer] :per_page Number of items per page
       # @return [Sawyer::Resource] Search results object
-      # @see https://developer.github.com/v3/search/#search-issues
+      # @see https://developer.github.com/v3/search/#search-issues-and-pull-requests
       def search_issues(query, options = {})
         search "search/issues", query, options
       end


### PR DESCRIPTION
This is the `4-stable` version of #1199

Minor change, but based on what I can tell, this should be the proper anchor tag:

https://developer.github.com/v3/search/#search-issues-and-pull-requests

v.s.

https://developer.github.com/v3/search/#search-issues

Which will default to the table of contents (not that a user wouldn't be able to figure it out from there).