### PR TITLE
Adds details on how to run a manual file integrity check

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,16 +2,47 @@
 
 1. Create a list of all the changes since the prior release
     1. Compare the latest release to master using https://github.com/octokit/octokit.rb/compare/`${latest}`...master
-    1. Open the linked pull requests from all the `Merge pull request #...` commits
-    1. For all non-documentation PRs, copy title (including pull request number) into markdown list items
-    1. (optional, but nice) Sort into logical buckets, like "support for additional endpoints", "enhancements", "bugfixes"
-    1. Reorganize to put the pull request number at the start of the line
-1. Ensure there are no breaking changes _(if there are breaking changes you'll need to create a release branch without those changes or bump the major version)_
-1. Update the version
+    2. Open the linked pull requests from all the `Merge pull request #...` commits
+    3. For all non-documentation PRs, copy title (including pull request number) into markdown list items
+    4. (optional, but nice) Sort into logical buckets, like "support for additional endpoints", "enhancements", "bugfixes"
+    5. Reorganize to put the pull request number at the start of the line
+2. Ensure there are no breaking changes _(if there are breaking changes you'll need to create a release branch without those changes or bump the major version)_
+3. Update the version
     1. Update the constant in `lib/octokit/version.rb`
-    1. Commit and push directly to master
-1. Run the `script/release` script to cut a release
-1. Draft a new release at https://github.com/octokit/octokit.rb/releases/new containing the curated changelog
+    2. Run the "File integrity check"
+    3. Commit the version change and push directly to master
+4. Run the `script/release` script to cut a release
+5. Draft a new release at https://github.com/octokit/octokit.rb/releases/new containing the curated changelog
+
+----
+
+## File integrity check
+
+(Given octokit.rb is currently shipped "manually")
+
+Because different environments behave differently, it is recommended that the integrity and file permissions of the files packed in the gem are verified. This is to help prevent things like releasing world writeable files in the gem. As we get things a little more automated, this will become unnecessary.
+
+Until then, it is recommended that if you are preparing a release you run the following prior to releasing the gem:
+
+From the root of octokit.rb
+
+```
+> gem build *.gemspec
+```
+
+Use the version from the build in the next commands
+
+```
+> tar -x -f octokit-#.##.#.gem 
+> tar -t -v --numeric-owner -f data.tar.gz |head -n 10
+```
+
+The files in the output should have the following permessions set:  
+`-rw-r--r--`
+
+(optional) Once verified, you can run `git clean -dfx` to clean things up before packing 
+
+----
 
 ## Prerequisites
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,37 +10,9 @@
 3. Update the version
     1. Update the constant in `lib/octokit/version.rb`
     2. Commit the version change and push directly to master
-4. Run the "File integrity check"
-5. Run the `script/release` script to cut a release
+4. (Optional) Run `script/release` with no parameters to execute a dry run of a release
+5. Run the `script/release -r` script to cut a release (this will run `script/validate` to perform the permission check)
 6. Draft a new release at https://github.com/octokit/octokit.rb/releases/new containing the curated changelog
-
-----
-
-## File integrity check
-
-(Given octokit.rb is currently shipped "manually")
-
-Because different environments behave differently, it is recommended that the integrity and file permissions of the files packed in the gem are verified. This is to help prevent things like releasing world writeable files in the gem. As we get things a little more automated, this will become unnecessary.
-
-Until then, it is recommended that if you are preparing a release you run the following prior to releasing the gem:
-
-From the root of octokit.rb
-
-```
-> gem build *.gemspec
-```
-
-Use the version from the build in the next commands
-
-```
-> tar -x -f octokit-#.##.#.gem 
-> tar -t -v --numeric-owner -f data.tar.gz |head -n 10
-```
-
-The files in the output should have the following permessions set:  
-`-rw-r--r--`
-
-(optional) Once verified, you can run `git clean -dfx` to clean things up before packing 
 
 ----
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,10 +9,10 @@
 2. Ensure there are no breaking changes _(if there are breaking changes you'll need to create a release branch without those changes or bump the major version)_
 3. Update the version
     1. Update the constant in `lib/octokit/version.rb`
-    2. Run the "File integrity check"
-    3. Commit the version change and push directly to master
-4. Run the `script/release` script to cut a release
-5. Draft a new release at https://github.com/octokit/octokit.rb/releases/new containing the curated changelog
+    2. Commit the version change and push directly to master
+4. Run the "File integrity check"
+5. Run the `script/release` script to cut a release
+6. Draft a new release at https://github.com/octokit/octokit.rb/releases/new containing the curated changelog
 
 ----
 

--- a/script/package
+++ b/script/package
@@ -4,4 +4,15 @@
 
 mkdir -p pkg
 gem build *.gemspec
-mv *.gem pkg
+
+./script/validate || rm *.gem
+
+echo "*** Packing and moving the octokit gem ***"
+if [ -f *.gem ]; then
+  mv *.gem pkg
+  echo -e '☑ success'
+else
+  echo -e '☒ failure'
+  exit 1
+fi
+

--- a/script/release
+++ b/script/release
@@ -5,12 +5,49 @@
 
 set -e
 
-version="$(script/package | grep Version: | awk '{print $2}')"
-[ -n "$version" ] || exit 1
+usage() { 
+  echo "Usage: $0 [-r] Tags and releases/publishes octokit" 1>&2; exit 1; 
+}
 
-echo $version
-git commit --allow-empty -a -m "Release $version"
-git tag "v$version"
-git push origin
-git push origin "v$version"
-gem push pkg/*-${version}.gem
+while [ $# -gt 0 ]
+do
+    case $1 in
+        '-r')
+            r=true
+            ;;
+        '-h')
+            usage
+            ;;
+        *)
+            echo "No valid parameter passed in, performing a dry run...";
+            ;;
+    esac
+    shift
+done
+
+if [ -z "${r}" ]; then
+  ./script/package
+    echo "*** Dry run: octokit was not tagged or released ***"
+    echo -e '☑ success'
+else
+
+  # We execite the script separately to get logging and proper exit conditions
+  ./script/package
+
+  # We need to pull the version from the actual file that is about to be published
+  file=$(ls pkg/*.gem| head -1)
+  version=$(echo $file | sed -e 's/.*octokit-\(.*\).gem.*/\1/') 
+  
+  [ -n "$version" ] || exit 1
+
+  echo "*** Tagging and publishing $version of octokit ***"
+
+  git commit --allow-empty -a -m "Release $version"
+  git tag "v$version"
+  git push origin
+  git push origin "v$version"
+  gem push pkg/*-${version}.gem
+  echo -e '☑ success'
+fi
+
+

--- a/script/validate
+++ b/script/validate
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Usage: script/gem
+# Validates the packed gem to determine if file permissions are correct.
+
+<<'###SCRIPT_COMMENT'
+Purpose: 
+(Given octokit.rb is currently shipped "manually")
+
+Because different environments behave differently, it is recommended that the integrity and file permissions of the files packed in the gem are verified.
+This is to help prevent things like releasing world writeable files in the gem. The simple check below looks at each file contained in the packed gem and
+verifies that the files are only owner writeable.
+
+Requirements:
+This script expects that script/package, script/release or 'gem build *.gemspec' have been run
+
+###SCRIPT_COMMENT
+
+
+FILE=$(ls *.gem| head -1)
+
+echo "*** Validating file permissions in the octokit gem ***"
+
+if [ ! -f "$FILE" ]; then
+    echo "$FILE does not exist. Please run script/package, script/release or 'gem build *.gemspec' to generate the gem to be validated"
+    echo -e '☒ failure'
+    exit 1
+fi
+
+tar -xf "${FILE}"
+
+# naive check to quickly see if any files in the gem are set to the wrong permissions
+for f in $(tar --numeric-owner -tvf data.tar.gz )
+do
+  if [ $f == "-rw-rw-rw-" ]; then
+     echo "World writeable files (-rw-rw-rw- | 666) detected in the gem. Please repack and make sure that all files in the gem are owner read write ( -rw-r--r-- | 644 )"
+     echo -e '☒ failure'
+     rm -f checksums.yaml.gz data.tar.gz metadata.gz
+     exit 1
+  fi
+done
+
+# Check clean up
+echo -e '☑ success'
+rm -f checksums.yaml.gz data.tar.gz metadata.gz


### PR DESCRIPTION
Adds details on how to check the files that are packed in the gem to help anyone who intends on releasing this make sure they are building and releasing this as intended.

This adds a script that is executed when the release or package scripts are run to naively check the permissions of the files in the gem - just as a safeguard.

Additionally, this adds parameters to script/release so that dry runs can be performed 

Hopefully, we'll be able to automate this, but for now, if anyone tries to release from something like a code space, for instance, then the gem will be released with world writeable files. We need to make sure that this is verified before release.
