### PR TITLE
Raise Octokit::InstallationSuspended when another error is received

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -84,7 +84,7 @@ module Octokit
         Octokit::BillingIssue
       elsif body =~ /Resource protected by organization SAML enforcement/i
         Octokit::SAMLProtected
-      elsif body =~ /suspended your access/i
+      elsif body =~ /suspended your access|This installation has been suspended/i
         Octokit::InstallationSuspended
       else
         Octokit::Forbidden

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -920,6 +920,14 @@ describe Octokit::Client do
         },
         :body => {:message => "This installation owned by octocat suspended your access at 2020-08-28T16:32:59Z."}.to_json
       expect { Octokit.post("/installation/repositories") }.to raise_error Octokit::InstallationSuspended
+
+      stub_post('/app/installations/12345/access_tokens').to_return \
+        :status => 403,
+        :headers => {
+          :content_type => "application/json",
+        },
+        :body => {:message => "This installation has been suspended // See: https://docs.github.com/rest/reference/apps#create-an-installation-access-token-for-an-app"}.to_json
+      expect { Octokit.post("/app/installations/12345/access_tokens") }.to raise_error Octokit::InstallationSuspended
     end
 
     it "raises on unknown client errors" do


### PR DESCRIPTION
When creating an app access token with `#create_app_installation_access_token`,
I received a response with the status `403`, which contains an error message like this:

```
POST https://api.github.com/app/installations/12345/access_tokens: 403 - This installation has been suspended // See: https://docs.github.com/rest/reference/apps#create-an-installation-access-token-for-an-app
```

I think this error should be raised as `Octokit::InstallationSuspended`.
What do you think?
