### PR TITLE
Update README to remove Octokit client instance creation with username and password.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,8 @@ Access the library in Ruby:
 
 ```ruby
 # Provide authentication credentials
-client = Octokit::Client.new(:login => 'defunkt', :password => 'c0d3b4ssssss!')
-
 # Set access_token instead of login and password if you use personal access token
-# client = Octokit::Client.new(:access_token => '[personal_access_token]!')
+client = Octokit::Client.new(:access_token => '[personal_access_token]!')
 
 # Fetch the current user
 client.user


### PR DESCRIPTION
As of November 2020, the GitHub API does not allow you to authenticate to the API via username and password. See https://github.blog/changelog/2020-11-13-token-authentication-required-for-api-operations/ for more details.

Therefore login with user and password must be removed from the README file of the project.