### PR TITLE
Fix `faraday_http_cache` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ Once configured, the middleware will store responses in cache based on ETag
 fingerprint and serve those back up for future `304` responses for the same
 resource. See the [project README][cache] for advanced usage.
 
-[cache]: https://github.com/plataformatec/faraday-http-cache
+[cache]: https://github.com/sourcelevel/faraday-http-cache
 [faraday]: https://github.com/lostisland/faraday
 
 ## Hacking on Octokit.rb


### PR DESCRIPTION
The subject is the message

The `faraday_http_cache` is currently in SourceLevel namespace (I'm the current maintainer) due to [Plataformatec acquires by Nubank](https://labsnews.com/en/news/business/nubank-acquires-consultancy-company-plataformatec/).