### PR TITLE
Remove "graduated" preview headers

### DIFF
--- a/lib/octokit/client/apps.rb
+++ b/lib/octokit/client/apps.rb
@@ -215,8 +215,7 @@ module Octokit
       #
       # @return [Boolean] Success
       def delete_installation(installation, options = {})
-        opts = ensure_api_media_type(:uninstall_github_app, options)
-        boolean_from_response :delete, "app/installations/#{installation}", opts
+        boolean_from_response :delete, "app/installations/#{installation}", options
       end
     end
   end

--- a/lib/octokit/client/checks.rb
+++ b/lib/octokit/client/checks.rb
@@ -23,7 +23,6 @@ module Octokit
       #   check_run.head_sha # => "7638417db6d59f3c431d3e1f261cc637155684cd"
       #   check_run.status # => "queued"
       def create_check_run(repo, name, head_sha, options = {})
-        ensure_api_media_type(:checks, options)
         options[:name] = name
         options[:head_sha] = head_sha
 
@@ -41,8 +40,6 @@ module Octokit
       #   check_run.id # => 51295429
       #   check_run.status # => "in_progress"
       def update_check_run(repo, id, options = {})
-        ensure_api_media_type(:checks, options)
-
         patch "#{Repository.path repo}/check-runs/#{id}", options
       end
 
@@ -63,8 +60,6 @@ module Octokit
       #   result.check_runs[0].id # => 51295429
       #   result.check_runs[0].status # => "in_progress"
       def check_runs_for_ref(repo, ref, options = {})
-        ensure_api_media_type(:checks, options)
-
         get "#{Repository.path repo}/commits/#{ref}/check-runs", options
       end
       alias :list_check_runs_for_ref :check_runs_for_ref
@@ -86,8 +81,6 @@ module Octokit
       #   result.check_runs[0].check_suite.id # => 50440400
       #   result.check_runs[0].status # => "in_progress"
       def check_runs_for_check_suite(repo, id, options = {})
-        ensure_api_media_type(:checks, options)
-
         get "#{Repository.path repo}/check-suites/#{id}/check-runs", options
       end
       alias :list_check_runs_for_check_suite :check_runs_for_check_suite
@@ -99,8 +92,6 @@ module Octokit
       # @return [Sawyer::Resource] A hash representing the check run
       # @see https://developer.github.com/v3/checks/runs/#get-a-single-check-run
       def check_run(repo, id, options = {})
-        ensure_api_media_type(:checks, options)
-
         get "#{Repository.path repo}/check-runs/#{id}", options
       end
 
@@ -116,8 +107,6 @@ module Octokit
       #   annotations[0].path # => "README.md"
       #   annotations[0].message # => "Looks good!"
       def check_run_annotations(repo, id, options = {})
-        ensure_api_media_type(:checks, options)
-
         get "#{Repository.path repo}/check-runs/#{id}/annotations", options
       end
 
@@ -132,8 +121,6 @@ module Octokit
       # @return [Sawyer::Resource] A hash representing the check suite
       # @see https://developer.github.com/v3/checks/suites/#get-a-single-check-suite
       def check_suite(repo, id, options = {})
-        ensure_api_media_type(:checks, options)
-
         get "#{Repository.path repo}/check-suites/#{id}", options
       end
 
@@ -153,8 +140,6 @@ module Octokit
       #   result.check_suites[0].id # => 50440400
       #   result.check_suites[0].app.id # => 76765
       def check_suites_for_ref(repo, ref, options = {})
-        ensure_api_media_type(:checks, options)
-
         get "#{Repository.path repo}/commits/#{ref}/check-suites", options
       end
       alias :list_check_suites_for_ref :check_suites_for_ref
@@ -172,8 +157,6 @@ module Octokit
       #   result.preferences.auto_trigger_checks[0].setting # => false
       #   result.repository.full_name # => "octocat/Hello-World"
       def set_check_suite_preferences(repo, options = {})
-        ensure_api_media_type(:checks, options)
-
         patch "#{Repository.path repo}/check-suites/preferences", options
       end
 
@@ -188,7 +171,6 @@ module Octokit
       #   check_suite.head_sha # => "7638417db6d59f3c431d3e1f261cc637155684cd"
       #   check_suite.status # => "queued"
       def create_check_suite(repo, head_sha, options = {})
-        ensure_api_media_type(:checks, options)
         options[:head_sha] = head_sha
 
         post "#{Repository.path repo}/check-suites", options
@@ -201,8 +183,6 @@ module Octokit
       # @return [Boolean] True if successful, raises an error otherwise
       # @see https://developer.github.com/v3/checks/suites/#rerequest-check-suite
       def rerequest_check_suite(repo, id, options = {})
