### PR TITLE
Return a boolean for application_authenticated

### DIFF
--- a/lib/octokit/authentication.rb
+++ b/lib/octokit/authentication.rb
@@ -45,7 +45,7 @@ module Octokit
     # @see https://developer.github.com/v3/#unauthenticated-rate-limited-requests
     # @return [Boolean]
     def application_authenticated?
-      @client_id && @client_secret
+      !!(@client_id && @client_secret)
     end
 
     private


### PR DESCRIPTION
Documentation specifies that this method returns a boolean when it returns the `@client_secret` or nil.