### PR TITLE
Bump version to 4.21.0

### DIFF
--- a/lib/octokit/version.rb
+++ b/lib/octokit/version.rb
@@ -5,7 +5,7 @@ module Octokit
 
   # Current minor release.
   # @return [Integer]
-  MINOR = 20
+  MINOR = 21
 
   # Current patch level.
   # @return [Integer]


### PR DESCRIPTION
Items for release notes:

* #1317 Fix logo link
* #1318 Fix GitHub brand
* #1319 Add delete_workflow_run method to Octokit::Client::ActionsWorkflowRuns module
* #1322 Add matching refs
* #1324 Add a new error: PathDiffTooLarge
* #1326 Remove "graduated" preview headers
* #1329 Rename branch support

cc: @tarebyte since you've running all the releases lately