### PR TITLE
Remove duplicated Faraday::Retry::Middleware:

### DIFF
--- a/lib/octokit/default.rb
+++ b/lib/octokit/default.rb
@@ -35,8 +35,7 @@ module Octokit
       # so we use it only when it's available.
       if defined?(Faraday::Request::Retry)
         builder.use Faraday::Request::Retry, exceptions: [Octokit::ServerError]
-      end
-      if defined?(Faraday::Retry::Middleware)
+      elsif defined?(Faraday::Retry::Middleware)
         builder.use Faraday::Retry::Middleware, exceptions: [Octokit::ServerError]
       end
 


### PR DESCRIPTION
👋 Hello, thanks for your work on maintaining Octokit ❤️ !

Remove duplicated Faraday::Retry::Middleware:

- ### Problem

  The Faraday::Retry::Middleware is added twice by Octokit when
  instantiating the Faraday::RackBuilder object.

  ```sh
  irb(main):001:0> Octokit.middleware
  =>
  #<Faraday::RackBuilder:0x0000000107898700
    @adapter=Faraday::Adapter::NetHttp,
    @handlers=
    [Faraday::Retry::Middleware,
    Faraday::Retry::Middleware,
    ...
  ```

  ### Context

  The latest Faraday version in the 1.x serie added an alias
  for `Faraday::Request::Retry`
  https://github.com/lostisland/faraday/blob/824423ccbb534d0b0553c3a0b3f2fbb9b0d84c60/lib/faraday.rb#L33

  ### Solution

  Use a elsif statement to avoid ending up with duplicated middleware