### PR TITLE
[bugfix] Ensures that he API Token in clear text is never present in the error stack trace when set in the URL

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -11,7 +11,7 @@ module Octokit
     # @param [Hash] response HTTP response
     # @return [Octokit::Error]
     def self.from_response(response)
-      status  = response[:status].to_i
+      status  = 404 # response[:status].to_i
       body    = response[:body].to_s
       headers = response[:response_headers]
 
@@ -213,7 +213,7 @@ module Octokit
     end
 
     def redact_url(url_string)
-      %w[client_secret access_token].each do |token|
+      %w[client_secret access_token api_key].each do |token|
         if url_string.include? token
           url_string.gsub!(/#{token}=\S+/, "#{token}=(redacted)")
         end

--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -11,7 +11,7 @@ module Octokit
     # @param [Hash] response HTTP response
     # @return [Octokit::Error]
     def self.from_response(response)
-      status  = 404 # response[:status].to_i
+      status  = response[:status].to_i
       body    = response[:body].to_s
       headers = response[:response_headers]
 

--- a/spec/octokit/error_spec.rb
+++ b/spec/octokit/error_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'octokit/error'
+
+# Mixed feelings about testing private methods due to portnetially breaking encapsulation but
+# given the nature of this method and the fact that it is meant to keep secrets out of logs
+# I think it is worth it and it will help us know if something changes in this area.
+describe Octokit::Error do
+  describe '.build_error_message' do
+    it 'redacts api_key' do
+      url = 'http://127.0.0.1:8989/setup/api/settings?api_key=++++THIS+IS+A+SECRET++++&settings=certificate%22%2C%22key%22%3A%22++++THIS+IS+A+SECRET+AS+WELL++++%22%7D%7D'.dup
+      error = Octokit::Error.new
+      expect(error.send(:redact_url, url)).to eq('http://127.0.0.1:8989/setup/api/settings?api_key=(redacted)')
+    end
+
+    it 'redacts client_secret' do
+      url = 'http://127.0.0.1:8989/setup/api/settings?client_secret=++++THIS+IS+A+SECRET++++'.dup
+      error = Octokit::Error.new
+      expect(error.send(:redact_url, url)).to eq('http://127.0.0.1:8989/setup/api/settings?client_secret=(redacted)')
+    end
+
+    it 'redacts access_token' do
+      url = 'http://127.0.0.1:8989/setup/api/settings?access_token=++++THIS+IS+A+SECRET++++'.dup
+      error = Octokit::Error.new
+      expect(error.send(:redact_url, url)).to eq('http://127.0.0.1:8989/setup/api/settings?access_token=(redacted)')
+    end
+  end
+end

--- a/spec/octokit/error_spec.rb
+++ b/spec/octokit/error_spec.rb
@@ -6,7 +6,7 @@ require 'octokit/error'
 # given the nature of this method and the fact that it is meant to keep secrets out of logs.
 # In this case, it is worth it and will help us know if something changes in this area.
 describe Octokit::Error do
-  describe '.build_error_message' do
+  describe '.redact_url' do
     it 'redacts api_key' do
       url = 'http://127.0.0.1:8989/setup/api/settings?api_key=++++THIS+IS+A+SECRET++++&settings=certificate%22%2C%22key%22%3A%22++++THIS+IS+A+SECRET+AS+WELL++++%22%7D%7D'.dup
       error = Octokit::Error.new

--- a/spec/octokit/error_spec.rb
+++ b/spec/octokit/error_spec.rb
@@ -2,9 +2,9 @@
 
 require 'octokit/error'
 
-# Mixed feelings about testing private methods due to portnetially breaking encapsulation but
+# I have mixed feelings about testing private methods due to potentially breaking encapsulation but
 # given the nature of this method and the fact that it is meant to keep secrets out of logs
-# I think it is worth it and it will help us know if something changes in this area.
+# I think it is worth it and will help us know if something changes in this area.
 describe Octokit::Error do
   describe '.build_error_message' do
     it 'redacts api_key' do

--- a/spec/octokit/error_spec.rb
+++ b/spec/octokit/error_spec.rb
@@ -2,9 +2,9 @@
 
 require 'octokit/error'
 
-# I have mixed feelings about testing private methods due to potentially breaking encapsulation but
-# given the nature of this method and the fact that it is meant to keep secrets out of logs
-# I think it is worth it and will help us know if something changes in this area.
+# I have mixed feelings about testing this method due to potentially breaking encapsulation but
+# given the nature of this method and the fact that it is meant to keep secrets out of logs.
+# In this case, it is worth it and will help us know if something changes in this area.
 describe Octokit::Error do
   describe '.build_error_message' do
     it 'redacts api_key' do


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #1559

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Prior to the change, the api_token that was passed via URI (currently the only way the GitHub REST API accepts this value) was being persisted and sent to STDOUT in the stack trace when errors occurred.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The value of the key from the URL now displays as `http://127.0.0.1:8989/setup/api/settings?api_key=(redacted)`


### Other information
<!-- Any other information that is important to this PR  -->

I added tests for the private method.

I have mixed feelings about testing this method from this class like this due to potentially breaking encapsulation, but given the nature of this method and the fact that it is meant to keep secrets out of logs.

I feel like it is worth it and will help us know if something changes in this area.

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A

----

