### PR TITLE
Tweak release documentation and process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,11 +7,9 @@
     4. (optional, but nice) Sort into logical buckets, like "support for additional endpoints", "enhancements", "bugfixes"
     5. Reorganize to put the pull request number at the start of the line
 2. Ensure there are no breaking changes _(if there are breaking changes you'll need to create a release branch without those changes or bump the major version)_
-3. Update the version
-    1. Update the constant in `lib/octokit/version.rb`
-    2. Commit the version change and push directly to master
-4. (Optional) Run `script/release` with no parameters to execute a dry run of a release
-5. Run the `script/release -r` script to cut a release (this will run `script/validate` to perform the permission check)
+3. Update the version in `lib/octokit/version.rb`
+4. Run `script/release` with no parameters to execute a dry run of a release
+5. Run the `script/release -r` script to cut a release. This will perform some sanity checks on permissions, build the gem into a `.gem` file, create a commit for your new version, tag the commit with the new version, push the commit and tag to GitHub and finally push the gem to RubyGems.
 6. Draft a new release at https://github.com/octokit/octokit.rb/releases/new containing the curated changelog
 
 ----

--- a/script/release
+++ b/script/release
@@ -35,7 +35,7 @@ else
   ./script/package
 
   # We need to pull the version from the actual file that is about to be published
-  file=$(ls pkg/*.gem| head -1)
+  file=$(ls pkg/*.gem | sort | tail -1)
   version=$(echo $file | sed -e 's/.*octokit-\(.*\).gem.*/\1/') 
   
   [ -n "$version" ] || exit 1

--- a/script/release
+++ b/script/release
@@ -42,7 +42,7 @@ else
 
   echo "*** Tagging and publishing $version of octokit ***"
 
-  git commit --allow-empty -a -m "Release $version"
+  git commit --allow-empty -a -m "v$version"
   git tag "v$version"
   git push origin
   git push origin "v$version"


### PR DESCRIPTION
This PR makes a number of improvements to our documentation and process for releasing a new version of the gem, contained in `RELEASE.md` and `script/release`. Specifically, it:

* fixes the instructions so you don't end up with two release commits - one created manually by following the instructions, and one created by `script/release`
* updates `script/release` to use the version number of the latest version when generating the commit message and Git tag, not the _oldest_ version (this is fine if you only have one `.gem` file, but not if you have old ones hanging around!)
* tweaks the commit message from the release script to be a simpler `v1.2.3` not `Release 1.2.3`