### PR TITLE
Specify `TargetRubyVersion: 2.7` in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.7
   NewCops: enable
 Metrics/BlockLength:
   AllowedMethods: ['describe', 'context'] 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,13 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-# Configuration parameters: Include.
-# Include: **/*.gemspec
-Gemspec/RequiredRubyVersion:
-  Exclude:
-    - 'octokit.gemspec'
-
 # Offense count: 13
 # Configuration parameters: AllowSafeAssignment.
 Lint/AssignmentInCondition:

--- a/Rakefile
+++ b/Rakefile
@@ -10,15 +10,13 @@ task test: :spec
 task default: :spec
 
 namespace :doc do
-  begin
-    require 'yard'
-    YARD::Rake::YardocTask.new do |task|
-      task.files   = ['README.md', 'LICENSE.md', 'lib/**/*.rb']
-      task.options = [
-        '--output-dir', 'doc/yard',
-        '--markup', 'markdown'
-      ]
-    end
-  rescue LoadError
+  require 'yard'
+  YARD::Rake::YardocTask.new do |task|
+    task.files   = ['README.md', 'LICENSE.md', 'lib/**/*.rb']
+    task.options = [
+      '--output-dir', 'doc/yard',
+      '--markup', 'markdown'
+    ]
   end
+rescue LoadError
 end

--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -163,10 +163,10 @@ module Octokit
       inspected.gsub! @bearer_token, '********' if @bearer_token
       # Only show last 4 of token, secret
       if @access_token
-        inspected.gsub! @access_token, "#{'*' * 36}#{@access_token[36..-1]}"
+        inspected.gsub! @access_token, "#{'*' * 36}#{@access_token[36..]}"
       end
       if @client_secret
-        inspected.gsub! @client_secret, "#{'*' * 36}#{@client_secret[36..-1]}"
+        inspected.gsub! @client_secret, "#{'*' * 36}#{@client_secret[36..]}"
       end
 
       inspected

--- a/lib/octokit/configurable.rb
+++ b/lib/octokit/configurable.rb
@@ -144,7 +144,7 @@ module Octokit
     private
 
     def options
-      Octokit::Configurable.keys.map { |key| [key, instance_variable_get(:"@#{key}")] }.to_h
+      Octokit::Configurable.keys.to_h { |key| [key, instance_variable_get(:"@#{key}")] }
     end
 
     def fetch_client_id_and_secret(overrides = {})

--- a/lib/octokit/default.rb
+++ b/lib/octokit/default.rb
@@ -49,7 +49,7 @@ module Octokit
       # Configuration options
       # @return [Hash]
       def options
-        Octokit::Configurable.keys.map { |key| [key, send(key)] }.to_h
+        Octokit::Configurable.keys.to_h { |key| [key, send(key)] }
       end
 
       # Default access token from ENV

--- a/lib/octokit/gist.rb
+++ b/lib/octokit/gist.rb
@@ -10,7 +10,7 @@ module Octokit
     # Instantiate {Gist} object from Gist URL
     # @ return [Gist]
     def self.from_url(url)
-      Gist.new(URI.parse(url).path[1..-1])
+      Gist.new(URI.parse(url).path[1..])
     end
 
     def initialize(gist)

--- a/lib/octokit/repository.rb
+++ b/lib/octokit/repository.rb
@@ -12,7 +12,7 @@ module Octokit
     #
     # @return [Repository]
     def self.from_url(url)
-      new URI.parse(url).path[1..-1]
+      new URI.parse(url).path[1..]
              .gsub(%r{^repos/}, '')
              .split('/', 3)[0..1]
              .join('/')

--- a/spec/octokit/client/actions_secrets_spec.rb
+++ b/spec/octokit/client/actions_secrets_spec.rb
@@ -25,10 +25,8 @@ describe Octokit::Client::ActionsSecrets do
     end
 
     after(:each) do
-      begin
-        @client.delete_repository(@repo.full_name) unless @repo.nil?
-      rescue Octokit::NotFound
-      end
+      @client.delete_repository(@repo.full_name) unless @repo.nil?
+    rescue Octokit::NotFound
     end
 
     describe '.get_public_key', :vcr do
@@ -45,10 +43,8 @@ describe Octokit::Client::ActionsSecrets do
     end
 
     after(:each) do
-      begin
-        @client.delete_repository(@repo.full_name) unless @repo.nil?
-      rescue Octokit::NotFound
-      end
+      @client.delete_repository(@repo.full_name) unless @repo.nil?
+    rescue Octokit::NotFound
     end
 
     describe '.list_secrets', :vcr do
@@ -86,10 +82,8 @@ describe Octokit::Client::ActionsSecrets do
     end
 
     after(:each) do
-      begin
-        @client.delete_repository(@repo.full_name) unless @repo.nil?
-      rescue Octokit::NotFound
-      end
+      @client.delete_repository(@repo.full_name) unless @repo.nil?
+    rescue Octokit::NotFound
     end
 
     describe '.list_secrets', :vcr do

--- a/spec/octokit/client/deployments_spec.rb
+++ b/spec/octokit/client/deployments_spec.rb
@@ -30,10 +30,8 @@ describe Octokit::Client::Deployments do
     end
 
     after(:each) do
