### PR TITLE
Add Ruby 3.2 to tested implementations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,7 @@ implementations:
 * Ruby 2.7
 * Ruby 3.0
 * Ruby 3.1
+* Ruby 3.2
 
 If something doesn't work on one of these Ruby versions, it's a bug.
 


### PR DESCRIPTION
## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Ruby 3.2 is missing for tested implementations in the README.md.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Add Ruby 3.2 to the tested implementations in the README.md.

### Other information
<!-- Any other information that is important to this PR  -->

This PR is follow up https://github.com/octokit/octokit.rb/pull/1524.

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

