### PR TITLE
Require multi-factor authentication to push new releases to RubyGems

### DIFF
--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = '>= 1.3.5'
   spec.summary = 'Ruby toolkit for working with the GitHub API'
   spec.version = Octokit::VERSION.dup
+  spec.metadata = { 'rubygems_mfa_required' => 'true' }
 end


### PR DESCRIPTION
This updates our gemspec to opt in to enforce multi-factor authentication (MFA) whenever we want to push releases of the gem, yank releases or add or remove owners.

This will increase the security of our users by making it more difficult for a bad actor to release a version of Octokit.rb.

After this is merged, the change will take effect from the first new release.

Fixes #1438.