-      begin
-        @client.delete_ref(@test_repo, "heads/#{@branch_name}")
-      rescue Octokit::UnprocessableEntity
-      end
+      @client.delete_ref(@test_repo, "heads/#{@branch_name}")
+    rescue Octokit::UnprocessableEntity
     end
 
     describe '.create_deployment' do

--- a/spec/octokit/client/hooks_spec.rb
+++ b/spec/octokit/client/hooks_spec.rb
@@ -14,10 +14,8 @@ describe Octokit::Client::Hooks do
     end
 
     after(:each) do
-      begin
-        @client.delete_repository(@repo.full_name)
-      rescue Octokit::NotFound
-      end
+      @client.delete_repository(@repo.full_name)
+    rescue Octokit::NotFound
     end
 
     describe '.hooks', :vcr do

--- a/spec/octokit/client/issues_spec.rb
+++ b/spec/octokit/client/issues_spec.rb
@@ -55,10 +55,8 @@ describe Octokit::Client::Issues do
     end
 
     after(:each) do
-      begin
-        @client.delete_repository(@repo.full_name)
-      rescue Octokit::NotFound
-      end
+      @client.delete_repository(@repo.full_name)
+    rescue Octokit::NotFound
     end
 
     describe '.create_issue', :vcr do

--- a/spec/octokit/client/reactions_spec.rb
+++ b/spec/octokit/client/reactions_spec.rb
@@ -14,10 +14,8 @@ describe Octokit::Client::Reactions do
     end
 
     after(:each) do
-      begin
-        @client.delete_repository(@repo.full_name)
-      rescue Octokit::NotFound
-      end
+      @client.delete_repository(@repo.full_name)
+    rescue Octokit::NotFound
     end
 
     context 'with commit comment' do

--- a/spec/octokit/client/refs_spec.rb
+++ b/spec/octokit/client/refs_spec.rb
@@ -73,10 +73,8 @@ describe Octokit::Client::Refs do
     end
 
     after(:each) do
-      begin
-        @client.delete_ref(@test_repo, 'heads/testing/test-ref')
-      rescue Octokit::UnprocessableEntity
-      end
+      @client.delete_ref(@test_repo, 'heads/testing/test-ref')
+    rescue Octokit::UnprocessableEntity
     end
 
     describe '.create_ref' do

--- a/spec/octokit/client/repositories_spec.rb
+++ b/spec/octokit/client/repositories_spec.rb
@@ -103,10 +103,8 @@ describe Octokit::Client::Repositories do
     end
 
     after(:each) do
-      begin
-        @client.delete_repository(@repo.full_name)
-      rescue Octokit::NotFound
-      end
+      @client.delete_repository(@repo.full_name)
+    rescue Octokit::NotFound
     end
 
     describe '.create_repository_from_template', :vcr do
@@ -403,10 +401,8 @@ describe Octokit::Client::Repositories do
     end
 
     after(:each) do
-      begin
-        @client.delete_repository(@repo.full_name)
-      rescue Octokit::NotFound
-      end
+      @client.delete_repository(@repo.full_name)
+    rescue Octokit::NotFound
     end
 
     describe '.permission_level', :vcr do
@@ -568,10 +564,9 @@ describe Octokit::Client::Repositories do
 
     after do
       # cleanup
-      begin
-        @client.delete_repository("#{test_github_org}/#{@repository.name}")
-      rescue Octokit::NotFound
-      end
+
+      @client.delete_repository("#{test_github_org}/#{@repository.name}")
+    rescue Octokit::NotFound
     end
 
     it 'repository transfer from myself to my organization' do

--- a/spec/octokit/client/repository_invitations_spec.rb
+++ b/spec/octokit/client/repository_invitations_spec.rb
@@ -14,10 +14,8 @@ describe Octokit::Client::RepositoryInvitations do
     end
 
     after(:each) do
-      begin
-        @client.delete_repository(@repo.id)
-      rescue Octokit::NotFound
-      end
+      @client.delete_repository(@repo.id)
+    rescue Octokit::NotFound
     end
 
     describe '.invite_user_to_repository', :vcr do

--- a/spec/octokit/client/source_import_spec.rb
+++ b/spec/octokit/client/source_import_spec.rb
@@ -13,10 +13,8 @@ describe Octokit::Client::SourceImport do
   end
 
   after(:each) do
-    begin
-      @client.delete_repository(@repo.full_name)
-    rescue Octokit::NotFound
-    end
+    @client.delete_repository(@repo.full_name)
+  rescue Octokit::NotFound
   end
 
   describe 'pre deprecation' do


### PR DESCRIPTION
## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

Version mismatch between `required_ruby_version` of gemspec and `TargetRubyVersion` of .rubocop.yml. Therefore, some new syntax up to Ruby 2.7 is not used.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

gemspec `required_ruby_version` requires 2.7 and higher, so specify `TargetRubyVersion` to 2.7. Some syntax detected by updating to 2.7 applies.

It also removes `Gemspec/RequiredRubyVersion` cop from .rubocop_todo.yml to enable the cop so that version mismatch can be detected.

### Other information
<!-- Any other information that is important to this PR  -->

This PR is follow up https://github.com/octokit/octokit.rb/pull/1454.

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

