### PR TITLE
Add context with rate limit struct for Octokit::TooManyRequests  and Octokit:: AbuseDetected errors

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -35,8 +35,7 @@ module Octokit
     end
 
      def build_error_context
-       rate_limited_errors = [Octokit::TooManyRequests, Octokit::AbuseDetected]
-       if rate_limited_errors.include?(self.class)
+       if RATE_LIMITED_ERRORS.include?(self.class)
          @context = Octokit::RateLimit.from_response(@response)
        end
      end
@@ -323,4 +322,5 @@ module Octokit
   # Raised when a repository is created with an invalid format
   class InvalidRepository < ArgumentError; end
 
+  RATE_LIMITED_ERRORS = [Octokit::TooManyRequests, Octokit::AbuseDetected]
 end

--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -34,9 +34,12 @@ module Octokit
       end
     end
 
-    def initialize(response=nil)
+    def initialize(response=nil,context=nil)
       @response = response
       super(build_error_message)
+      if self.class.superclass == Octokit::Forbidden
+        context = Octokit::RateLimit.from_response(response)
+      end
     end
 
     # Documentation URL returned by the API for some errors

--- a/lib/octokit/rate_limit.rb
+++ b/lib/octokit/rate_limit.rb
@@ -20,7 +20,7 @@ module Octokit
     # @return [RateLimit]
     def self.from_response(response)
       info = new
-      if response && !response.headers.nil?
+      if response && response.respond_to?(:headers) && !response.headers.nil?
         info.limit = (response.headers['X-RateLimit-Limit'] || 1).to_i
         info.remaining = (response.headers['X-RateLimit-Remaining'] || 1).to_i
         info.resets_at = Time.at((response.headers['X-RateLimit-Reset'] || Time.now).to_i)

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -1062,7 +1062,44 @@ describe Octokit::Client do
             :content_type => "application/json",
         },
         :body => {:message => "Bandwidth exceeded"}.to_json
-    expect { Octokit.get('/user') }.to raise_error(an_instance_of(Octokit::ServerError).and having_attributes({context: nil}))
+    begin
+      Octokit.get('/user')
+    rescue Octokit::ServerError => server_error
+      expect(server_error.context).to be_nil
+    end
+  end
+
+  it "returns context with default data when rate limit error occurs but headers are missing" do
+    stub_get('/user').to_return \
+        :status => 403,
+        :headers => {
+            :content_type => "application/json",
+        },
+        :body => {:message => "rate limit exceeded"}.to_json
+    begin
+      expect_any_instance_of(Faraday::Env).to receive(:headers).at_least(:once).and_return({})
+      Octokit.get('/user')
+    rescue Octokit::TooManyRequests => rate_limit_error
+      expect(rate_limit_error.context).to be_an_instance_of(Octokit::RateLimit)
+    end
+  end
+
+  it "returns context when non rate limit error occurs but rate limit headers are present" do
+    stub_get('/user').to_return \
+        :status => 403,
+        :headers => {
+            'content_type' => 'application/json'
+        },
+        :body => {:message => "rate limit exceeded"}.to_json
+    begin
+      rate_limit_headers = {'X-RateLimit-Limit' => 60, 'X-RateLimit-Remaining' => 42, 'X-RateLimit-Reset' => (Time.now + 60).to_i}
+      expect_any_instance_of(Faraday::Env).to receive(:headers).at_least(:once).and_return(rate_limit_headers)
+      Octokit.get('/user')
+    rescue Octokit::TooManyRequests => rate_limit_error
+      expect(rate_limit_error.context).to be_an_instance_of(Octokit::RateLimit)
+      expect(rate_limit_error.context.limit).to eql 60
+      expect(rate_limit_error.context.remaining).to eql 42
+    end
   end
 
   describe "module call shortcut" do

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -1055,6 +1055,16 @@ describe Octokit::Client do
     end
   end
 
+  it "returns empty context when non rate limit error occurs" do
+    stub_get('/user').to_return \
+        :status => 509,
+        :headers => {
+            :content_type => "application/json",
+        },
+        :body => {:message => "Bandwidth exceeded"}.to_json
+    expect { Octokit.get('/user') }.to raise_error(an_instance_of(Octokit::ServerError).and having_attributes({context: nil}))
+  end
+
   describe "module call shortcut" do
     before do
       Octokit.reset!


### PR DESCRIPTION
This adds the `context` attribute to `Octokit:: Error` for much smoother handling of exception like `Octokit::TooManyRequests` and `Octokit:: AbuseDetected`, so that clients consuming them can use the values specified for better retries. 

Can be consumed like this

```ruby
 begin
  octokit_client.get('resource')
rescue Octokit::TooManyRequests => rate_limited_error
  puts "Retry in #{rate_limited_errro.retry_in} seconds"
 # Do fancy sutff
end 
```
Specifically useful when using with background processors like `sidekiq`

```ruby
class PollingWorker
  include Sidekiq::Worker

  sidekiq_retry_in do |attempt, exception|
    case exception
    when Octokit::TooManyRequests
      exception.context.resets_in
    when Octokit::AbuseDetected
      exception.context.resets_in
    end
  end

  def perform
    # Do Polling work
    poller = Octokit::Client.new
    data = poller.fetch('/resource')
  end
end
 
```


The idea is to have meaningful context for all types of errors depending upon the type of error.