### PR TITLE
Add client methods to support Actions artifact APIs.

### DIFF
--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -11,6 +11,7 @@ require 'octokit/rate_limit'
 require 'octokit/repository'
 require 'octokit/user'
 require 'octokit/organization'
+require 'octokit/client/actions_artifacts'
 require 'octokit/client/actions_secrets'
 require 'octokit/client/actions_workflows'
 require 'octokit/client/actions_workflow_jobs'
@@ -74,6 +75,7 @@ module Octokit
     include Octokit::Configurable
     include Octokit::Connection
     include Octokit::Warnable
+    include Octokit::Client::ActionsArtifacts
     include Octokit::Client::ActionsSecrets
     include Octokit::Client::Authorizations
     include Octokit::Client::Checks

--- a/lib/octokit/client/actions_artifacts.rb
+++ b/lib/octokit/client/actions_artifacts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Octokit
   class Client
     # Methods for the Actions Artifacts API

--- a/lib/octokit/client/actions_artifacts.rb
+++ b/lib/octokit/client/actions_artifacts.rb
@@ -22,7 +22,7 @@ module Octokit
       # @param workflow_run_id [Integer] Id of a workflow run
       #
       # @return [Sawyer::Resource] the total count and an array of artifacts
-      # @see https://developer.github.com/v3/actions/artifacts#list-workflow-run-artifacts
+      # @see https://docs.github.com/en/rest/actions/artifacts#list-workflow-run-artifacts
       def workflow_run_artifacts(repo, workflow_run_id, options = {})
         paginate "#{Repository.path repo}/actions/runs/#{workflow_run_id}/artifacts", options
       end
@@ -33,7 +33,7 @@ module Octokit
       # @param id [Integer] Id of an artifact
       #
       # @return [Sawyer::Resource] Artifact information
-      # @see https://developer.github.com/v3/actions/artifacts#get-an-artifact
+      # @see https://docs.github.com/en/rest/actions/artifacts#get-an-artifact
       def artifact(repo, id, options = {})
         get "#{Repository.path repo}/actions/artifacts/#{id}", options
       end
@@ -44,7 +44,7 @@ module Octokit
       # @param id [Integer] Id of an artifact
       #
       # @return [String] URL to the .zip archive of the artifact
-      # @see https://developer.github.com/v3/actions/workflow-runs/#download-workflow-run-logs
+      # @see https://docs.github.com/en/rest/actions/workflow-runs#download-workflow-run-logs
       def artifact_download_url(repo, id, options = {})
         url = "#{Repository.path repo}/actions/artifacts/#{id}/zip"
 
@@ -58,7 +58,7 @@ module Octokit
       # @param id [Integer] Id of an artifact
       #
       # @return [Boolean] Return true if the artifact was successfully deleted
-      # @see https://developer.github.com/v3/actions/artifacts#delete-an-artifact
+      # @see https://docs.github.com/en/rest/actions/artifacts#delete-an-artifact
       def delete_artifact(repo, id, options = {})
         boolean_from_response :delete, "#{Repository.path repo}/actions/artifacts/#{id}", options
       end

