### PR TITLE
Support Ruby 2.7

### DIFF
--- a/.github/workflows/octokit.yml
+++ b/.github/workflows/octokit.yml
@@ -43,7 +43,9 @@ jobs:
         run: chmod 600 spec/fixtures/.netrc
       - name: Install dependencies
         run: |
-          bundle install --path=.bundle/gems --without=development --jobs 4 --retry 3
+          bundle config set path .bundle/gems
+          bundle config set without development
+          bundle install --jobs 4 --retry 3
       - name: Test with RSpec
         env:
           GITHUB_CI: 1

--- a/README.md
+++ b/README.md
@@ -713,16 +713,12 @@ when writing new specs.
 
 ## Supported Ruby Versions
 
-This library aims to support and is [tested against][travis] the following Ruby
+This library aims to support and is [tested against][actions] the following Ruby
 implementations:
 
-* Ruby 2.0
-* Ruby 2.1
-* Ruby 2.2
-* Ruby 2.3
-* Ruby 2.4
 * Ruby 2.5
 * Ruby 2.6
+* Ruby 2.7
 
 If something doesn't work on one of these Ruby versions, it's a bug.
 
@@ -737,7 +733,7 @@ implementation, you will be responsible for providing patches in a timely
 fashion. If critical issues for a particular implementation exist at the time
 of a major release, support for that Ruby version may be dropped.
 
-[travis]: https://travis-ci.org/octokit/octokit.rb
+[actions]: https://github.com/octokit/octokit.rb/actions
 
 ## Versioning
 


### PR DESCRIPTION
It has been a few months since [Ruby 2.7 was released](https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/).
I think it's time we supported Ruby 2.7.

This change adds Ruby 2.7 to our CI workflow (also small refactorings).

In addition, this change fixes also the "Supported Ruby Versions" section in the README,
because this section refers to Travis CI that is no longer used and describes older Ruby versions (<= 2.4) that are not tested.

### Note

The gemspec sets `required_ruby_version = '>= 2.0.0'` and it probably should be fixed together.
But the gemspec change may break existing library users, so I don't it. Please give me more information about this if you have.

https://github.com/octokit/octokit.rb/blob/002cba873b676af014a5de8ab3d8ea65a30c6edd/octokit.gemspec#L19

```diff
-spec.required_ruby_version = '>= 2.0.0'
+spec.required_ruby_version = '>= 2.4.0'
```

### Updated

This PR merges PR #1206 that has added Ruby 2.7, so this PR actually modifies just the README description.
See also https://github.com/octokit/octokit.rb/pull/1243#issuecomment-613693810