### PR TITLE
Get Octokit working with Ruby's immutable ("frozen") string literals functionality

### DIFF
--- a/.github/workflows/octokit.yml
+++ b/.github/workflows/octokit.yml
@@ -43,6 +43,9 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - name: Setup .netrc
         run: chmod 600 spec/fixtures/.netrc
+      - name: Ruby 2.5 needs a newer RubyGems to support frozen-string-literal
+        if: ${{ matrix.ruby == '2.5' }}
+        run: gem update --system 2.7.11
       - name: Install dependencies
         run: |
           bundle config set path .bundle/gems

--- a/.github/workflows/octokit.yml
+++ b/.github/workflows/octokit.yml
@@ -51,4 +51,5 @@ jobs:
       - name: Test with RSpec
         env:
           GITHUB_CI: 1
+          RUBYOPT: --enable-frozen-string-literal
         run: bundle exec rspec -w

--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -195,7 +195,7 @@ module Octokit
     def build_error_message
       return nil if @response.nil?
 
-      message =  "#{@response[:method].to_s.upcase} "
+      message = +"#{@response[:method].to_s.upcase} "
       message << redact_url(@response[:url].to_s) + ": "
       message << "#{@response[:status]} - "
       message << "#{response_message}" unless response_message.nil?

--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -180,7 +180,7 @@ module Octokit
     def response_error_summary
       return nil unless data.is_a?(Hash) && !Array(data[:errors]).empty?
 
-      summary = "\nError summary:\n"
+      summary = +"\nError summary:\n"
       summary << data[:errors].map do |error|
         if error.is_a? Hash
           error.map { |k,v| "  #{k}: #{v}" }
@@ -196,7 +196,7 @@ module Octokit
       return nil if @response.nil?
 
       message = +"#{@response[:method].to_s.upcase} "
-      message << redact_url(@response[:url].to_s) + ": "
+      message << redact_url(@response[:url].to_s.dup) + ": "
       message << "#{@response[:status]} - "
       message << "#{response_message}" unless response_message.nil?
       message << "#{response_error}" unless response_error.nil?


### PR DESCRIPTION
This picks up @olleolleolle's work in #1354, getting Ruby's immutable ("frozen") string literal functionality working in Octokit.rb and enforcing that in our CI setup.

The one thing that has changed since the original PR - which I have to create as I am unable to contribute to the branch - is that a new version of the dependency `multipart-post` gem has been released which makes it frozen string-compatible ❤️ 