### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/octokit.yml
+++ b/.github/workflows/octokit.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu ]
-        ruby: [ 2.5, 2.6, 2.7, '3.0', head ]
+        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, head ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.