### PR TITLE
WIP: Update sawyer dependency

### DIFF
--- a/lib/octokit/version.rb
+++ b/lib/octokit/version.rb
@@ -5,7 +5,7 @@ module Octokit
 
   # Current minor release.
   # @return [Integer]
-  MINOR = 22
+  MINOR = 23
 
   # Current patch level.
   # @return [Integer]

--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -5,7 +5,7 @@ require 'octokit/version'
 
 Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1', '< 3'
-  spec.add_dependency 'sawyer', '>= 0.5.3', '~> 0.8.0'
+  spec.add_dependency 'sawyer', '>= 0.5.3', '~> 0.9.0'
   spec.add_dependency 'faraday', '>= 0.9'
   spec.authors = ["Wynn Netherland", "Erik Michaels-Ober", "Clint Shryock"]
   spec.description = %q{Simple wrapper for the GitHub API}


### PR DESCRIPTION
Updates the sawyer dependency to allow for faraday 2.0 gem. Let me know if there's anything else I can update or fix here. 