### PR TITLE
Ensures that any nil parameters being passed in will initalize with Octokit's defaults instead of nil

### DIFF
--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -132,7 +132,7 @@ module Octokit
     def initialize(options = {})
       # Use options passed in, but fall back to module defaults
       Octokit::Configurable.keys.each do |key|
-        value = options.key?(key) ? options[key] : Octokit.instance_variable_get(:"@#{key}")
+        value = options[key].nil? ? Octokit.instance_variable_get(:"@#{key}") : options[key]
         instance_variable_set(:"@#{key}", value)
       end
 

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -44,6 +44,12 @@ describe Octokit::Client do
         }
       end
 
+      it "defaults are used when parameters are nil" do
+        new_opts = @opts.merge(:api_endpoint => nil)
+        client = Octokit::Client.new(new_opts)
+        expect(client.api_endpoint).to eq(Octokit.api_endpoint)
+      end
+
       it "overrides module configuration" do
         client = Octokit::Client.new(@opts)
         expect(client.per_page).to eq(40)

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -44,7 +44,7 @@ describe Octokit::Client do
         }
       end
 
-      it "defaults are used when parameters are nil" do
+      it "uses defaults when parameters are nil" do
         new_opts = @opts.merge(:api_endpoint => nil)
         client = Octokit::Client.new(new_opts)
         expect(client.api_endpoint).to eq(Octokit.api_endpoint)


### PR DESCRIPTION
This replaces @akerl original [PR](https://github.com/octokit/octokit.rb/pull/1117) due to heavy deviation of base branches and the age of the changeset.  The source change was pulled directly from his PR and a test was added to ensure the change.

From #1117 

> This should fix https://github.com/octokit/octokit.rb/issues/1113 . The issue there affected 2 of my gems as well. It looks like the fix for https://github.com/octokit/octokit.rb/issues/1088 accidentally affected nil values as well as false. Because nil is a common pattern for pass-through configuration, parameters set to nil should still be overridden by module defaults.