### PR TITLE
Add Octokit::InstallationSuspended error

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -84,6 +84,8 @@ module Octokit
         Octokit::BillingIssue
       elsif body =~ /Resource protected by organization SAML enforcement/i
         Octokit::SAMLProtected
+      elsif body =~ /suspended your access/i
+        Octokit::InstallationSuspended
       else
         Octokit::Forbidden
       end
@@ -271,6 +273,10 @@ module Octokit
   # Raised when GitHub returns a 403 HTTP status code
   # and body matches 'Resource protected by organization SAML enforcement'
   class SAMLProtected < Forbidden; end
+
+  # Raised when GitHub returns a 403 HTTP status code
+  # and body matches 'suspended your access'
+  class InstallationSuspended < Forbidden; end
 
   # Raised when GitHub returns a 404 HTTP status code
   class NotFound < ClientError; end

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -911,7 +911,15 @@ describe Octokit::Client do
         :headers => {
           :content_type => "application/json",
         }
-        expect { Octokit.get('/torrentz') }.to raise_error Octokit::UnavailableForLegalReasons
+      expect { Octokit.get('/torrentz') }.to raise_error Octokit::UnavailableForLegalReasons
+
+      stub_post('/installation/repositories').to_return \
+        :status => 403,
+        :headers => {
+          :content_type => "application/json",
+        },
+        :body => {:message => "This installation owned by octocat suspended your access at 2020-08-28T16:32:59Z."}.to_json
+      expect { Octokit.post("/installation/repositories") }.to raise_error Octokit::InstallationSuspended
     end
 
     it "raises on unknown client errors" do


### PR DESCRIPTION
rspec fails for Ruby head, but also did for current 4-stable branch:
https://github.com/stmllr/octokit.rb/runs/1093022877

What's the procedure to backport this PR to master? Is there anything I can do?