--- a/lib/octokit/client/actions_artifacts.rb
+++ b/lib/octokit/client/actions_artifacts.rb
@@ -1,0 +1,65 @@
+module Octokit
+  class Client
+    # Methods for the Actions Artifacts API
+    #
+    # @see https://developer.github.com/v3/actions/artifacts
+    module ActionsArtifacts
+      # List all artifacts for a repository
+      #
+      # @param repo [Integer, String, Repository, Hash] A GitHub repository
+      #
+      # @return [Sawyer::Resource] the total count and an array of artifacts
+      # @see https://developer.github.com/v3/actions/artifacts#list-artifacts-for-a-repository
+      def repository_artifacts(repo, options = {})
+        paginate "#{Repository.path repo}/actions/artifacts", options
+      end
+
+      # List all artifacts for a workflow run
+      #
+      # @param repo [Integer, String, Repository, Hash] A GitHub repository
+      # @param workflow_run_id [Integer] Id of a workflow run
+      #
+      # @return [Sawyer::Resource] the total count and an array of artifacts
+      # @see https://developer.github.com/v3/actions/artifacts#list-workflow-run-artifacts
+      def workflow_run_artifacts(repo, workflow_run_id, options = {})
+        paginate "#{Repository.path repo}/actions/runs/#{workflow_run_id}/artifacts", options
+      end
+
+      # Get an artifact
+      #
+      # @param repo [Integer, String, Repository, Hash] A GitHub repository
+      # @param id [Integer] Id of an artifact
+      #
+      # @return [Sawyer::Resource] Artifact information
+      # @see https://developer.github.com/v3/actions/artifacts#get-an-artifact
+      def artifact(repo, id, options = {})
+        get "#{Repository.path repo}/actions/artifacts/#{id}", options
+      end
+
+      # Get a download URL for an artifact
+      #
+      # @param repo [Integer, String, Repository, Hash] A GitHub repository
+      # @param id [Integer] Id of an artifact
+      #
+      # @return [String] URL to the .zip archive of the artifact
+      # @see https://developer.github.com/v3/actions/workflow-runs/#download-workflow-run-logs
+      def artifact_download_url(repo, id, options = {})
+        url = "#{Repository.path repo}/actions/artifacts/#{id}/zip"
+
+        response = client_without_redirects.head(url, options)
+        response.headers['Location']
+      end
+
+      # Delete an artifact
+      #
+      # @param repo [Integer, String, Repository, Hash] A GitHub repository
+      # @param id [Integer] Id of an artifact
+      #
+      # @return [Boolean] Return true if the artifact was successfully deleted
+      # @see https://developer.github.com/v3/actions/artifacts#delete-an-artifact
+      def delete_artifact(repo, id, options = {})
+        boolean_from_response :delete, "#{Repository.path repo}/actions/artifacts/#{id}", options
+      end
+    end
+  end
+end

--- a/spec/cassettes/Octokit_Client_ActionsArtifacts/_artifact/returns_the_requested_artifact.json
+++ b/spec/cassettes/Octokit_Client_ActionsArtifacts/_artifact/returns_the_requested_artifact.json
@@ -1,0 +1,124 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repos/<GITHUB_LOGIN>/<GITHUB_TEST_REPOSITORY>/actions/artifacts/362518594",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 5.5.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Wed, 14 Sep 2022 00:30:09 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"b3e29c2607b804ddc4762de34fc90791462b0a94836b2e3073841e6b305f0e6e\""
+          ],
+          "X-Oauth-Scopes": [
+            "repo, workflow"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2022-09-20 23:45:13 UTC"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-08-09"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4994"
+          ],
+          "X-Ratelimit-Reset": [
+            "1663119007"
+          ],
+          "X-Ratelimit-Used": [
+            "6"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0405:0770:2B5BB:2CF24:63212091"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJpZCI6MzYyNTE4NTk0LCJub2RlX2lkIjoiTURnNlFYSjBhV1poWTNRek5q\nSTFNVGcxT1RRPSIsIm5hbWUiOiJoZWxsby50eHQiLCJzaXplX2luX2J5dGVz\nIjoxNCwidXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy88R0lU\nSFVCX0xPR0lOPi88R0lUSFVCX1RFU1RfUkVQT1NJVE9SWT4vYWN0aW9ucy9h\ncnRpZmFjdHMvMzYyNTE4NTk0IiwiYXJjaGl2ZV9kb3dubG9hZF91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zLzxHSVRIVUJfTE9HSU4+LzxH\nSVRIVUJfVEVTVF9SRVBPU0lUT1JZPi9hY3Rpb25zL2FydGlmYWN0cy8zNjI1\nMTg1OTQvemlwIiwiZXhwaXJlZCI6ZmFsc2UsImNyZWF0ZWRfYXQiOiIyMDIy\nLTA5LTE0VDAwOjI0OjQ1WiIsInVwZGF0ZWRfYXQiOiIyMDIyLTA5LTE0VDAw\nOjI0OjQ2WiIsImV4cGlyZXNfYXQiOiIyMDIyLTA5LTE1VDAwOjI0OjQyWiIs\nIndvcmtmbG93X3J1biI6eyJpZCI6MzA0OTI5ODAyMywicmVwb3NpdG9yeV9p\nZCI6MTk5MDI2MzE1LCJoZWFkX3JlcG9zaXRvcnlfaWQiOjE5OTAyNjMxNSwi\naGVhZF9icmFuY2giOiJtYXN0ZXIiLCJoZWFkX3NoYSI6Ijk5OWJlODY3MzNk\nNWJmNGE2NzIyZDc4ZjMzYjJkZGMyNDI0Yzc5OGQifX0=\n"
+        }
+      },
+      "recorded_at": "Wed, 14 Sep 2022 00:30:09 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.1.0"
+}

