### PR TITLE
Add `Octokit::Client#delete_organization` to support org deletion

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -56,7 +56,7 @@ module Octokit
       #
       # @param org [String, Integer] Organization login or ID.
       # @return [Boolean] True if deletion successful, otherwise false.
-      # @see https://docs.github.com/rest/reference/orgs/#delete-an-organization
+      # @see https://docs.github.com/rest/orgs/orgs#delete-an-organization
       # @example
       #   @client.delete_organization("my-org")
       # @example

--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -52,7 +52,7 @@ module Octokit
 
       # Delete an organization.
       #
-      # Requires authenticated client with proper organization permissions.
+      # Requires authenticated organization owner.
       #
       # @param org [String, Integer] Organization GitHub login or id.
       # @return [Boolean] True if deletion successful, otherwise false.

--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -54,7 +54,7 @@ module Octokit
       #
       # Requires authenticated organization owner.
       #
-      # @param org [String, Integer] Organization GitHub login or id.
+      # @param org [String, Integer] Organization login or ID.
       # @return [Boolean] True if deletion successful, otherwise false.
       # @see https://docs.github.com/rest/reference/orgs/#delete-an-organization
       # @example

--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -50,6 +50,22 @@ module Octokit
       end
       alias update_org update_organization
 
+      # Delete an organization.
+      #
+      # Requires authenticated client with proper organization permissions.
+      #
+      # @param org [String, Integer] Organization GitHub login or id.
+      # @return [Boolean] True if deletion successful, otherwise false.
+      # @see https://docs.github.com/rest/reference/orgs/#delete-an-organization
+      # @example
+      #   @client.delete_organization("my-org")
+      # @example
+      #   @client.delete_org("my-org")
+      def delete_organization(org)
+        boolean_from_response :delete, Organization.path(org)
+      end
+      alias delete_org delete_organization
+
       # Get organizations for a user.
       #
       # Nonauthenticated calls to this method will return organizations that

--- a/spec/cassettes/Octokit_Client_Organizations/_delete_organization/deletes_an_organization.json
+++ b/spec/cassettes/Octokit_Client_Organizations/_delete_organization/deletes_an_organization.json
@@ -1,0 +1,117 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/orgs/random-org-to-be-deleted",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 6.1.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 202,
+          "message": "Accepted"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 24 Mar 2023 16:19:28 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, delete:packages, delete_repo, gist, notifications, project, repo, site_admin, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            "admin:org"
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-04-26 23:27:37 UTC"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4996"
+          ],
+          "X-Ratelimit-Reset": [
+            "1679676295"
+          ],
+          "X-Ratelimit-Used": [
+            "4"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "1D45:3E5D:57C414:596DB8:641DCD90"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Fri, 24 Mar 2023 16:19:28 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.1.0"
+}

--- a/spec/octokit/client/organizations_spec.rb
+++ b/spec/octokit/client/organizations_spec.rb
@@ -24,10 +24,10 @@ describe Octokit::Client::Organizations do
 
   describe ".delete_organization", :vcr do
     it "deletes an organization" do
-      @client.delete_organization(test_github_org)
-      assert_requested :delete, github_url("/orgs/#{test_github_org}")
+      @client.delete_organization("random-org-to-be-deleted")
+      assert_requested :delete, github_url("/orgs/random-org-to-be-deleted")
     end
-  end # .delete_organization
+  end
 
   describe '.organizations', :vcr do
     it 'returns all organizations for a user' do

--- a/spec/octokit/client/organizations_spec.rb
+++ b/spec/octokit/client/organizations_spec.rb
@@ -22,6 +22,13 @@ describe Octokit::Client::Organizations do
     end
   end # .update_organization
 
+  describe ".delete_organization", :vcr do
+    it "deletes an organization" do
+      @client.delete_organization(test_github_org)
+      assert_requested :delete, github_url("/orgs/#{test_github_org}")
+    end
+  end # .delete_organization
+
   describe '.organizations', :vcr do
     it 'returns all organizations for a user' do
       organizations = @client.organizations(test_github_login)

--- a/spec/octokit/client/organizations_spec.rb
+++ b/spec/octokit/client/organizations_spec.rb
@@ -22,10 +22,10 @@ describe Octokit::Client::Organizations do
     end
   end # .update_organization
 
-  describe "#delete_organization", :vcr do
-    it "deletes an organization" do
-      @client.delete_organization("random-org-to-be-deleted")
-      assert_requested :delete, github_url("/orgs/random-org-to-be-deleted")
+  describe '#delete_organization', :vcr do
+    it 'deletes an organization' do
+      @client.delete_organization('random-org-to-be-deleted')
+      assert_requested :delete, github_url('/orgs/random-org-to-be-deleted')
     end
   end
 

--- a/spec/octokit/client/organizations_spec.rb
+++ b/spec/octokit/client/organizations_spec.rb
@@ -22,7 +22,7 @@ describe Octokit::Client::Organizations do
     end
   end # .update_organization
 
-  describe ".delete_organization", :vcr do
+  describe "#delete_organization", :vcr do
     it "deletes an organization" do
       @client.delete_organization("random-org-to-be-deleted")
       assert_requested :delete, github_url("/orgs/random-org-to-be-deleted")


### PR DESCRIPTION
This PR adds `Octokit::Client#delete_organization` for the recently added API endpoint to delete an org:

https://docs.github.com/rest/orgs/orgs#delete-an-organization

Resolves https://github.com/octokit/octokit.rb/issues/1557

----

## Behavior

### Before the change?

* The Octokit client could not delete orgs.

### After the change?

* The Octokit client can delete orgs.

### Other information

* Changelog item: Add `Octokit::Client#delete_organization` for new API endpoint to delete organizations.

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

Please add the corresponding label for change this PR introduces:

(I can't add labels)

- Feature/model/API additions: `Type: Feature`

----

