### PR TITLE
Remove references to the `master` and `4-stable` branches in our Actions workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,17 +13,11 @@ name: "CodeQL"
 
 on:
   push:
-    # TODO: Remove reference to deprecated `4-stable` branch once we have tidied
-    # up the branch names
     branches:
-      - 4-stable
       - main
   pull_request:
     # The branches below must be a subset of the branches above
-    # TODO: Remove reference to deprecated `4-stable` branch once we have tidied
-    # up the branch names
     branches:
-      - 4-stable
       - main
   schedule:
     - cron: '43 0 * * 6'

--- a/.github/workflows/octokit.yml
+++ b/.github/workflows/octokit.yml
@@ -5,17 +5,9 @@ on:
      branches:
      - main
      - '*'
-     # TODO: Remove references to deprecated `master` and `4-stable` branches
-     # once we have tidied up the branch names
-     - master
-     - 4-stable
    pull_request:
      branches:
      - main
-     # TODO: Remove references to deprecated `master` and `4-stable` branches
-     # once we have tidied up the branch names
-     - master
-     - 4-stable
 
 jobs:
   ci:


### PR DESCRIPTION
We've now renamed the `4-stable` branch to `main` and deleted the `master` branch (or, more accurately, renamed it to `master-old`).

This removes the references to those branches in our GitHub Actions workflow files.