### PR TITLE
Fix `ruby-head` CI suite

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -9,7 +9,10 @@ require 'rspec'
 require 'webmock/rspec'
 require 'base64'
 require 'jwt'
-require 'pry-byebug'
+# latest version of pry-byebug is not compatible with Ruby 3.2.0
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.2.0')
+  require 'pry-byebug'
+end
 
 WebMock.disable_net_connect!()
 


### PR DESCRIPTION
The ruby-head test suite is currently failing due to:
```
Failure/Error: require 'pry-byebug'

NameError:
  undefined method `=~' for class `Pry::Code'
```

which was actually fixed in pry version 0.14.0, but unfortunately, pry-byebug’s latest version only allows for pry version 0.13.0 due to this unresolved issue: https://github.com/deivid-rodriguez/pry-byebug/issues/343

Since `pry-byebug` is only used locally and not in production systems, I think it's okay to remove it in versions of ruby >= 3.2 (which introduce the issue) to unblock the CI suites for now until pry-byebug begins supporting later versions of pry that incorporate the fix.  