### PR TITLE
Ensure Octokit::* Exceptions Extend Octokit::Error

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -306,13 +306,13 @@ module Octokit
   class ServiceUnavailable < ServerError; end
 
   # Raised when client fails to provide valid Content-Type
-  class MissingContentType < ArgumentError; end
+  class MissingContentType < ClientError; end
 
   # Raised when a method requires an application client_id
   # and secret but none is provided
-  class ApplicationCredentialsRequired < StandardError; end
+  class ApplicationCredentialsRequired < ClientError; end
 
   # Raised when a repository is created with an invalid format
-  class InvalidRepository < ArgumentError; end
+  class InvalidRepository < Error; end
 
 end


### PR DESCRIPTION
https://github.com/octokit/octokit.rb/blob/4e3f7792610e03ff5d19afd6ab9e349715b3b8b3/lib/octokit/error.rb#L2

`# Custom error class for rescuing from all GitHub errors` isn't currently true. There are a few exceptions that extend stdlib exceptions, making it impossible for `rescue Octokit::Error` to catch all errors this library raises. These changes attempt to make the above statement true, and makes it so every exception is a child of `Octokit::Error` in one form or another.

I'm aware of the repercussions that come with accepting this change, so I'm not sure it will be accepted. Anyone rescuing `StandardError` will be fine, but if they targeted `ArgumentError` specifically then they will no longer catch `MissingContentType` exceptions, though my guess is that's pretty rare since it is only raised in `Releases`, and only after the code tries everything possible to determine a content type for the file.

This PR is based on the `4-stable` branch, but there is a new exception on `master` repeating the same pattern that will need adjusted as well https://github.com/octokit/octokit.rb/blob/4e3f7792610e03ff5d19afd6ab9e349715b3b8b3/lib/octokit/error.rb#L311-L312 `MissingKey` - let me know if I should switch base branches and change that one as well.