### PR TITLE
Trigger GitHub Actions workflows on the `main` branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ 4-stable ]
+    # TODO: Remove reference to deprecated `4-stable` branch once we have tidied
+    # up the branch names
+    branches: [ 4-stable main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ 4-stable ]
+    # TODO: Remove reference to deprecated `4-stable` branch once we have tidied
+    # up the branch names
+    branches: [ 4-stable main ]
   schedule:
     - cron: '43 0 * * 6'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,12 +15,16 @@ on:
   push:
     # TODO: Remove reference to deprecated `4-stable` branch once we have tidied
     # up the branch names
-    branches: [ 4-stable main ]
+    branches:
+      - 4-stable
+      - main
   pull_request:
     # The branches below must be a subset of the branches above
     # TODO: Remove reference to deprecated `4-stable` branch once we have tidied
     # up the branch names
-    branches: [ 4-stable main ]
+    branches:
+      - 4-stable
+      - main
   schedule:
     - cron: '43 0 * * 6'
 

--- a/.github/workflows/octokit.yml
+++ b/.github/workflows/octokit.yml
@@ -3,11 +3,17 @@ name: CI
 on:
    push:
      branches:
+     - main
+     - '*'
+     # TODO: Remove references to deprecated `master` and `4-stable` branches
+     # once we have tidied up the branch names
      - master
      - 4-stable
-     - '*'
    pull_request:
      branches:
+     - main
+     # TODO: Remove references to deprecated `master` and `4-stable` branches
+     # once we have tidied up the branch names
      - master
      - 4-stable
 


### PR DESCRIPTION
Currently, the default branch for this repo is `4-stable` (not `main` or `master`) and we have some old code which was proposed to be the v5.x version of Octokit.rb in the `5-alpha` branch.

We now want to release a new major version of Octokit to drop support for old Ruby versions - see https://github.com/octokit/octokit.rb/pull/1424.

To do that, we'll delete the unused `master` branch and rename `4-stable` to `main`.

Ahead of that change, this updates our GitHub Actions workflows to support the name `main`. Once the rename is done, we can remove all of the references to the old branch names.