### PR TITLE
Remove MacOS and Windows testing

### DIFF
--- a/.github/workflows/octokit.yml
+++ b/.github/workflows/octokit.yml
@@ -6,10 +6,6 @@ on:
      - master
      - 4-stable
      - '*'
-   pull_request:
-     branches:
-     - master
-     - 4-stable
 
 jobs:
   ci:
@@ -19,12 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu, macos, windows ]
+        os: [ ubuntu ]
         ruby: [ 2.5, 2.6, 2.7, head ]
-        include:
-          - { os: windows, ruby: mingw }
-        exclude:
-          - { os: windows, ruby: head }
 
     steps:
       - uses: actions/checkout@v2
@@ -49,4 +41,4 @@ jobs:
       - name: Test with RSpec
         env:
           GITHUB_CI: 1
-        run: bundle exec rspec
+        run: bundle exec rspec -w

--- a/.github/workflows/octokit.yml
+++ b/.github/workflows/octokit.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   ci:
-    name: ${{ matrix.os }} Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}-latest
 
     strategy:


### PR DESCRIPTION
Octokit doesn't have any OS specific functionality, so we don't need to run test suites against MacOS and Windows. 

This PR updates the workflow to only run on Ubuntu-latest.