-        ensure_api_media_type(:checks, options)
-
         post "#{Repository.path repo}/check-suites/#{id}/rerequest", options
         true
       end

--- a/lib/octokit/preview.rb
+++ b/lib/octokit/preview.rb
@@ -6,7 +6,6 @@ module Octokit
     PREVIEW_TYPES = {
       :applications_api       => 'application/vnd.github.doctor-strange-preview+json'.freeze,
       :branch_protection      => 'application/vnd.github.luke-cage-preview+json'.freeze,
-      :checks                 => 'application/vnd.github.antiope-preview+json'.freeze,
       :commit_search          => 'application/vnd.github.cloak-preview+json'.freeze,
       :commit_pulls           => 'application/vnd.github.groot-preview+json'.freeze,
       :commit_branches        => 'application/vnd.github.groot-preview+json'.freeze,
@@ -23,9 +22,7 @@ module Octokit
       :topics                 => 'application/vnd.github.mercy-preview+json'.freeze,
       :community_profile      => 'application/vnd.github.black-panther-preview+json'.freeze,
       :strict_validation      => 'application/vnd.github.speedy-preview+json'.freeze,
-      :drafts                 => 'application/vnd.github.shadow-cat-preview'.freeze,
       :template_repositories  => 'application/vnd.github.baptiste-preview+json'.freeze,
-      :uninstall_github_app   => 'application/vnd.github.gambit-preview+json'.freeze,
       :project_card_events    => 'application/vnd.github.starfox-preview+json'.freeze,
       :vulnerability_alerts   => 'application/vnd.github.dorian-preview+json'.freeze,
     }

--- a/spec/octokit/client/apps_spec.rb
+++ b/spec/octokit/client/apps_spec.rb
@@ -274,7 +274,7 @@ describe Octokit::Client::Apps do
 
     describe ".delete_installation" do
       it "deletes an installation" do
-        response = @jwt_client.delete_installation(installation, accept: Octokit::Preview::PREVIEW_TYPES[:uninstall_github_app])
+        response = @jwt_client.delete_installation(installation)
         expect(response).to be_truthy
       end
     end # .delete_installation

--- a/spec/octokit/client/checks_spec.rb
+++ b/spec/octokit/client/checks_spec.rb
@@ -20,7 +20,6 @@ describe Octokit::Client::Checks, :vcr do
         @test_repo,
         @check_name,
         @commit,
-        accept: preview_header,
       )
 
       assert_requested :post, repo_url("check-runs")
@@ -31,7 +30,6 @@ describe Octokit::Client::Checks, :vcr do
         @test_repo,
         @check_name,
         @commit,
-        accept: preview_header,
       )
 
       expect(check_run.name).to eq(@check_name)