--- a/spec/cassettes/Octokit_Client_ActionsArtifacts/_artifact_download_url/returns_the_location_of_artifact_zip_archive.json
+++ b/spec/cassettes/Octokit_Client_ActionsArtifacts/_artifact_download_url/returns_the_location_of_artifact_zip_archive.json
@@ -1,0 +1,102 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "head",
+        "uri": "https://api.github.com/repos/<GITHUB_LOGIN>/<GITHUB_TEST_REPOSITORY>/actions/artifacts/362518594/zip",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 5.5.0"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 302,
+          "message": "Found"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Wed, 14 Sep 2022 00:30:10 GMT"
+          ],
+          "Content-Type": [
+            "text/html;charset=utf-8"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Location": [
+            "https://pipelines.actions.githubusercontent.com/serviceHosts/833a0c19-e430-43c5-ad4b-ffd8a794e906/_apis/pipelines/1/runs/3/signedartifactscontent?artifactName=hello.txt&urlExpires=2022-09-14T00%3A31%3A10.3987297Z&urlSigningMethod=HMACV2&urlSignature=bcxwAz34CgmtYfPXvslRZNWm2pVI9vH61nZqA996X0A%3D"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-08-09"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4992"
+          ],
+          "X-Ratelimit-Reset": [
+            "1663119007"
+          ],
+          "X-Ratelimit-Used": [
+            "8"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "0407:949B:2F9974F:30C78CD:63212092"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Wed, 14 Sep 2022 00:30:10 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.1.0"
+}

--- a/spec/cassettes/Octokit_Client_ActionsArtifacts/_delete_artifact/deletes_the_artifact.json
+++ b/spec/cassettes/Octokit_Client_ActionsArtifacts/_delete_artifact/deletes_the_artifact.json
@@ -1,0 +1,111 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/<GITHUB_LOGIN>/<GITHUB_TEST_REPOSITORY>/actions/artifacts/362518594",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 5.5.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Wed, 14 Sep 2022 00:30:11 GMT"
+          ],
+          "X-Oauth-Scopes": [
+            "repo, workflow"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2022-09-20 23:45:13 UTC"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-08-09"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4990"
+          ],
+          "X-Ratelimit-Reset": [
+            "1663119007"
+          ],
+          "X-Ratelimit-Used": [
+            "10"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "0409:0A3D:D7C272:DDDDC5:63212092"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Wed, 14 Sep 2022 00:30:11 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.1.0"
+}

