### PR TITLE
Allow using the response_headers or headers when getting Rate Limit Info

### DIFF
--- a/lib/octokit/rate_limit.rb
+++ b/lib/octokit/rate_limit.rb
@@ -20,10 +20,12 @@ module Octokit
     # @return [RateLimit]
     def self.from_response(response)
       info = new
-      if response.respond_to?(:headers) && !response.headers.nil?
-        info.limit = (response.headers['X-RateLimit-Limit'] || 1).to_i
-        info.remaining = (response.headers['X-RateLimit-Remaining'] || 1).to_i
-        info.resets_at = Time.at((response.headers['X-RateLimit-Reset'] || Time.now).to_i)
+      headers = response.headers if response.respond_to?(:headers) && !response.headers.nil?
+      headers ||= response.response_headers if response.respond_to?(:response_headers) && !response.response_headers.nil?
+      if headers
+        info.limit = (headers['X-RateLimit-Limit'] || 1).to_i
+        info.remaining = (headers['X-RateLimit-Remaining'] || 1).to_i
+        info.resets_at = Time.at((headers['X-RateLimit-Reset'] || Time.now).to_i)
         info.resets_in = [(info.resets_at - Time.now).to_i, 0].max
       end
 

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -1167,12 +1167,13 @@ describe Octokit::Client do
     stub_get('/user').to_return \
       status: 403,
       headers: {
-        'content_type' => 'application/json'
+        'content_type' => 'application/json',
+        'X-RateLimit-Limit' => 60,
+        'X-RateLimit-Remaining' => 42,
+        'X-RateLimit-Reset' => (Time.now + 60).to_i
       },
       body: { message: 'rate limit exceeded' }.to_json
     begin
-      rate_limit_headers = { 'X-RateLimit-Limit' => 60, 'X-RateLimit-Remaining' => 42, 'X-RateLimit-Reset' => (Time.now + 60).to_i }
-      expect_any_instance_of(Faraday::Env).to receive(:headers).at_least(:once).and_return(rate_limit_headers)
       Octokit.get('/user')
     rescue Octokit::TooManyRequests => e
       expect(e.context).to be_an_instance_of(Octokit::RateLimit)
@@ -1189,7 +1190,6 @@ describe Octokit::Client do
       },
       body: { message: 'You have exceeded a secondary rate limit.' }.to_json
     begin
-      expect_any_instance_of(Faraday::Env).to receive(:headers).at_least(:once).and_return({})
       Octokit.get('/user')
     rescue Octokit::TooManyRequests => e
       expect(e.context).to be_an_instance_of(Octokit::RateLimit)
@@ -1200,12 +1200,13 @@ describe Octokit::Client do
     stub_get('/user').to_return \
       status: 403,
       headers: {
-        'content_type' => 'application/json'
+        'content_type' => 'application/json',
+        'X-RateLimit-Limit' => 60,
+        'X-RateLimit-Remaining' => 42,
+        'X-RateLimit-Reset' => (Time.now + 60).to_i 
       },
       body: { message: 'You have exceeded a secondary rate limit.' }.to_json
     begin
-      rate_limit_headers = { 'X-RateLimit-Limit' => 60, 'X-RateLimit-Remaining' => 42, 'X-RateLimit-Reset' => (Time.now + 60).to_i }
-      expect_any_instance_of(Faraday::Env).to receive(:headers).at_least(:once).and_return(rate_limit_headers)
       Octokit.get('/user')
     rescue Octokit::TooManyRequests => e
       expect(e.context).to be_an_instance_of(Octokit::RateLimit)

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -1203,7 +1203,7 @@ describe Octokit::Client do
         'content_type' => 'application/json',
         'X-RateLimit-Limit' => 60,
         'X-RateLimit-Remaining' => 42,
-        'X-RateLimit-Reset' => (Time.now + 60).to_i 
+        'X-RateLimit-Reset' => (Time.now + 60).to_i
       },
       body: { message: 'You have exceeded a secondary rate limit.' }.to_json
     begin

--- a/spec/octokit/rate_limit_spec.rb
+++ b/spec/octokit/rate_limit_spec.rb
@@ -16,7 +16,7 @@ describe Octokit::RateLimit do
     let(:response) { double('response') }
 
     it 'parses rate limit info from response headers' do
-      expect(response).to receive(:headers)
+      expect(response).to receive(:response_headers)
         .at_least(:once)
         .and_return(response_headers)
       info = described_class.from_response(response)
@@ -27,7 +27,7 @@ describe Octokit::RateLimit do
     end
 
     it 'returns a positive rate limit for Enterprise' do
-      expect(response).to receive(:headers)
+      expect(response).to receive(:response_headers)
         .at_least(:once)
         .and_return({})
       info = described_class.from_response(response)
@@ -46,7 +46,7 @@ describe Octokit::RateLimit do
     end
 
     it 'handles resets_in time in past' do
-      expect(response).to receive(:headers)
+      expect(response).to receive(:response_headers)
         .at_least(:once)
         .and_return(
           response_headers.merge('X-RateLimit-Reset' => (Time.now - 60).to_i)


### PR DESCRIPTION
Resolves #1400 

----

## Behavior

### Before the change?

* `Octokit::TooManyRequests#context.rate_limit` methods return nil

### After the change?


* `Octokit::TooManyRequests#context.rate_limit` methods return the correct values


### Other information

* I've left this as prioritizing the `headers` field over `response_headers`, it's not clear to me when `headers` was valid (I'm not sure if it was an older version of faraday or something), I looked through the code and I think it's because the `on_complete` uses `response_env` (might be [here](https://github.com/octokit/octokit.rb/blob/82765ce829c109644d520d11e86f8673203eb83f/lib/octokit/middleware/follow_redirects.rb#L75) instead of `response` (`Faraday::Response` has `headers` delegating to `env.response_headers`

Note: I can't see where to add in bug fix information in this repo?

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

- Bugfix: `Type: Bug`

