### PR TITLE
docs: Remove a dangling "Please abide by" from CONTRIBUTING.md [ci skip]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,6 @@
     add "[ci skip]" to your commit message to avoid needless CI builds.
 12. [Submit a pull request.][pr]
 
-Please abide by
-
 [fork]: https://help.github.com/articles/fork-a-repo
 [branch]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
 [pr]: https://help.github.com/articles/using-pull-requests


### PR DESCRIPTION
It look like it probably preceded a link to the CoC in an earlier draft of 8e469aa11bf7f6fe8e9afb56998f8055572cc005, but now it's just dangling.