### PR TITLE
Drop support for EOL'd Ruby versions 2.6 and earlier

### DIFF
--- a/.github/workflows/octokit.yml
+++ b/.github/workflows/octokit.yml
@@ -26,18 +26,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu ]
-        ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', '3.1', head ]
+        ruby: [ 2.7, '3.0', '3.1', head ]
         faraday: [ '~> 1.0', '~> 2.0' ]
-        exclude:
-          # Faraday 2.x only works with Ruby versions 2.6 onwards.
-          # Fortunately, the gem supports Faraday 1.x, so we can just
-          # test against that.
-          - ruby: 2.5
-            faraday: '~> 2.0'
-          - ruby: 2.4
-            faraday: '~> 2.0'
-          - ruby: 2.3
-            faraday: '~> 2.0'
     env:
       FARADAY_VERSION: ${{ matrix.faraday }}
 
@@ -56,9 +46,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - name: Setup .netrc
         run: chmod 600 spec/fixtures/.netrc
-      - name: Ruby 2.5 and earlier need a newer RubyGems to support frozen-string-literal
-        if: ${{ matrix.ruby == '2.5' || matrix.ruby == '2.4' || matrix.ruby == '2.3'  }}
-        run: gem update --system 2.7.11
       - name: Install dependencies
         run: |
           bundle config set path .bundle/gems
@@ -69,12 +56,6 @@ jobs:
           GITHUB_CI: 1
           RUBYOPT: --enable-frozen-string-literal
         run: bundle exec rspec -w
-        if: ${{ matrix.ruby != '2.3' }}
-      - name: Test with RSpec without frozen string literals enabled
-        env:
-          GITHUB_CI: 1
-        run: bundle exec rspec -w
-        if: ${{ matrix.ruby == '2.3' }}
       - name: Lint with Rubocop
         env:
           GITHUB_CI: 1

--- a/README.md
+++ b/README.md
@@ -740,8 +740,6 @@ when writing new specs.
 This library aims to support and is [tested against][actions] the following Ruby
 implementations:
 
-* Ruby 2.5
-* Ruby 2.6
 * Ruby 2.7
 * Ruby 3.0
 * Ruby 3.1

--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.licenses = ['MIT']
   spec.name = 'octokit'
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.7.0'
   spec.required_rubygems_version = '>= 1.3.5'
   spec.summary = 'Ruby toolkit for working with the GitHub API'
   spec.version = Octokit::VERSION.dup


### PR DESCRIPTION
This drops support for older Ruby versions which have reached end-of-life, so Octokit.rb will only work with Ruby 2.7, 3.0 and 3.1.

Today, the gemspec claims to support v2.0 onwards, but in practice, only v2.3 onwards are tested in CI and actually working.