### PR TITLE
Remove integrations preview header

### DIFF
--- a/lib/octokit/client/apps.rb
+++ b/lib/octokit/client/apps.rb
@@ -12,8 +12,7 @@ module Octokit
       #
       # @return [Sawyer::Resource] App information
       def app(options = {})
-        opts = ensure_api_media_type(:integrations, options)
-        get "app", opts
+        get "app", options
       end
 
       # Find all installations that belong to an App
@@ -24,8 +23,7 @@ module Octokit
       #
       # @return [Array<Sawyer::Resource>] the total_count and an array of installations
       def find_app_installations(options = {})
-        opts = ensure_api_media_type(:integrations, options)
-        paginate "app/installations", opts
+        paginate "app/installations", options
       end
       alias find_installations find_app_installations
 
@@ -47,8 +45,7 @@ module Octokit
       #
       # @return [Sawyer::Resource] the total_count and an array of installations
       def find_user_installations(options = {})
-        opts = ensure_api_media_type(:integrations, options)
-        paginate("user/installations", opts) do |data, last_response|
+        paginate("user/installations", options) do |data, last_response|
           data.installations.concat last_response.data.installations
         end
       end
@@ -61,8 +58,7 @@ module Octokit
       #
       # @return [Sawyer::Resource] Installation information
       def installation(id, options = {})
-        opts = ensure_api_media_type(:integrations, options)
-        get "app/installations/#{id}", opts
+        get "app/installations/#{id}", options
       end
 
       # Create a new installation token
@@ -74,8 +70,7 @@ module Octokit
       #
       # @return [<Sawyer::Resource>] An installation token
       def create_app_installation_access_token(installation, options = {})
-        opts = ensure_api_media_type(:integrations, options)
-        post "app/installations/#{installation}/access_tokens", opts
+        post "app/installations/#{installation}/access_tokens", options
       end
       alias create_installation_access_token create_app_installation_access_token
 
@@ -98,8 +93,7 @@ module Octokit
       #
       # @return [Sawyer::Resource] Installation information
       def find_organization_installation(organization, options = {})
-        opts = ensure_api_media_type(:integrations, options)
-        get "#{Organization.path(organization)}/installation", opts
+        get "#{Organization.path(organization)}/installation", options
       end
 
       # Enables an app to find the repository's installation information.
@@ -111,8 +105,7 @@ module Octokit
       #
       # @return [Sawyer::Resource] Installation information
       def find_repository_installation(repo, options = {})
-        opts = ensure_api_media_type(:integrations, options)
-        get "#{Repository.path(repo)}/installation", opts
+        get "#{Repository.path(repo)}/installation", options
       end
 
       # Enables an app to find the user's installation information.
@@ -124,8 +117,7 @@ module Octokit
       #
       # @return [Sawyer::Resource] Installation information
       def find_user_installation(user, options = {})
-        opts = ensure_api_media_type(:integrations, options)
-        get "#{User.path(user)}/installation", opts
+        get "#{User.path(user)}/installation", options
       end
 
       # List repositories that are accessible to the authenticated installation
@@ -136,8 +128,7 @@ module Octokit
       #
       # @return [Sawyer::Resource] the total_count and an array of repositories
       def list_app_installation_repositories(options = {})
-        opts = ensure_api_media_type(:integrations, options)
-        paginate("installation/repositories", opts) do |data, last_response|
+        paginate("installation/repositories", options) do |data, last_response|
           data.repositories.concat last_response.data.repositories
         end
       end
@@ -163,8 +154,7 @@ module Octokit
       #
       # @return [Boolean] Success
       def add_repository_to_app_installation(installation, repo, options = {})
-        opts = ensure_api_media_type(:integrations, options)
-        boolean_from_response :put, "user/installations/#{installation}/repositories/#{repo}", opts
+        boolean_from_response :put, "user/installations/#{installation}/repositories/#{repo}", options
       end
       alias add_repo_to_installation add_repository_to_app_installation
 
@@ -188,8 +178,7 @@ module Octokit
       #
       # @return [Boolean] Success
       def remove_repository_from_app_installation(installation, repo, options = {})