--- a/spec/cassettes/Octokit_Client_ActionsArtifacts/_repository_artifacts/returns_all_artifacts_for_a_repository.json
+++ b/spec/cassettes/Octokit_Client_ActionsArtifacts/_repository_artifacts/returns_all_artifacts_for_a_repository.json
@@ -1,0 +1,124 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repos/<GITHUB_LOGIN>/<GITHUB_TEST_REPOSITORY>/actions/artifacts",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 5.5.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Wed, 14 Sep 2022 00:30:07 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"a7110c5e38e30185e3eea02e3708267858abf5fbb899765333d109b9282c83bb\""
+          ],
+          "X-Oauth-Scopes": [
+            "repo, workflow"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2022-09-20 23:45:13 UTC"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-08-09"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4998"
+          ],
+          "X-Ratelimit-Reset": [
+            "1663119007"
+          ],
+          "X-Ratelimit-Used": [
+            "2"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0401:9212:D11764:D6EA3C:6321208F"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJ0b3RhbF9jb3VudCI6MSwiYXJ0aWZhY3RzIjpbeyJpZCI6MzYyNTE4NTk0\nLCJub2RlX2lkIjoiTURnNlFYSjBhV1poWTNRek5qSTFNVGcxT1RRPSIsIm5h\nbWUiOiJoZWxsby50eHQiLCJzaXplX2luX2J5dGVzIjoxNCwidXJsIjoiaHR0\ncHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy88R0lUSFVCX0xPR0lOPi88R0lU\nSFVCX1RFU1RfUkVQT1NJVE9SWT4vYWN0aW9ucy9hcnRpZmFjdHMvMzYyNTE4\nNTk0IiwiYXJjaGl2ZV9kb3dubG9hZF91cmwiOiJodHRwczovL2FwaS5naXRo\ndWIuY29tL3JlcG9zLzxHSVRIVUJfTE9HSU4+LzxHSVRIVUJfVEVTVF9SRVBP\nU0lUT1JZPi9hY3Rpb25zL2FydGlmYWN0cy8zNjI1MTg1OTQvemlwIiwiZXhw\naXJlZCI6ZmFsc2UsImNyZWF0ZWRfYXQiOiIyMDIyLTA5LTE0VDAwOjI0OjQ1\nWiIsInVwZGF0ZWRfYXQiOiIyMDIyLTA5LTE0VDAwOjI0OjQ2WiIsImV4cGly\nZXNfYXQiOiIyMDIyLTA5LTE1VDAwOjI0OjQyWiIsIndvcmtmbG93X3J1biI6\neyJpZCI6MzA0OTI5ODAyMywicmVwb3NpdG9yeV9pZCI6MTk5MDI2MzE1LCJo\nZWFkX3JlcG9zaXRvcnlfaWQiOjE5OTAyNjMxNSwiaGVhZF9icmFuY2giOiJt\nYXN0ZXIiLCJoZWFkX3NoYSI6Ijk5OWJlODY3MzNkNWJmNGE2NzIyZDc4ZjMz\nYjJkZGMyNDI0Yzc5OGQifX1dfQ==\n"
+        }
+      },
+      "recorded_at": "Wed, 14 Sep 2022 00:30:08 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.1.0"
+}

--- a/spec/cassettes/Octokit_Client_ActionsArtifacts/_workflow_run_artifacts/returns_all_artifacts_for_a_workflow_run.json
+++ b/spec/cassettes/Octokit_Client_ActionsArtifacts/_workflow_run_artifacts/returns_all_artifacts_for_a_workflow_run.json
@@ -1,0 +1,124 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repos/<GITHUB_LOGIN>/<GITHUB_TEST_REPOSITORY>/actions/runs/3049298023/artifacts",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 5.5.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Wed, 14 Sep 2022 00:30:08 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"a7110c5e38e30185e3eea02e3708267858abf5fbb899765333d109b9282c83bb\""
+          ],
+          "X-Oauth-Scopes": [
+            "repo, workflow"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2022-09-20 23:45:13 UTC"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-08-09"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4996"
+          ],
+          "X-Ratelimit-Reset": [
+            "1663119007"
+          ],
+          "X-Ratelimit-Used": [
+            "4"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0403:4118:28A7740:29D5156:63212090"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJ0b3RhbF9jb3VudCI6MSwiYXJ0aWZhY3RzIjpbeyJpZCI6MzYyNTE4NTk0\nLCJub2RlX2lkIjoiTURnNlFYSjBhV1poWTNRek5qSTFNVGcxT1RRPSIsIm5h\nbWUiOiJoZWxsby50eHQiLCJzaXplX2luX2J5dGVzIjoxNCwidXJsIjoiaHR0\ncHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy88R0lUSFVCX0xPR0lOPi88R0lU\nSFVCX1RFU1RfUkVQT1NJVE9SWT4vYWN0aW9ucy9hcnRpZmFjdHMvMzYyNTE4\nNTk0IiwiYXJjaGl2ZV9kb3dubG9hZF91cmwiOiJodHRwczovL2FwaS5naXRo\ndWIuY29tL3JlcG9zLzxHSVRIVUJfTE9HSU4+LzxHSVRIVUJfVEVTVF9SRVBP\nU0lUT1JZPi9hY3Rpb25zL2FydGlmYWN0cy8zNjI1MTg1OTQvemlwIiwiZXhw\naXJlZCI6ZmFsc2UsImNyZWF0ZWRfYXQiOiIyMDIyLTA5LTE0VDAwOjI0OjQ1\nWiIsInVwZGF0ZWRfYXQiOiIyMDIyLTA5LTE0VDAwOjI0OjQ2WiIsImV4cGly\nZXNfYXQiOiIyMDIyLTA5LTE1VDAwOjI0OjQyWiIsIndvcmtmbG93X3J1biI6\neyJpZCI6MzA0OTI5ODAyMywicmVwb3NpdG9yeV9pZCI6MTk5MDI2MzE1LCJo\nZWFkX3JlcG9zaXRvcnlfaWQiOjE5OTAyNjMxNSwiaGVhZF9icmFuY2giOiJt\nYXN0ZXIiLCJoZWFkX3NoYSI6Ijk5OWJlODY3MzNkNWJmNGE2NzIyZDc4ZjMz\nYjJkZGMyNDI0Yzc5OGQifX1dfQ==\n"
+        }
+      },
+      "recorded_at": "Wed, 14 Sep 2022 00:30:08 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.1.0"
+}

