### PR TITLE
Fix typo: Techincally -> Technically [ci skip]

### DIFF
--- a/lib/octokit/client/authorizations.rb
+++ b/lib/octokit/client/authorizations.rb
@@ -59,7 +59,7 @@ module Octokit
       #  client = Octokit::Client.new(:login => 'ctshryock', :password => 'secret')
       #  client.create_authorization({:idempotent => true, :client_id => 'xxxx', :client_secret => 'yyyy', :scopes => ["user"]})
       def create_authorization(options = {})
-        # Techincally we can omit scopes as GitHub has a default, however the
+        # Technically we can omit scopes as GitHub has a default, however the
         # API will reject us if we send a POST request with an empty body.
         options = options.dup
         if options.delete :idempotent


### PR DESCRIPTION
Alternative of https://github.com/octokit/octokit.rb/pull/1290

@tarebyte I changed the base branch and here's another one!
