### PR TITLE
Uses of FaradayMiddleware#on_complete should not be private

### DIFF
--- a/lib/octokit/response/feed_parser.rb
+++ b/lib/octokit/response/feed_parser.rb
@@ -7,8 +7,6 @@ module Octokit
     # Parses RSS and Atom feed responses.
     class FeedParser < Faraday::Response::Middleware
 
-      private
-
       def on_complete(env)
         if env[:response_headers]["content-type"] =~ /(\batom|\brss)/
           require 'rss'

--- a/lib/octokit/response/raise_error.rb
+++ b/lib/octokit/response/raise_error.rb
@@ -9,8 +9,6 @@ module Octokit
     # HTTP status codes returned by the API
     class RaiseError < Faraday::Response::Middleware
 
-      private
-
       def on_complete(response)
         if error = Octokit::Error.from_response(response)
           raise error


### PR DESCRIPTION
Fixes https://github.com/octokit/octokit.rb/issues/1315

In https://github.com/lostisland/faraday/pull/1194 `on_complete` was introduced to `Faraday::Middleware` and was extracted out of `Faraday::Response`. Because our implementations of `on_complete` were `private` they no longer responded to `FaradayMiddleware#call`.

This updates all uses of `Octokit::Response::Middleware` so that `on_complete` isn't a private method.