-        opts = ensure_api_media_type(:integrations, options)
-        boolean_from_response :delete, "user/installations/#{installation}/repositories/#{repo}", opts
+        boolean_from_response :delete, "user/installations/#{installation}/repositories/#{repo}", options
       end
       alias remove_repo_from_installation remove_repository_from_app_installation
 
@@ -212,8 +201,7 @@ module Octokit
       #
       # @return [Sawyer::Resource] the total_count and an array of repositories
       def find_installation_repositories_for_user(installation, options = {})
-        opts = ensure_api_media_type(:integrations, options)
-        paginate("user/installations/#{installation}/repositories", opts) do |data, last_response|
+        paginate("user/installations/#{installation}/repositories", options) do |data, last_response|
           data.repositories.concat last_response.data.repositories
         end
       end

--- a/lib/octokit/preview.rb
+++ b/lib/octokit/preview.rb
@@ -20,7 +20,6 @@ module Octokit
       :pages                  => 'application/vnd.github.mister-fantastic-preview+json'.freeze,
       :projects               => 'application/vnd.github.inertia-preview+json'.freeze,
       :traffic                => 'application/vnd.github.spiderman-preview'.freeze,
-      :integrations           => 'application/vnd.github.machine-man-preview+json'.freeze,
       :topics                 => 'application/vnd.github.mercy-preview+json'.freeze,
       :community_profile      => 'application/vnd.github.black-panther-preview+json'.freeze,
       :strict_validation      => 'application/vnd.github.speedy-preview+json'.freeze,

--- a/spec/octokit/client/apps_spec.rb
+++ b/spec/octokit/client/apps_spec.rb
@@ -14,7 +14,7 @@ describe Octokit::Client::Apps do
 
   describe ".app", :vcr do
     it "returns current App" do
-      response = @jwt_client.app(accept: preview_header)
+      response = @jwt_client.app()
 
       expect(response.id).not_to be_nil
       assert_requested :get, github_url("/app")
@@ -26,7 +26,7 @@ describe Octokit::Client::Apps do
         api_endpoint: "https://ghe.local/api/v3"
 
       request = stub_get("https://ghe.local/api/v3/app")
-      response = client.app(accept: preview_header)
+      response = client.app()
 
       assert_requested request
     end
@@ -44,7 +44,7 @@ describe Octokit::Client::Apps do
 
   describe ".find_app_installations", :vcr do
     it "returns installations for an app" do
-      installations = @jwt_client.find_app_installations(accept: preview_header)
+      installations = @jwt_client.find_app_installations()
       expect(installations).to be_kind_of Array
       assert_requested :get, github_url("/app/installations")
     end
@@ -55,7 +55,7 @@ describe Octokit::Client::Apps do
         api_endpoint: "https://ghe.local/api/v3"
 
       request = stub_get("https://ghe.local/api/v3/app/installations")
-      response = client.find_app_installations(accept: preview_header)
+      response = client.find_app_installations()
 
       assert_requested request
     end
@@ -63,7 +63,7 @@ describe Octokit::Client::Apps do
 
   describe ".find_user_installations", :vcr do
     it "returns installations for a user" do
-      response = @client.find_user_installations(accept: preview_header)
+      response = @client.find_user_installations()
 
       expect(response.total_count).not_to be_nil
       expect(response.installations).to be_kind_of(Array)
@@ -76,14 +76,14 @@ describe Octokit::Client::Apps do
         api_endpoint: "https://ghe.local/api/v3"
 
       request = stub_get("https://ghe.local/api/v3/user/installations")
-      response = client.find_user_installations(accept: preview_header)
+      response = client.find_user_installations()
 
       assert_requested request
     end
 
     it "allows auto_pagination", :vcr do
       @client.auto_paginate = true
-      response = @client.find_user_installations(accept: preview_header, per_page: 1)
+      response = @client.find_user_installations(per_page: 1)
 
       expect(response.total_count).to eq 2
       expect(response.installations.count).to eq 2
@@ -95,7 +95,7 @@ describe Octokit::Client::Apps do
     let(:organization) { test_github_org }
 
     it "returns installation for an organization" do
-      response = @jwt_client.find_organization_installation(organization, accept: preview_header)
+      response = @jwt_client.find_organization_installation(organization)
 
       expect(response.id).not_to be_nil
       expect(response.target_type).to eq("Organization")
