### PR TITLE
Require `octokit/rate_limit` from `lib/octokit/error.rb` so `RateLimit` is available

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -1,3 +1,5 @@
+require 'octokit/rate_limit'
+
 module Octokit
   # Custom error class for rescuing from all GitHub errors
   class Error < StandardError


### PR DESCRIPTION
`Octokit::Error#build_error_context` uses `RateLimit.from_response` but does not require the file for `RateLimit` explicitly.

This can lead to cases where the `RateLimit` module is not available when needed, causing an error.

This requires the file explicitly where the module is used.

Fixes #1422.