@@ -45,7 +43,6 @@ describe Octokit::Client::Checks, :vcr do
       @client.update_check_run(
         @test_repo,
         @check_run_id,
-        accept: preview_header,
         completed_at: "2019-01-17T14:52:51Z",
         conclusion: "success",
         output: {
@@ -70,7 +67,6 @@ describe Octokit::Client::Checks, :vcr do
       check_run = @client.update_check_run(
         @test_repo,
         @check_run_id,
-        accept: preview_header,
         completed_at: "2019-01-17T14:52:51Z",
         conclusion: "success",
         output: {
@@ -98,7 +94,6 @@ describe Octokit::Client::Checks, :vcr do
       result = @client.check_runs_for_ref(
         @test_repo,
         @commit,
-        accept: preview_header,
       )
 
       expect(result.total_count).to eq(1)
@@ -111,7 +106,6 @@ describe Octokit::Client::Checks, :vcr do
       result = @client.check_runs_for_ref(
         @test_repo,
         @branch,
-        accept: preview_header,
       )
 
       expect(result.total_count).to eq(1)
@@ -124,7 +118,6 @@ describe Octokit::Client::Checks, :vcr do
       result = @client.check_runs_for_ref(
         @test_repo,
         @tag,
-        accept: preview_header,
       )
 
       expect(result.total_count).to eq(1)
@@ -137,7 +130,6 @@ describe Octokit::Client::Checks, :vcr do
       result = @client.check_runs_for_ref(
         @test_repo,
         @commit,
-        accept: preview_header,
         status: "completed",
       )
 
@@ -148,7 +140,6 @@ describe Octokit::Client::Checks, :vcr do
       result = @client.check_runs_for_ref(
         @test_repo,
         @commit,
-        accept: preview_header,
         status: "queued",
       )
 
@@ -164,8 +155,7 @@ describe Octokit::Client::Checks, :vcr do
       result = @client.check_runs_for_check_suite(
         @test_repo,
         @check_suite_id,
-        accept: preview_header,
-      )
+     )
 
       expect(result.total_count).to eq(1)
       expect(result.check_runs).to be_a(Array)
@@ -177,7 +167,6 @@ describe Octokit::Client::Checks, :vcr do
       result = @client.check_runs_for_check_suite(
         @test_repo,
         @check_suite_id,
-        accept: preview_header,
         status: "completed",
       )
 
@@ -188,7 +177,6 @@ describe Octokit::Client::Checks, :vcr do
       result = @client.check_runs_for_check_suite(
         @test_repo,
         @check_suite_id,
-        accept: preview_header,
         status: "queued",
       )
 
@@ -204,7 +192,6 @@ describe Octokit::Client::Checks, :vcr do
       check_run = @client.check_run(
         @test_repo,
         @check_run_id,
-        accept: preview_header,
       )
 
       expect(check_run.id).to eq(@check_run_id)
@@ -218,7 +205,6 @@ describe Octokit::Client::Checks, :vcr do
       annotations = @client.check_run_annotations(
         @test_repo,
         @check_run_id,
-        accept: preview_header,
       )
 
       expect(annotations).to be_a(Array)
@@ -232,7 +218,6 @@ describe Octokit::Client::Checks, :vcr do
       check_suite = @client.check_suite(
         @test_repo,
         @check_suite_id,
-        accept: preview_header,
       )
 
       expect(check_suite.id).to eq(@check_suite_id)
@@ -245,7 +230,6 @@ describe Octokit::Client::Checks, :vcr do
       result = @client.check_suites_for_ref(
         @test_repo,
         @commit,
-        accept: preview_header,
       )
 
       expect(result.total_count).to eq(1)
@@ -258,7 +242,6 @@ describe Octokit::Client::Checks, :vcr do
       result = @client.check_suites_for_ref(
         @test_repo,
         @branch,
-        accept: preview_header,
       )
 
       expect(result.total_count).to eq(1)
@@ -271,7 +254,6 @@ describe Octokit::Client::Checks, :vcr do
       result = @client.check_suites_for_ref(
         @test_repo,
         @tag,
-        accept: preview_header,
       )
 
       expect(result.total_count).to eq(1)
@@ -284,7 +266,6 @@ describe Octokit::Client::Checks, :vcr do
       result = @client.check_suites_for_ref(
         @test_repo,
         @commit,
-        accept: preview_header,
         check_name: "bogus-check-name",
       )
 
@@ -295,7 +276,6 @@ describe Octokit::Client::Checks, :vcr do
       result = @client.check_suites_for_ref(
         @test_repo,
         @commit,
-        accept: preview_header,
         check_name: @check_name,
       )
 
@@ -310,7 +290,6 @@ describe Octokit::Client::Checks, :vcr do
     it "sets check suite preferences" do
       @client.set_check_suite_preferences(
         @test_repo,
-        accept: preview_header,
         auto_trigger_checks: [
           {
             app_id: test_github_integration,
@@ -328,7 +307,6 @@ describe Octokit::Client::Checks, :vcr do
       @client.create_check_suite(
         @test_repo,
         @commit,
-        accept: preview_header,
       )
 
       assert_requested :post, repo_url("check-suites")
@@ -338,7 +316,6 @@ describe Octokit::Client::Checks, :vcr do
       check_suite = @client.create_check_suite(
         @test_repo,
         @commit,
-        accept: preview_header,
       )
 
       expect(check_suite.head_sha).to eq(@commit)
@@ -351,7 +328,6 @@ describe Octokit::Client::Checks, :vcr do
       @client.rerequest_check_suite(
         @test_repo,
         @check_suite_id,
-        accept: preview_header,
       )
 
       assert_requested :post, repo_url("check-suites/#{@check_suite_id}/rerequest")
@@ -359,10 +335,6 @@ describe Octokit::Client::Checks, :vcr do
   end
 
   private
-
-  def preview_header
-    Octokit::Preview::PREVIEW_TYPES[:checks]
-  end
 
   def repo_url(repo_path)
     github_url(["repos", @test_repo, repo_path].join("/"))


### PR DESCRIPTION
Remove "graduated" preview headers:
* Checks API's `antiope` preview header - see https://developer.github.com/changes/2020-10-01-graduate-antiope-preview/
* "Delete an installation" endpoint `gambit` preview header - https://developer.github.com/changes/2020-04-07-graduated-previews/
* "draft pull request " endpoint `shadow-cat` preview header
