### PR TITLE
Drop support for Ruby 1.9.2 in `Octokit::Client::Contents#create_contents`

### DIFF
--- a/lib/octokit/client/contents.rb
+++ b/lib/octokit/client/contents.rb
@@ -80,9 +80,7 @@ module Octokit
         end
         raise ArgumentError, 'content or :file option required' if content.nil?
 
-        options[:content] = Base64.respond_to?(:strict_encode64) ?
-          Base64.strict_encode64(content) :
-          Base64.encode64(content).delete("\n") # Ruby 1.9.2
+        options[:content] = Base64.strict_encode64(content)
         options[:message] = message
         url = "#{Repository.path repo}/contents/#{path}"
         put url, options


### PR DESCRIPTION
The `#create_contents` method currently has code, added for compatibility ruby Ruby 1.9.2, which uses different `Base64` methods depending on the Ruby version.

This removes that code, since we don't support 1.9.2 and the `.strict_encode64` method has been present since 1.9.3.

Fixes #1433.