@@ -108,14 +108,14 @@ describe Octokit::Client::Apps do
         api_endpoint: "https://ghe.local/api/v3"
 
       request = stub_get("https://ghe.local/api/v3/organizations/1234/installation")
-      response = client.find_organization_installation(1234, accept: preview_header)
+      response = client.find_organization_installation(1234)
 
       assert_requested request
     end
 
     it "allows auto_pagination" do
       @jwt_client.auto_paginate = true
-      response = @jwt_client.find_organization_installation(organization, accept: preview_header, per_page: 1)
+      response = @jwt_client.find_organization_installation(organization, per_page: 1)
 
       expect(response.id).not_to be_nil
       expect(response.target_type).to eq("Organization")
@@ -125,7 +125,7 @@ describe Octokit::Client::Apps do
   describe ".find_repository_installation", :vcr do
 
     it "returns installation for an repository" do
-      response = @jwt_client.find_repository_installation(@test_org_repo, accept: preview_header)
+      response = @jwt_client.find_repository_installation(@test_org_repo)
 
       expect(response.id).not_to be_nil
       expect(response.target_type).to eq("Organization")
@@ -138,14 +138,14 @@ describe Octokit::Client::Apps do
         api_endpoint: "https://ghe.local/api/v3"
 
       request = stub_get("https://ghe.local/api/v3/repos/testing/1234/installation")
-      response = client.find_repository_installation('testing/1234', accept: preview_header)
+      response = client.find_repository_installation('testing/1234')
 
       assert_requested request
     end
 
     it "allows auto_pagination" do
       @jwt_client.auto_paginate = true
-      response = @jwt_client.find_repository_installation(@test_org_repo, accept: preview_header, per_page: 1)
+      response = @jwt_client.find_repository_installation(@test_org_repo, per_page: 1)
 
       expect(response.id).not_to be_nil
       expect(response.target_type).to eq("Organization")
@@ -156,7 +156,7 @@ describe Octokit::Client::Apps do
     let(:user) { test_github_login }
 
     it "returns installation for a user" do
-      response = @jwt_client.find_user_installation(user, accept: preview_header)
+      response = @jwt_client.find_user_installation(user)
 
       expect(response.id).not_to be_nil
       expect(response.account.login).to eq(user)
@@ -169,14 +169,14 @@ describe Octokit::Client::Apps do
         api_endpoint: "https://ghe.local/api/v3"
 
       request = stub_get("https://ghe.local/api/v3/users/1234/installation")
-      response = client.find_user_installation('1234', accept: preview_header)
+      response = client.find_user_installation('1234')
 
       assert_requested request
     end
 
     it "allows auto_pagination" do
       @jwt_client.auto_paginate = true
-      response = @jwt_client.find_user_installation(user, accept: preview_header, per_page: 1)
+      response = @jwt_client.find_user_installation(user, per_page: 1)
 
       expect(response.id).not_to be_nil
       expect(response.account.login).to eq(user)
@@ -188,7 +188,7 @@ describe Octokit::Client::Apps do
 
     describe ".installation" do
       it "returns the installation" do
-        response = @jwt_client.installation(installation, accept: preview_header)
+        response = @jwt_client.installation(installation)
         expect(response).to be_kind_of Sawyer::Resource
         assert_requested :get, github_url("/app/installations/#{installation}")
       end
@@ -199,7 +199,7 @@ describe Octokit::Client::Apps do
           api_endpoint: "https://ghe.local/api/v3"
 
         request = stub_get("https://ghe.local/api/v3/app/installations/1234")
-        response = client.installation(1234, accept: preview_header)
+        response = client.installation(1234)
 
         assert_requested request
       end
@@ -207,7 +207,7 @@ describe Octokit::Client::Apps do
 
     describe ".find_installation_repositories_for_user" do
       it "returns repositories for a user" do
-        response = @client.find_installation_repositories_for_user(installation, accept: preview_header)
+        response = @client.find_installation_repositories_for_user(installation)
         expect(response.total_count).not_to be_nil
         expect(response.repositories).to be_kind_of(Array)
         assert_requested :get, github_url("/user/installations/#{installation}/repositories")
@@ -219,14 +219,14 @@ describe Octokit::Client::Apps do
           api_endpoint: "https://ghe.local/api/v3"
 
         request = stub_get("https://ghe.local/api/v3/user/installations/1234/repositories")
