### PR TITLE
Add a new error: PathDiffTooLarge

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -106,6 +106,8 @@ module Octokit
     def self.error_for_422(body)
       if body =~ /PullRequestReviewComment/i && body =~ /(commit_id|end_commit_oid) is not part of the pull request/i
         Octokit::CommitIsNotPartOfPullRequest
+      elsif body =~ /Path diff too large/i
+        Octokit::PathDiffTooLarge
       else
         Octokit::UnprocessableEntity
       end
@@ -313,6 +315,10 @@ module Octokit
   # Raised when GitHub returns a 422 HTTP status code
   # and body matches 'PullRequestReviewComment' and 'commit_id (or end_commit_oid) is not part of the pull request'
   class CommitIsNotPartOfPullRequest < UnprocessableEntity; end
+
+  # Raised when GitHub returns a 422 HTTP status code and body matches 'Path diff too large'.
+  # It could occur when attempting to post review comments on a "too large" file.
+  class PathDiffTooLarge < UnprocessableEntity; end
 
   # Raised when GitHub returns a 451 HTTP status code
   class UnavailableForLegalReasons < ClientError; end

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -949,6 +949,22 @@ describe Octokit::Client do
           ]
         }.to_json
       expect { Octokit.post('/repositories/123456789/pulls/1/comments') }.to raise_error Octokit::CommitIsNotPartOfPullRequest
+
+      stub_post('/repositories/123456789/pulls/21/comments').to_return \
+        :status => 422,
+        :headers => {
+          :content_type => 'application/json',
+        },
+        :body => {
+          :message => 'Validation Failed',
+          :errors => [
+            :message  => 'path diff too large',
+            :resource => 'PullRequestReviewComment',
+            :field    => 'path',
+            :code     => 'custom'
+          ]
+        }.to_json
+      expect { Octokit.post('/repositories/123456789/pulls/21/comments') }.to raise_error Octokit::PathDiffTooLarge
     end
 
     it "raises on unknown client errors" do


### PR DESCRIPTION
The error response with status `422` from GitHub includes an error message, `"Path diff too large"` when posting review comments on a "too large" file. I want to propose a new error class to handle this type of error.


```
$ octokit.create_pull_request_comment(245358625, 21, comment, d7a6bd842ee99bd3aafbf649b153391d43842b36, test.scss, 2)
Octokit::UnprocessableEntity: POST https://api.github.com/repositories/245358625/pulls/21/comments: 422 - Validation Failed
Error summary:
  resource: PullRequestReviewComment
  code: custom
  field: path
  message: path diff too large // See: https://docs.github.com/rest/reference/pulls#create-a-review-comment-for-a-pull-request
```