### PR TITLE
Fix Faraday required minimum version

### DIFF
--- a/.github/workflows/octokit.yml
+++ b/.github/workflows/octokit.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   ci:
-    name: Ruby ${{ matrix.ruby }}
+    name: 'Ruby ${{ matrix.ruby }} with Faraday ${{ matrix.faraday }}'
     runs-on: ${{ matrix.os }}-latest
 
     strategy:
@@ -21,6 +21,10 @@ jobs:
       matrix:
         os: [ ubuntu ]
         ruby: [ 2.5, 2.6, 2.7, '3.0', head ]
+        faraday: [ '~> 0.16.0', '~> 0.17.0', '>= 1.0' ]
+
+    env:
+      FARADAY_VERSION: ${{ matrix.faraday }}
 
     steps:
       - uses: actions/checkout@v2
@@ -28,9 +32,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ./.bundle/gems
-          key: cache-${{ runner.os }}-${{ matrix.ruby }}-${{ github.sha }}
+          key: cache-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.faraday }}-${{ github.sha }}
           restore-keys: |
-            cache-${{ runner.os }}-${{ matrix.ruby }}-
+            cache-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.faraday }}
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -39,3 +39,7 @@ group :test, :development do
 end
 
 gemspec
+
+install_if -> { ENV['FARADAY_VERSION'] } do
+  gem 'faraday', ENV['FARADAY_VERSION']
+end

--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -5,7 +5,7 @@ require 'octokit/version'
 
 Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1', '< 3'
-  spec.add_dependency 'sawyer', '>= 0.5.3', '~> 0.8.0'
+  spec.add_dependency 'sawyer', '>= 0.5.3', '~> 0.9.0'
   spec.add_dependency 'faraday', '>= 0.16.2'
   spec.authors = ["Wynn Netherland", "Erik Michaels-Ober", "Clint Shryock"]
   spec.description = %q{Simple wrapper for the GitHub API}

--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -6,7 +6,7 @@ require 'octokit/version'
 Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1', '< 3'
   spec.add_dependency 'sawyer', '>= 0.5.3', '~> 0.8.0'
-  spec.add_dependency 'faraday', '>= 0.9'
+  spec.add_dependency 'faraday', '>= 0.16.2'
   spec.authors = ["Wynn Netherland", "Erik Michaels-Ober", "Clint Shryock"]
   spec.description = %q{Simple wrapper for the GitHub API}
   spec.email = ['wynn.netherland@gmail.com', 'sferik@gmail.com', 'clint@ctshryock.com']


### PR DESCRIPTION
This change increases the Faraday required minimum version from `0.9` to `0.16.2`.

When running the tests with Faraday 0.15, we get the following error:

```
TypeError: superclass mismatch for class RequestOptions
```

This change also adds a `FARADAY_VERSION` environment variable and a Faraday matrix to the CI configuration.
By this addition, you can run the tests with any Faraday version like this:

```shell
FARADAY_VERSION='~> 0.16.0' bundle install && bundle exec rspec
```

See also [all Faraday's versions](https://rubygems.org/gems/faraday/versions)