--- a/spec/octokit/client/actions_artifacts_spec.rb
+++ b/spec/octokit/client/actions_artifacts_spec.rb
@@ -55,7 +55,7 @@ describe Octokit::Client::ActionsArtifacts, :vcr do
       status = @client.delete_artifact(@test_repo, @artifact_id)
 
       assert_requested :delete, github_url("repos/#{@test_repo}/actions/artifacts/#{@artifact_id}")
-      expect(status).to be(true).or be(false)
+      expect(status).to be(true)
     end
   end
 end

--- a/spec/octokit/client/actions_artifacts_spec.rb
+++ b/spec/octokit/client/actions_artifacts_spec.rb
@@ -1,0 +1,64 @@
+require 'helper'
+
+describe Octokit::Client::ActionsArtifacts, :vcr do
+  before do
+    Octokit.reset!
+    @client = oauth_client
+    @workflow_run_id = 123
+    @artifact_id = 456
+  end
+
+  after do
+    Octokit.reset!
+  end
+
+  describe '.repository_artifacts' do
+    it 'returns all artifacts for a repository' do
+      request = stub_get("repos/#{@test_repo}/actions/artifacts")
+
+      @client.repository_artifacts(@test_repo)
+
+      assert_requested request
+    end
+  end
+
+  describe '.workflow_run_artifacts' do
+    it 'returns all artifacts for a workflow run' do
+      request = stub_get("repos/#{@test_repo}/actions/runs/#{@workflow_run_id}/artifacts")
+
+      @client.workflow_run_artifacts(@test_repo, @workflow_run_id)
+
+      assert_requested request
+    end
+  end
+
+  describe '.artifact' do
+    it 'returns the requested artifact' do
+      request = stub_get("repos/#{@test_repo}/actions/artifacts/#{@artifact_id}")
+
+      @client.artifact(@test_repo, @artifact_id)
+
+      assert_requested request
+    end
+  end
+
+  describe '.artifact_download_url' do
+    it 'returns the location of artifact .zip archive' do
+      request = stub_head("repos/#{@test_repo}/actions/artifacts/#{@artifact_id}/zip")
+
+      @client.artifact_download_url(@test_repo, @artifact_id)
+
+      assert_requested request
+    end
+  end
+
+  describe '.delete_artifact' do
+    it 'deletes the artifact' do
+      request = stub_delete("repos/#{@test_repo}/actions/artifacts/#{@artifact_id}")
+
+      @client.delete_artifact(@test_repo, @artifact_id)
+
+      assert_requested request
+    end
+  end
+end

--- a/spec/octokit/client/actions_artifacts_spec.rb
+++ b/spec/octokit/client/actions_artifacts_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe Octokit::Client::ActionsArtifacts, :vcr do

--- a/spec/octokit/client/actions_artifacts_spec.rb
+++ b/spec/octokit/client/actions_artifacts_spec.rb
@@ -6,8 +6,8 @@ describe Octokit::Client::ActionsArtifacts, :vcr do
   before do
     Octokit.reset!
     @client = oauth_client
