### PR TITLE
Switch to GitHub's Openapi

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ end
 desc "Generate the API client files based on the OpenAPI route docs."
 task :generate do
   require_relative "lib/openapi_client_generator"
-  OpenAPIClientGenerator::API.at(OasParser::Definition.resolve("../routes/openapi/api.github.com/index.json")) do |api|
+  OpenAPIClientGenerator::API.at(OasParser::Definition.resolve("../api.github.com-deref.json")) do |api|
     File.open("lib/octokit/client/#{api.resource}.rb", "w") do |f|
       f.puts api.to_s
     end


### PR DESCRIPTION
We've been reading in openapi definitions from `octokit/routes` but GitHub has started their own source of truth of openapi definitions. This PR uses these definitions instead.

Ideally, we'd probably want to switch this task to grab it from the internet, but as the definitions are still being worked on, I think this makes it easier to develop without introducing definition changes in the middle of random PRs.

But as this PR shows, this switch causes no difference to the generated files 🚀 

xref: #1157 