### PR TITLE
Remove Octokit::Client::Hooks#available_hooks

### DIFF
--- a/lib/octokit/client/hooks.rb
+++ b/lib/octokit/client/hooks.rb
@@ -4,16 +4,6 @@ module Octokit
   class Client
     # Methods for the Hooks API
     module Hooks
-      # List all Service Hooks supported by GitHub
-      #
-      # @return [Sawyer::Resource] A list of all hooks on GitHub
-      # @see https://developer.github.com/v3/repos/hooks/#services
-      # @example List all hooks
-      #   Octokit.available_hooks
-      def available_hooks(options = {})
-        get 'hooks', options
-      end
-
       # List repo hooks
       #
       # Requires authenticated client.

--- a/spec/octokit/client/hooks_spec.rb
+++ b/spec/octokit/client/hooks_spec.rb
@@ -8,13 +8,6 @@ describe Octokit::Client::Hooks do
     @client = oauth_client
   end
 
-  describe '.available_hooks', :vcr do
-    it 'returns all the hooks supported by GitHub with their parameters' do
-      hooks = @client.available_hooks
-      expect(hooks.first.name).to eq('activecollab')
-    end
-  end
-
   context 'with repository' do
     before(:each) do
       @repo = @client.create_repository('an-repo')


### PR DESCRIPTION
Fixes #1430. 

As noted by Tim in the above issue, this should land in a breaking change even though the underlying API hasn't been operational for some time. 