### PR TITLE
Rename obsolete parameter `IgnoredMethods` to `AllowedMethods`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
   TargetRubyVersion: 2.3
   NewCops: enable
 Metrics/BlockLength:
-  IgnoredMethods: ['describe', 'context'] 
+  AllowedMethods: ['describe', 'context'] 
 Layout/BlockAlignment:
   Exclude: 
     # This file is causing Rubocop to error - see <https://github.com/octokit/octokit.rb/runs/6779545664>


### PR DESCRIPTION
Fix the following rubocop warning.

> Warning: obsolete parameter `IgnoredMethods` (for `Metrics/BlockLength`) found in .rubocop.yml
`IgnoredMethods` has been renamed to `AllowedMethods` and/or `AllowedPatterns`.