### PR TITLE
Suppress various warnings

### DIFF
--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -252,7 +252,7 @@ module Octokit
       conn_opts[:ssl] = { verify_mode: @ssl_verify_mode } if @ssl_verify_mode
       conn = Faraday.new(conn_opts) do |http|
         if basic_authenticated?
-          http.request *FARADAY_BASIC_AUTH_KEYS, @login, @password
+          http.request(*FARADAY_BASIC_AUTH_KEYS, @login, @password)
         elsif token_authenticated?
           http.request :authorization, 'token', @access_token
         elsif bearer_authenticated?

--- a/lib/octokit/client/pub_sub_hubbub.rb
+++ b/lib/octokit/client/pub_sub_hubbub.rb
@@ -91,7 +91,7 @@ module Octokit
         conn = Faraday.new(url: @api_endpoint) do |http|
           http.headers[:user_agent] = user_agent
           if basic_authenticated?
-            http.request *FARADAY_BASIC_AUTH_KEYS, @login, @password
+            http.request(*FARADAY_BASIC_AUTH_KEYS, @login, @password)
           elsif token_authenticated?
             http.request :authorization, 'token', @access_token
           end

--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -107,13 +107,13 @@ module Octokit
         http.headers[:content_type] = 'application/json'
         http.headers[:user_agent] = user_agent
         if basic_authenticated?
-          http.request *FARADAY_BASIC_AUTH_KEYS, @login, @password
+          http.request(*FARADAY_BASIC_AUTH_KEYS, @login, @password)
         elsif token_authenticated?
           http.request :authorization, 'token', @access_token
         elsif bearer_authenticated?
           http.request :authorization, 'Bearer', @bearer_token
         elsif application_authenticated?
-          http.request *FARADAY_BASIC_AUTH_KEYS, @client_id, @client_secret
+          http.request(*FARADAY_BASIC_AUTH_KEYS, @client_id, @client_secret)
         end
       end
     end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -22,6 +22,7 @@ end
 WebMock.disable_net_connect!
 
 RSpec.configure do |config|
+  config.warnings = true
   config.raise_errors_for_deprecations!
   config.before(:all) do
     @test_repo = "#{test_github_login}/#{test_github_repository}"

--- a/spec/octokit/client/actions_secrets_spec.rb
+++ b/spec/octokit/client/actions_secrets_spec.rb
@@ -63,7 +63,7 @@ describe Octokit::Client::ActionsSecrets do
       it 'creating secret returns 204 (even though API docs claims it should be 201)' do
         box = create_box(@client.get_public_key(@repo.id))
         encrypted = box[:box].encrypt(@secret[:value])
