### PR TITLE
Update "See Also" link for projects API client

### DIFF
--- a/lib/octokit/client/projects.rb
+++ b/lib/octokit/client/projects.rb
@@ -4,7 +4,7 @@ module Octokit
   class Client
     # Methods for Projects API
     #
-    # @see https://developer.github.com/v3/repos/projects
+    # @see https://docs.github.com/en/rest/projects
     module Projects
       # List projects for a repository
       #


### PR DESCRIPTION
The current link 404s, I believe the docs were moved to https://docs.github.com/en/rest/projects
<img width="1234" alt="Screen Shot 2022-09-02 at 2 16 31 PM" src="https://user-images.githubusercontent.com/28542979/188214041-2c12af93-ce3e-44c5-a55d-747c1069daaf.png">
