### PR TITLE
CI: Add 3.0 to matrix

### DIFF
--- a/.github/workflows/octokit.yml
+++ b/.github/workflows/octokit.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu ]
-        ruby: [ 2.5, 2.6, 2.7, head ]
+        ruby: [ 2.5, 2.6, 2.7, '3.0', head ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR extends the build matrix with the latest generally available Ruby version.