-    @workflow_run_id = 123
-    @artifact_id = 456
+    @workflow_run_id = 3_049_298_023
+    @artifact_id = 362_518_594
   end
 
   after do
@@ -16,51 +16,46 @@ describe Octokit::Client::ActionsArtifacts, :vcr do
 
   describe '.repository_artifacts' do
     it 'returns all artifacts for a repository' do
-      request = stub_get("repos/#{@test_repo}/actions/artifacts")
+      repository_artifacts = @client.repository_artifacts(@test_repo)
 
-      @client.repository_artifacts(@test_repo)
-
-      assert_requested request
+      assert_requested :get, github_url("repos/#{@test_repo}/actions/artifacts")
+      expect(repository_artifacts).to be_kind_of Sawyer::Resource
     end
   end
 
   describe '.workflow_run_artifacts' do
     it 'returns all artifacts for a workflow run' do
-      request = stub_get("repos/#{@test_repo}/actions/runs/#{@workflow_run_id}/artifacts")
+      workflow_run_artifacts = @client.workflow_run_artifacts(@test_repo, @workflow_run_id)
 
-      @client.workflow_run_artifacts(@test_repo, @workflow_run_id)
-
-      assert_requested request
+      assert_requested :get, github_url("repos/#{@test_repo}/actions/runs/#{@workflow_run_id}/artifacts")
+      expect(workflow_run_artifacts).to be_kind_of Sawyer::Resource
     end
   end
 
   describe '.artifact' do
     it 'returns the requested artifact' do
-      request = stub_get("repos/#{@test_repo}/actions/artifacts/#{@artifact_id}")
+      artifact = @client.artifact(@test_repo, @artifact_id)
 
-      @client.artifact(@test_repo, @artifact_id)
-
-      assert_requested request
+      assert_requested :get, github_url("repos/#{@test_repo}/actions/artifacts/#{@artifact_id}")
+      expect(artifact).to be_kind_of Sawyer::Resource
     end
   end
 
   describe '.artifact_download_url' do
     it 'returns the location of artifact .zip archive' do
-      request = stub_head("repos/#{@test_repo}/actions/artifacts/#{@artifact_id}/zip")
+      url = @client.artifact_download_url(@test_repo, @artifact_id)
 
-      @client.artifact_download_url(@test_repo, @artifact_id)
-
-      assert_requested request
+      assert_requested :head, github_url("repos/#{@test_repo}/actions/artifacts/#{@artifact_id}/zip")
+      expect(url).to be_kind_of String
     end
   end
 
   describe '.delete_artifact' do
     it 'deletes the artifact' do
-      request = stub_delete("repos/#{@test_repo}/actions/artifacts/#{@artifact_id}")
+      status = @client.delete_artifact(@test_repo, @artifact_id)
 
-      @client.delete_artifact(@test_repo, @artifact_id)
-
-      assert_requested request
+      assert_requested :delete, github_url("repos/#{@test_repo}/actions/artifacts/#{@artifact_id}")
+      expect(status).to be(true).or be(false)
     end
   end
 end


### PR DESCRIPTION
Partially addresses https://github.com/octokit/octokit.rb/issues/1216.

This adds support for the Actions artifact APIs documented at https://docs.github.com/en/rest/actions/artifacts.

## Help needed please 🙏🏿 

- [x] As a first-time contributor, I need a maintainer to approve my pending Actions workflows on this PR please. 
- [x] It isn't clear to me how to record a new cassette for these tests. I've tried hardcoding the [default record_mode](https://github.com/lerebear/octokit.rb/blob/52e099abe3b355d44d921ea10bc7979a47b1df59/spec/helper.rb#L144) to `:once` and running tests with either `script/test` or `bundle exec rspec spec/octokit/client/actions_artifacts_spec.rb`, both to no avail. The lack of cassettes for these new tests will likely cause them to fail once the pending Actions workflows are authorized, so any guidance here would be much appreciated.
- [x] I'm not sure how to satisfy the documentation requirement from the contribution guide. I've run `bundle exec rake doc:yard` locally, but I'm not sure how to interpret its output. Please let me know if there's anything more to do here.