### PR TITLE
Bump to v6.0.0

### DIFF
--- a/lib/octokit/version.rb
+++ b/lib/octokit/version.rb
@@ -3,15 +3,15 @@
 module Octokit
   # Current major release.
   # @return [Integer]
-  MAJOR = 5
+  MAJOR = 6
 
   # Current minor release.
   # @return [Integer]
-  MINOR = 6
+  MINOR = 0
 
   # Current patch level.
   # @return [Integer]
-  PATCH = 1
+  PATCH = 0
 
   # Full release version.
   # @return [String]


### PR DESCRIPTION
As a result of #1494 and #1495, we're cutting a new major release (even though the APIs that underly this functionality has long been deprecated). 