### PR TITLE
Remove coveralls gem

### DIFF
--- a/.github/workflows/octokit.yml
+++ b/.github/workflows/octokit.yml
@@ -47,5 +47,4 @@ jobs:
       - name: Test with RSpec
         env:
           GITHUB_CI: 1
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
         run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ group :test do
   install_if -> { RUBY_VERSION >= '2.8' } do
     gem 'rexml', '>= 3.2.4'
   end
-  gem 'coveralls', require: false
   gem 'json', '~> 1.7', platforms: [:jruby]
   gem 'jwt', '~> 2.2', '>= 2.2.1'
   gem 'mime-types', '~> 3.3', '>= 3.3.1'

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -11,7 +11,7 @@ require 'base64'
 require 'jwt'
 require 'pry-byebug'
 
-WebMock.disable_net_connect!(:allow => 'coveralls.io')
+WebMock.disable_net_connect!()
 
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,11 +1,5 @@
 if RUBY_ENGINE == 'ruby'
   require 'simplecov'
-  require 'coveralls'
-
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new [
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
-  ]
   SimpleCov.start
 end
 


### PR DESCRIPTION
This PR fixes #1244 and removes the `coveralls` gem, since it's been throwing errors in our build and no longer seems to be maintained. We'll rely only on `simplecov` for our testing coverage. 