-        resp = @client.create_or_update_secret(
+        @client.create_or_update_secret(
           @repo.id, @secret[:name],
           key_id: box[:key_id], encrypted_value: Base64.strict_encode64(encrypted)
         )
@@ -109,7 +109,7 @@ describe Octokit::Client::ActionsSecrets do
       it 'updating existing secret returns 204' do
         box = create_box(@client.get_public_key(@repo.id))
         encrypted = box[:box].encrypt('new value')
-        resp = @client.create_or_update_secret(
+        @client.create_or_update_secret(
           @repo.id, @secret[:name],
           key_id: box[:key_id], encrypted_value: Base64.strict_encode64(encrypted)
         )
@@ -119,7 +119,7 @@ describe Octokit::Client::ActionsSecrets do
 
     describe '.delete_secret', :vcr do
       it 'delete existing secret' do
-        resp = @client.delete_secret(@repo.id, @secret[:name])
+        @client.delete_secret(@repo.id, @secret[:name])
         expect(@client.last_response.status).to eq(204)
       end
     end

--- a/spec/octokit/client/actions_workflow_runs_spec.rb
+++ b/spec/octokit/client/actions_workflow_runs_spec.rb
@@ -86,7 +86,7 @@ describe Octokit::Client::ActionsWorkflowRuns, :vcr do
     it 'deletes the workflow run' do
       request = stub_delete("repos/#{@test_repo}/actions/runs/#{@run_id}")
 
-      response = @client.delete_workflow_run(@test_repo, @run_id)
+      @client.delete_workflow_run(@test_repo, @run_id)
 
       assert_requested request
     end

--- a/spec/octokit/client/apps_spec.rb
+++ b/spec/octokit/client/apps_spec.rb
@@ -28,7 +28,7 @@ describe Octokit::Client::Apps do
         api_endpoint: 'https://ghe.local/api/v3'
 
       request = stub_get('https://ghe.local/api/v3/app')
-      response = client.app
+      client.app
 
       assert_requested request
     end
@@ -57,7 +57,7 @@ describe Octokit::Client::Apps do
         api_endpoint: 'https://ghe.local/api/v3'
 
       request = stub_get('https://ghe.local/api/v3/app/installations')
-      response = client.find_app_installations
+      client.find_app_installations
 
       assert_requested request
     end
@@ -78,7 +78,7 @@ describe Octokit::Client::Apps do
         api_endpoint: 'https://ghe.local/api/v3'
 
       request = stub_get('https://ghe.local/api/v3/user/installations')
-      response = client.find_user_installations
+      client.find_user_installations
 
       assert_requested request
     end
@@ -110,7 +110,7 @@ describe Octokit::Client::Apps do
         api_endpoint: 'https://ghe.local/api/v3'
 
       request = stub_get('https://ghe.local/api/v3/organizations/1234/installation')
-      response = client.find_organization_installation(1234)
+      client.find_organization_installation(1234)
 
       assert_requested request
     end
@@ -139,7 +139,7 @@ describe Octokit::Client::Apps do
         api_endpoint: 'https://ghe.local/api/v3'
 
       request = stub_get('https://ghe.local/api/v3/repos/testing/1234/installation')
-      response = client.find_repository_installation('testing/1234')
+      client.find_repository_installation('testing/1234')
 
       assert_requested request
     end
@@ -170,7 +170,7 @@ describe Octokit::Client::Apps do
         api_endpoint: 'https://ghe.local/api/v3'
 
       request = stub_get('https://ghe.local/api/v3/users/1234/installation')
-      response = client.find_user_installation('1234')
+      client.find_user_installation('1234')
 
       assert_requested request
     end
@@ -200,7 +200,7 @@ describe Octokit::Client::Apps do
           api_endpoint: 'https://ghe.local/api/v3'
 
         request = stub_get('https://ghe.local/api/v3/app/installations/1234')
-        response = client.installation(1234)
+        client.installation(1234)
 
         assert_requested request
       end
@@ -220,7 +220,7 @@ describe Octokit::Client::Apps do
           api_endpoint: 'https://ghe.local/api/v3'
 
         request = stub_get('https://ghe.local/api/v3/user/installations/1234/repositories')
-        response = client.find_installation_repositories_for_user(1234)
+        client.find_installation_repositories_for_user(1234)
 
         assert_requested request
       end
@@ -267,7 +267,7 @@ describe Octokit::Client::Apps do
 
         path = 'app/installations/1234/access_tokens'
         request = stub_post("https://ghe.local/api/v3/#{path}")
-        response = client.create_app_installation_access_token(1234)
+        client.create_app_installation_access_token(1234)
 
         assert_requested request
       end
@@ -312,7 +312,7 @@ describe Octokit::Client::Apps do
 
         it 'works for GitHub Enterprise installs' do
           request = stub_get('https://ghe.local/api/v3/installation/repositories')
-          response = ghe_installation_client.list_app_installation_repositories
+          ghe_installation_client.list_app_installation_repositories
           assert_requested request
         end
         it 'allows auto_pagination', :vcr do
@@ -389,7 +389,7 @@ describe Octokit::Client::Apps do
       describe '.add_repository_to_app_installation' do
         it 'works for GitHub Enterprise installs' do
           request = stub_put('https://ghe.local/api/v3/user/installations/1234/repositories/1234')
-          response = ghe_client.add_repository_to_app_installation(1234, 1234)
+          ghe_client.add_repository_to_app_installation(1234, 1234)
           assert_requested request
         end
       end # .add_repository_to_app_installation
@@ -397,7 +397,7 @@ describe Octokit::Client::Apps do
       describe '.remove_repository_from_app_installation' do
         it 'works for GitHub Enterprise installs' do
           request = stub_delete('https://ghe.local/api/v3/user/installations/1234/repositories/1234')
-          response = ghe_client.remove_repository_from_app_installation(1234, 1234)
+          ghe_client.remove_repository_from_app_installation(1234, 1234)
           assert_requested request
         end
       end # .remove_repository_from_app_installation

--- a/spec/octokit/client/hooks_spec.rb
+++ b/spec/octokit/client/hooks_spec.rb
@@ -117,7 +117,7 @@ describe Octokit::Client::Hooks do
       end
       it 'creates an org hook for by ID' do
         request = stub_post('/organizations/1/hooks')
-        org_hook = @client.create_org_hook(1, { url: 'http://railsbp.com', content_type: 'json' })
+        @client.create_org_hook(1, { url: 'http://railsbp.com', content_type: 'json' })
         assert_requested request
       end
     end # .create_org_hook

--- a/spec/octokit/client/organizations_spec.rb
+++ b/spec/octokit/client/organizations_spec.rb
@@ -324,7 +324,7 @@ describe Octokit::Client::Organizations do
   describe '.organization_membership', :vcr do
     it 'returns an organization membership' do
       stub_get github_url("/user/memberships/orgs/#{test_github_org}")
-      membership = @client.organization_membership(test_github_org)
+      @client.organization_membership(test_github_org)
       assert_requested :get, github_url("/user/memberships/orgs/#{test_github_org}")
     end
 
@@ -352,7 +352,7 @@ describe Octokit::Client::Organizations do
 
   describe '.update_organization_membership', :vcr do
     it 'updates an organization membership' do
-      membership = @client.update_organization_membership(test_github_org, { state: 'active' })
+      @client.update_organization_membership(test_github_org, { state: 'active' })
       assert_requested :patch, github_url("/user/memberships/orgs/#{test_github_org}")
     end
 

--- a/spec/octokit/client/rate_limit_spec.rb
+++ b/spec/octokit/client/rate_limit_spec.rb
@@ -5,7 +5,7 @@ require 'helper'
 describe Octokit::Client do
   subject { Octokit::Client }
 
-  let(:client) { client = Octokit::Client.new }
+  let(:client) { Octokit::Client.new }
 
   describe '#rate_limit' do
     context 'with no last response' do

--- a/spec/octokit/client/releases_spec.rb
+++ b/spec/octokit/client/releases_spec.rb
@@ -138,7 +138,7 @@ describe Octokit::Client::Releases do
 
   describe '.latest_release', :vcr do
     it 'returns the latest release' do
-      result = Octokit.latest_release('octokit/octokit.rb')
+      Octokit.latest_release('octokit/octokit.rb')
       assert_requested :get, github_url('/repos/octokit/octokit.rb/releases/latest')
     end
   end # .latest_release

--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -57,7 +57,7 @@ describe Octokit::Client::Repositories do
 
     it 'creates a repository for an organization by ID' do
       request = stub_post(github_url('/organizations/1/repos'))
-      repository = @client.create_repository('an-org-repo', organization: 1)
+      @client.create_repository('an-org-repo', organization: 1)
       assert_requested request
     end
   end

--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -73,7 +73,7 @@ describe Octokit::Client::Repositories do
 
     context 'is_template is passed in params', :vcr do
       it 'uses the template repositories preview flag and succeeds' do
-        @client.edit_repository(@repo.full_name, is_template: true)
+        @client.edit_repository(@repo.full_name, is_template: true, accept: Octokit::Preview::PREVIEW_TYPES.fetch(:template_repositories))
         expect(@client.repository(@repo.full_name).is_template).to be true
       end
     end
@@ -128,11 +128,11 @@ describe Octokit::Client::Repositories do
 
     describe '.create_repository_from_template', :vcr do
       before do
-        @client.edit_repository(@repo.full_name, is_template: true)
+        @client.edit_repository(@repo.full_name, is_template: true, accept: Octokit::Preview::PREVIEW_TYPES.fetch(:template_repositories))
       end
 
       it 'generates a repository from the template' do
-        @client.create_repository_from_template(@repo.id, 'Cloned repo')
+        @client.create_repository_from_template(@repo.id, 'Cloned repo', accept: Octokit::Preview::PREVIEW_TYPES.fetch(:template_repositories))
         assert_requested :post, github_url("/repositories/#{@repo.id}/generate")
       end
     end
@@ -147,7 +147,7 @@ describe Octokit::Client::Repositories do
     describe '.update_repository', :vcr do
       it 'updates the matching repository' do
         description = "It's epic"
-        repository = @client.edit_repository(@repo.full_name, description: description)
+        repository = @client.edit_repository(@repo.full_name, description: description, accept: Octokit::Preview::PREVIEW_TYPES.fetch(:template_repositories))
         expect(repository.description).to eq(description)
         assert_requested :patch, github_url("/repos/#{@repo.full_name}")
       end

--- a/spec/octokit/client/stats_spec.rb
+++ b/spec/octokit/client/stats_spec.rb
@@ -37,7 +37,7 @@ describe Octokit::Client::Stats do
       end
 
       it "doesn't retry when GitHub returns 204" do
-        stats = @client.contributors_stats('octokit/octokit.rb', retry_timeout: 4)
+        @client.contributors_stats('octokit/octokit.rb', retry_timeout: 4)
         assert_requested :get, github_url('/repos/octokit/octokit.rb/stats/contributors'), times: 3
       end
 

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -616,9 +616,7 @@ describe Octokit::Client do
       client.get('/foo')
 
       assert_requested original_request
-      assert_requested(:get, 'https://example.com/bar') do |req|
-        req.headers['Authorization'] == 'dummy'
-      end
+      assert_requested(redirect_request.with(headers: { 'Authorization' => 'dummy' }))
     end
 
     it 'follows at most 3 consecutive redirects' do

--- a/spec/octokit/enterprise_admin_client/search_indexing_spec.rb
+++ b/spec/octokit/enterprise_admin_client/search_indexing_spec.rb
@@ -11,7 +11,7 @@ describe Octokit::EnterpriseAdminClient::SearchIndexing do
   shared_examples 'search index queuer' do |expected_target|
     context 'with a valid target' do
       it "queues #{expected_target} to be indexed" do
-        queue_result = @admin_client.method(subject).call target
+        @admin_client.method(subject).call target
         assert_requested :post,
                          github_enterprise_url('staff/indexing_jobs'),
                          body: { target: expected_target }.to_json

--- a/spec/octokit/enterprise_admin_client/users_spec.rb
+++ b/spec/octokit/enterprise_admin_client/users_spec.rb
@@ -87,7 +87,7 @@ describe Octokit::EnterpriseAdminClient::Users do
 
   describe '.delete_key', :vcr do
     it 'deletes a public keys' do
-      result = @admin_client.delete_key(1)
+      @admin_client.delete_key(1)
       expect(@admin_client.last_response.status).to eq(204)
       assert_requested :delete, github_enterprise_url('admin/keys/1')
     end

--- a/spec/octokit/enterprise_management_console_client/management_console_spec.rb
+++ b/spec/octokit/enterprise_management_console_client/management_console_spec.rb
@@ -28,7 +28,7 @@ describe Octokit::EnterpriseManagementConsoleClient::ManagementConsole do
 
   describe '.upgrade', :vcr do
     it 'upgrades the Enterprise installation' do
-      resp = @enterprise_management_console_client.upgrade(@license)
+      @enterprise_management_console_client.upgrade(@license)
 
       expect(@enterprise_management_console_client.last_response.status).to eq(202)
       assert_requested :post, github_management_console_url('setup/api/upgrade')


### PR DESCRIPTION
This PR fixes the following Ruby warnings by wrapping argument calls in parens:

```
.../lib/octokit/client.rb:255: warning: `*' interpreted as argument prefix
.../lib/octokit/connection.rb:110: warning: `*' interpreted as argument prefix
.../lib/octokit/connection.rb:116: warning: `*' interpreted as argument prefix
.../lib/octokit/client/pub_sub_hubbub.rb:94: warning: `*' interpreted as argument prefix
```

This PR also enables warnings in specs and fixes the following warnings reported when running specs:

```
warning: assigned but unused variable
```

```
WARNING: The preview version of the Template_repositories API is not yet suitable for production use.
You can avoid this message by supplying an appropriate media type in the 'Accept' request
header.
```
