### PR TITLE
Add Faraday DEFAULT_EXCEPTIONS for when retry middleware is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ traffic:
 
 ```ruby
 stack = Faraday::RackBuilder.new do |builder|
-  builder.use Faraday::Retry::Middleware, exceptions: [Octokit::ServerError] # or Faraday::Request::Retry for Faraday < 2.0
+  builder.use Faraday::Retry::Middleware, exceptions: Faraday::Request::Retry::DEFAULT_EXCEPTIONS + [Octokit::ServerError] # or Faraday::Request::Retry for Faraday < 2.0
   builder.use Octokit::Middleware::FollowRedirects
   builder.use Octokit::Response::RaiseError
   builder.use Octokit::Response::FeedParser

--- a/lib/octokit/default.rb
+++ b/lib/octokit/default.rb
@@ -34,9 +34,11 @@ module Octokit
       # In Faraday 2.x, Faraday::Request::Retry was moved to a separate gem
       # so we use it only when it's available.
       if defined?(Faraday::Request::Retry)
-        builder.use Faraday::Request::Retry, exceptions: [Octokit::ServerError]
+        retry_exceptions = Faraday::Request::Retry::DEFAULT_EXCEPTIONS + [Octokit::ServerError]
+        builder.use Faraday::Request::Retry, exceptions: retry_exceptions
       elsif defined?(Faraday::Retry::Middleware)
-        builder.use Faraday::Retry::Middleware, exceptions: [Octokit::ServerError]
+        retry_exceptions = Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [Octokit::ServerError]
+        builder.use Faraday::Retry::Middleware, exceptions: retry_exceptions
       end
 
       builder.use Octokit::Middleware::FollowRedirects


### PR DESCRIPTION
Resolves #1188 

----

## Behavior

### Before the change?

* Octokit would not retry on timeouts

### After the change?

* Octokit does retry on timeouts


### Other information

* It's pretty straightforward, I can see the original issue marks this as a breaking change.

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No (I don't think so)

If `Yes`, what's the impact:  

* This _could_ be a breaking change since Octokit will now retry on errors it didn't before, but https://github.com/octokit/octokit.rb/pull/1021 wasn't marked as a breaking change,


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

I want to mark this as a bug, but I can understand if it's a feature!
