### PR TITLE
Add delete_workflow_run method to Octokit::Client::ActionsWorkflowRuns module

### DIFF
--- a/lib/octokit/client/actions_workflow_runs.rb
+++ b/lib/octokit/client/actions_workflow_runs.rb
@@ -65,6 +65,17 @@ module Octokit
         boolean_from_response :post, "#{Repository.path repo}/actions/runs/#{id}/cancel", options
       end
 
+      # Deletes a workflow run
+      #
+      # @param repo [Integer, String, Repository, Hash] A GitHub repository
+      # @param id [Integer] Id of a workflow run
+      #
+      # @return [Boolean] Returns true if the run is deleted
+      # @see https://docs.github.com/en/rest/reference/actions#delete-a-workflow-run
+      def delete_workflow_run(repo, id, options = {})
+        boolean_from_response :delete, "#{Repository.path repo}/actions/runs/#{id}", options
+      end
+
       # Get a download url for archived log files of a workflow run
       #
       # @param repo [Integer, String, Repository, Hash] A GitHub repository

--- a/spec/octokit/client/actions_workflow_runs_spec.rb
+++ b/spec/octokit/client/actions_workflow_runs_spec.rb
@@ -80,6 +80,16 @@ describe Octokit::Client::ActionsWorkflowRuns, :vcr do
     end
   end
 
+  describe '.delete_workflow_run' do
+    it 'deletes the workflow run' do
+      request = stub_delete("repos/#{@test_repo}/actions/runs/#{@run_id}")
+
+      response = @client.delete_workflow_run(@test_repo, @run_id)
+
+      assert_requested request
+    end
+  end
+
   describe '.workflow_run_logs' do
     it 'returns the location of the workflow run logs' do
       request = stub_head("repos/#{@test_repo}/actions/runs/#{@run_id}/logs")


### PR DESCRIPTION
Changes add `delete_workflow_run` method to `Octokit::Client::ActionsWorkflowRuns` module.