### PR TITLE
Correct documentation URL for `#artifact_download_url`

### DIFF
--- a/lib/octokit/client/actions_artifacts.rb
+++ b/lib/octokit/client/actions_artifacts.rb
@@ -44,7 +44,7 @@ module Octokit
       # @param id [Integer] Id of an artifact
       #
       # @return [String] URL to the .zip archive of the artifact
-      # @see https://docs.github.com/en/rest/actions/workflow-runs#download-workflow-run-logs
+      # @see https://docs.github.com/en/rest/actions/artifacts#download-an-artifact
       def artifact_download_url(repo, id, options = {})
         url = "#{Repository.path repo}/actions/artifacts/#{id}/zip"
 


### PR DESCRIPTION
With each client method, we include its URL in our API documentation on https://docs.github.com. After releasing v5.6.0, I spotted that the URL for `#artifact_download_url` was incorrect, pointing to a different API. This fixes it.