### PR TITLE
Make faraday retry fully optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Access the library in Ruby:
 
     require 'octokit'
 
+Octokit.rb uses the `faraday` gem under the hood. When using `faraday > 2`,
+automatic request retries may be enabled by also installing the gem `faraday-retry`.
+
 ## Making requests
 
 [API methods][] are available as client instance methods.

--- a/lib/octokit/default.rb
+++ b/lib/octokit/default.rb
@@ -10,7 +10,7 @@ if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
   begin
     require 'faraday/retry'
   rescue LoadError
-    Octokit::Warnable.octokit_warn 'To use retry middleware with Faraday v2.0+, install `faraday-retry` gem'
+    # Ignore that faraday-retry is not present.
   end
 end
 


### PR DESCRIPTION
Resolves #1567 

----

## Behavior

### Before the change?

When loading the gem with `faraday > 2` and `faraday-retry` not installed, a warning is printed.

### After the change?

When loading the gem with `faraday > 2` and `faraday-retry` not installed, no warning is printed.

### Other information

This is one of the possible solutions for #1567, specifically the one I prefer. I am well aware that the maintainers could prefer another one and, if so, I could modify the pull request accordingly.

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
  - kind of N/A since this has not been tested before
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A

### Pull request type

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