-        response = client.find_installation_repositories_for_user(1234, accept: preview_header)
+        response = client.find_installation_repositories_for_user(1234)
 
         assert_requested request
       end
 
       it "allows auto_pagination", :vcr do
         @client.auto_paginate = true
-        response = @client.find_installation_repositories_for_user(installation, accept: preview_header, per_page: 1)
+        response = @client.find_installation_repositories_for_user(installation, per_page: 1)
 
         expect(response.total_count).to eq 2
         expect(response.repositories.count).to eq 2
@@ -237,7 +237,7 @@ describe Octokit::Client::Apps do
     describe ".create_integration_installation_access_token" do
       it "creates an access token for the installation" do
         allow(@jwt_client).to receive(:octokit_warn)
-        response = @jwt_client.create_integration_installation_access_token(installation, accept: preview_header)
+        response = @jwt_client.create_integration_installation_access_token(installation)
 
         expect(response).to be_kind_of(Sawyer::Resource)
         expect(response.token).not_to be_nil
@@ -250,7 +250,7 @@ describe Octokit::Client::Apps do
 
     describe ".create_app_installation_access_token" do
       it "creates an access token for the installation" do
-        response = @jwt_client.create_app_installation_access_token(installation, accept: preview_header)
+        response = @jwt_client.create_app_installation_access_token(installation)
 
         expect(response).to be_kind_of(Sawyer::Resource)
         expect(response.token).not_to be_nil
@@ -266,7 +266,7 @@ describe Octokit::Client::Apps do
 
         path = "app/installations/1234/access_tokens"
         request = stub_post("https://ghe.local/api/v3/#{path}")
-        response = client.create_app_installation_access_token(1234, accept: preview_header)
+        response = client.create_app_installation_access_token(1234)
 
         assert_requested request
       end
@@ -281,7 +281,7 @@ describe Octokit::Client::Apps do
 
     context "with app installation access token" do
       let(:installation_client) do
-        token = @jwt_client.create_app_installation_access_token(installation, accept: preview_header).token
+        token = @jwt_client.create_app_installation_access_token(installation).token
         use_vcr_placeholder_for(token, '<INTEGRATION_INSTALLATION_TOKEN>')
         Octokit::Client.new(:access_token => token)
       end
@@ -295,7 +295,7 @@ describe Octokit::Client::Apps do
       describe ".list_integration_installation_repositories" do
         it "lists the installations repositories" do
           allow(installation_client).to receive(:octokit_warn)
-          response = installation_client.list_integration_installation_repositories(accept: preview_header)
+          response = installation_client.list_integration_installation_repositories()
           expect(response.total_count).not_to be_nil
           expect(response.repositories).to be_kind_of(Array)
           expect(installation_client).to have_received(:octokit_warn).with(/Deprecated/)
@@ -304,19 +304,19 @@ describe Octokit::Client::Apps do
 
       describe ".list_app_installation_repositories" do
         it "lists the installations repositories" do
-          response = installation_client.list_app_installation_repositories(accept: preview_header)
+          response = installation_client.list_app_installation_repositories()
           expect(response.total_count).not_to be_nil
           expect(response.repositories).to be_kind_of(Array)
         end
 
         it "works for GitHub Enterprise installs" do
           request = stub_get("https://ghe.local/api/v3/installation/repositories")
-          response = ghe_installation_client.list_app_installation_repositories(accept: preview_header)
+          response = ghe_installation_client.list_app_installation_repositories()
           assert_requested request
         end
         it "allows auto_pagination", :vcr do
           installation_client.auto_paginate = true
-          response = installation_client.list_app_installation_repositories({accept: preview_header, per_page: 1})
+          response = installation_client.list_app_installation_repositories({per_page: 1})
 
           expect(response.total_count).to eq 2
           expect(response.repositories.count).to eq 2
@@ -342,7 +342,7 @@ describe Octokit::Client::Apps do
       describe ".add_repository_to_integration_installation" do
         it "adds the repository to the installation" do
           allow(@client).to receive(:octokit_warn)
