### PR TITLE
Update README to remove Octokit client instance creation with username and password.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Access the library in Ruby:
 
 ```ruby
 # Provide authentication credentials
-# Set access_token instead of login and password if you use personal access token
 client = Octokit::Client.new(:access_token => 'personal_access_token')
 
 # Fetch the current user

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Access the library in Ruby:
 ```ruby
 # Provide authentication credentials
 # Set access_token instead of login and password if you use personal access token
-client = Octokit::Client.new(:access_token => '[personal_access_token]!')
+client = Octokit::Client.new(:access_token => 'personal_access_token')
 
 # Fetch the current user
 client.user

--- a/README.md
+++ b/README.md
@@ -86,10 +86,8 @@ Access the library in Ruby:
 
 ```ruby
 # Provide authentication credentials
-client = Octokit::Client.new(:access_token => 'personal_access_token')
-
-# You can still use the username/password syntax by replacing the password value with your PAT.
-# client = Octokit::Client.new(:login => 'defunkt', :password => 'personal_access_token')
+# Set access_token instead of login and password if you use personal access token
+client = Octokit::Client.new(:access_token => '[personal_access_token]!')
 
 # Fetch the current user
 client.user


### PR DESCRIPTION
As of November 2020, the GitHub API does not allow you to authenticate to the API via username and password. See https://github.blog/changelog/2020-11-13-token-authentication-required-for-api-operations/ for more details.

Therefore login with user and password must be removed from the README file of the project.