### PR TITLE
Allow autoloading Octokit::Repository

### DIFF
--- a/lib/octokit.rb
+++ b/lib/octokit.rb
@@ -6,6 +6,7 @@ module Octokit
   autoload(:Client, File.join(__dir__, 'octokit/client'))
   autoload(:EnterpriseAdminClient, File.join(__dir__, 'octokit/enterprise_admin_client'))
   autoload(:EnterpriseManagementConsoleClient, File.join(__dir__, 'octokit/enterprise_management_console_client'))
+  autoload(:Repository, File.join(__dir__, 'octokit/repository'))
 
   class << self
     include Octokit::Configurable


### PR DESCRIPTION
Hello!

Since dd5612e269336ecd43f7f12dbae077ecbef4cea2, it's not possible to reference `Octokit::Repository` when only `lib/octokit.rb` file has been required.

Steps to reproduce:

> require 'octokit'
> Octokit::Repository # => NameError

This is hitting as at Solidus, where our extensions try to directly reference `Octokit::Repository` as part of auto discovering the repository to generate a Changelog from. See https://github.com/solidusio/solidus_dev_support/blob/0764caad00f1b755d2cfdeef15762d85d5f58a01/lib/solidus_dev_support/rake_tasks.rb#L81. We found the problem since the last release yesterday.

Thanks for your work and, please, don't hesitate to ask us whatever you might need.