### PR TITLE
create_ref: match start of input

### DIFF
--- a/lib/octokit/client/refs.rb
+++ b/lib/octokit/client/refs.rb
@@ -58,7 +58,7 @@ module Octokit
       # @example Create refs/heads/master for octocat/Hello-World with sha 827efc6d56897b048c772eb4087f854f46256132
       #   Octokit.create_ref("octocat/Hello-World", "heads/master", "827efc6d56897b048c772eb4087f854f46256132")
       def create_ref(repo, ref, sha, options = {})
-        ref = "refs/#{ref}" unless ref =~ %r{refs/}
+        ref = "refs/#{ref}" unless ref =~ %r{\Arefs/}
         parameters = {
           :ref  => ref,
           :sha  => sha

--- a/spec/octokit/client/refs_spec.rb
+++ b/spec/octokit/client/refs_spec.rb
@@ -47,6 +47,13 @@ describe Octokit::Client::Refs do
         assert_requested request
     end
 
+    it "prepends refs/ to the ref parameter when required" do
+      request = stub_post("/repos/#{@test_repo}/git/refs").
+        with(:body => {ref: "refs/heads/refs/test-ref-2", sha: @first_sha}.to_json)
+        @client.create_ref(@test_repo, "heads/refs/test-ref-2", @first_sha)
+        assert_requested request
+    end
+
     it "does not duplicate refs/ in ref parameter" do
       request = stub_post("/repos/#{@test_repo}/git/refs").
         with(:body => {ref: "refs/heads/testing/test-ref-2", sha: @first_sha}.to_json)


### PR DESCRIPTION
[/repos/{owner}/{repo}/git/refs](https://docs.github.com/en/rest/reference/git#create-a-reference) states

> Required. The name of the fully qualified reference (ie: refs/heads/master). **If it doesn't start with 'refs' and have at least two slashes**, it will be rejected.

Octokit tries to mask this complexity from the user: accepting `heads/foo` and prepending `refs/` instead of requiring `refs/heads/foo` be passed.

This misbehaved when `refs/` appears anywhere else in `ref`, like `heads/refs/is/slang/for/referees`. I've added a failing tests case and updated the regexp to only match against the start of input to fix it.