### PR TITLE
Fix logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ruby toolkit for the GitHub API.
 
-![logo](http://cl.ly/image/3Y013H0A2z3z/gundam-ruby.png)
+![logo](https://docs.github.com/assets/images/gundamcat.png)
 
 Upgrading? Check the [Upgrade Guide](#upgrading-guide) before bumping to a new
 [major version][semver].


### PR DESCRIPTION
The logo link is 404ing, and this is a sane alternative I found.