### PR TITLE
Pass down ssl.verify to Faraday connection

### DIFF
--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -178,15 +178,9 @@ module Octokit
       conn_opts = @connection_options
       conn_opts[:builder] = @middleware if @middleware
       conn_opts[:proxy] = @proxy if @proxy
-      if conn_opts[:ssl].nil?
-        conn_opts[:ssl] = { :verify_mode => @ssl_verify_mode } if @ssl_verify_mode
-      else
-        if @connection_options[:ssl][:verify] == false
-          conn_opts[:ssl] = { :verify_mode => 0}
-        else
-          conn_opts[:ssl] = { :verify_mode => @ssl_verify_mode }
-        end
-      end
+      conn_opts[:ssl] ||= {}
+      conn_opts[:ssl][:verify_mode] ||= 0 if conn_opts.dig(:ssl, :verify) == false
+      conn_opts[:ssl][:verify_mode] ||= @ssl_verify_mode if @ssl_verify_mode
       opts[:faraday] = Faraday.new(conn_opts)
 
       opts

--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -178,9 +178,15 @@ module Octokit
       conn_opts = @connection_options
       conn_opts[:builder] = @middleware if @middleware
       conn_opts[:proxy] = @proxy if @proxy
-      conn_opts[:ssl] ||= {}
-      conn_opts[:ssl][:verify_mode] ||= 0 if conn_opts.dig(:ssl, :verify) == false
-      conn_opts[:ssl][:verify_mode] ||= @ssl_verify_mode if @ssl_verify_mode
+      if conn_opts[:ssl].nil?
+        conn_opts[:ssl] = { :verify_mode => @ssl_verify_mode } if @ssl_verify_mode
+      else
+        verify = @connection_options[:ssl][:verify]
+        conn_opts[:ssl] = {
+          :verify => verify,
+          :verify_mode => verify == false ? 0 : @ssl_verify_mode
+        }
+      end
       opts[:faraday] = Faraday.new(conn_opts)
 
       opts

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -435,6 +435,7 @@ describe Octokit::Client do
         :connection_options => {:ssl => {:verify => true}}
       )
       conn = client.send(:agent).instance_variable_get(:"@conn")
+      expect(conn.ssl[:verify]).to eq(true)
       expect(conn.ssl[:verify_mode]).to eq(OpenSSL::SSL::VERIFY_PEER)
     end
     it "sets an ssl verify => false" do
@@ -442,6 +443,7 @@ describe Octokit::Client do
         :connection_options => {:ssl => {:verify => false}}
       )
       conn = client.send(:agent).instance_variable_get(:"@conn")
+      expect(conn.ssl[:verify]).to eq(false)
       expect(conn.ssl[:verify_mode]).to eq(OpenSSL::SSL::VERIFY_NONE)
     end
     it "sets an ssl verify mode" do


### PR DESCRIPTION
This ensures adapters properly set SSL related options.

Adapters like Typhoeus [only check `options[:ssl][:verify]`](https://github.com/typhoeus/typhoeus/blob/v1.4.0/lib/typhoeus/adapters/faraday.rb#L137-L141).