### PR TITLE
Paginate outside_collaborators calls

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -236,7 +236,7 @@ module Octokit
       # @example
       #   @client.outside_collaborators('github')
       def outside_collaborators(org, options={})
-        get "#{Organization.path org}/outside_collaborators", options
+        paginate "#{Organization.path org}/outside_collaborators", options
       end
 
       # Remove outside collaborator from an organization


### PR DESCRIPTION
We were only returning the first page of results, even if the client `auto_paginate` option was set.