-          response = @client.add_repository_to_integration_installation(installation, @repo.id, accept: preview_header)
+          response = @client.add_repository_to_integration_installation(installation, @repo.id)
           expect(response).to be_truthy
           expect(@client).to have_received(:octokit_warn).with(/Deprecated/)
         end
@@ -350,20 +350,20 @@ describe Octokit::Client::Apps do
 
       describe ".add_repository_to_app_installation" do
         it "adds the repository to the installation" do
-          response = @client.add_repository_to_app_installation(installation, @repo.id, accept: preview_header)
+          response = @client.add_repository_to_app_installation(installation, @repo.id)
           expect(response).to be_truthy
         end
       end # .add_repository_to_app_installation
 
       context 'with installed repository on installation' do
         before(:each) do
-          @client.add_repository_to_app_installation(installation, @repo.id, accept: preview_header)
+          @client.add_repository_to_app_installation(installation, @repo.id)
         end
 
         describe ".remove_repository_from_integration_installation" do
           it "removes the repository from the installation" do
             allow(@client).to receive(:octokit_warn)
-            response = @client.remove_repository_from_integration_installation(installation, @repo.id, accept: preview_header)
+            response = @client.remove_repository_from_integration_installation(installation, @repo.id)
             expect(response).to be_truthy
             expect(@client).to have_received(:octokit_warn).with(/Deprecated/)
           end
@@ -371,7 +371,7 @@ describe Octokit::Client::Apps do
 
         describe ".remove_repository_from_app_installation" do
           it "removes the repository from the installation" do
-            response = @client.remove_repository_from_app_installation(installation, @repo.id, accept: preview_header)
+            response = @client.remove_repository_from_app_installation(installation, @repo.id)
             expect(response).to be_truthy
           end
         end # .remove_repository_from_app_installation
@@ -388,7 +388,7 @@ describe Octokit::Client::Apps do
       describe ".add_repository_to_app_installation" do
         it "works for GitHub Enterprise installs" do
           request = stub_put("https://ghe.local/api/v3/user/installations/1234/repositories/1234")
-          response = ghe_client.add_repository_to_app_installation(1234, 1234, accept: preview_header)
+          response = ghe_client.add_repository_to_app_installation(1234, 1234)
           assert_requested request
         end
       end # .add_repository_to_app_installation
@@ -396,16 +396,10 @@ describe Octokit::Client::Apps do
       describe ".remove_repository_from_app_installation" do
         it "works for GitHub Enterprise installs" do
           request = stub_delete("https://ghe.local/api/v3/user/installations/1234/repositories/1234")
-          response = ghe_client.remove_repository_from_app_installation(1234, 1234, accept: preview_header)
+          response = ghe_client.remove_repository_from_app_installation(1234, 1234)
           assert_requested request
         end
       end # .remove_repository_from_app_installation
     end # with repository on GitHub Enterprise
   end # with app installation
-
-  private
-
-  def preview_header
-    Octokit::Preview::PREVIEW_TYPES[:integrations]
-  end
 end


### PR DESCRIPTION
In August, Github "graduated" the Integrations API (aka [Apps API](https://docs.github.com/en/free-pro-team@latest/rest/reference/apps)) out of preview mode, into the official API - https://developer.github.com/changes/2020-08-20-graduate-machine-man-and-sailor-v-previews/. The `Accept: application/vnd.github.machine-man-preview+json` preview header is no longer required. Octokit still sets that header and it displays a warning if that header wasn't explcitly set by the user. 

This PR removes the `:integrations` preview header since it is no longer necessary. I didn't add any tests since there weren't any existing tests around preview headers.

Example `curl` request without the preview header (proving it's not necessary):
```
curl -H "Authorization: Bearer <token>" https://api.github.com/installation/repositories

HTTP/1.1 200 OK
...
```

Example of the old code generating the warning:
```ruby
2.7.0 :003 > client = Octokit::Client.new(bearer_token: token)
2.7.0 :004 > client.list_app_installation_repositories()
WARNING: The preview version of the Integrations API is not yet suitable for production use.
You can avoid this message by supplying an appropriate media type in the 'Accept' request
header.
 => {:total_count=>1, ...
 ```

 Example of the new code which doesn't have the warning:
 ```ruby
 2.7.0 :008 > client.list_app_installation_repositories()
 => {:total_count=>1, ...
 ```