### PR TITLE
Update regex for Octokit::TooLargeContent

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -77,7 +77,7 @@ module Octokit
         Octokit::TooManyRequests
       when /login attempts exceeded/i
         Octokit::TooManyLoginAttempts
-      when /returns blobs up to [0-9]+ MB/i
+      when /returns blobs (up to|between) [0-9\-]+ MB/i
         Octokit::TooLargeContent
       when /abuse/i
         Octokit::AbuseDetected


### PR DESCRIPTION
The error message changed at some point and Octokit no longer throws Octokit::TooLargeContent
- Github Enterprise 3.6.1 is affected
- Fixes https://github.com/octokit/octokit.rb/issues/1482

In Github Enterprise 3.6.1 (and probably others), the message returned in the Sawyer::Resource is 

```
Either the raw or object media type must be used for this endpoint for blobs between 1-100 MB. The raw type will return the file contents, and the JSON type will return the file's metadata. Please try again with a valid media type.
```