### PR TITLE
Revert "Update README to remove Octokit client instance creation with username and password."

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Access the library in Ruby:
 # Provide authentication credentials
 client = Octokit::Client.new(:access_token => 'personal_access_token')
 
+# You can still use the username/password syntax by replacing the password value with your PAT.
+# client = Octokit::Client.new(:login => 'defunkt', :password => 'personal_access_token')
+
 # Fetch the current user
 client.user
 ```


### PR DESCRIPTION
Reverts octokit/octokit.rb#1338

Although the username/password authentication has been deprecated, you can use the syntax as long as you [use your PAT](https://docs.github.com/en/rest/overview/other-authentication-methods#via-oauth-and-personal-access-tokens) instead of your password. Thus, these comments were valid so we can add them back ✨ 