### PR TITLE
Use test-queue for parallel testing

### DIFF
--- a/.github/workflows/octokit.yml
+++ b/.github/workflows/octokit.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           GITHUB_CI: 1
           RUBYOPT: "--enable-frozen-string-literal"
-        run: bundle exec rspec -w
+        run: bundle exec rspec-queue -w
       - name: Lint with Rubocop
         env:
           GITHUB_CI: 1

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :test do
   gem 'rbnacl', '~> 7.1.1'
   gem 'rspec', '~> 3.9'
   gem 'simplecov', require: false
+  gem 'test-queue'
   gem 'vcr', '~> 6.1'
   gem 'webmock', '~> 3.8', '>= 3.8.2'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -3,11 +3,17 @@
 require 'bundler'
 Bundler::GemHelper.install_tasks
 
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new(:spec)
-
 task test: :spec
 task default: :spec
+
+desc 'Run RSpec'
+task :spec do
+  if Process.respond_to?(:fork)
+    sh('rspec-queue')
+  else
+    sh('rspec')
+  end
+end
 
 namespace :doc do
   require 'yard'


### PR DESCRIPTION
This PR makes developer tests parallel using test-queue: https://github.com/tmm1/test-queue

## Behavior

### Before

Around 55 seconds:

```console
$ bundle exec rake spec
(snip)

Finished in 55.03 seconds (files took 0.77671 seconds to load)
865 examples, 0 failures

Randomized with seed 6253
```

### After

Around 11 seconds (e.g. 8 CPUs with hyper threading) :

```console
$ bundle exec rake spec
rspec-queue spec
Starting test-queue master (/tmp/test_queue_12223_3620.sock)

==> Summary (16 workers in 11.6051s)

    [ 1]                                      65 examples, 0 failures         1 suites in 7.1969s      (pid 12226 exit 0 )
    [ 2]                                      19 examples, 0 failures         1 suites in 7.3070s      (pid 12227 exit 0 )
    [ 3]                                      20 examples, 0 failures         1 suites in 11.5977s      (pid 12228 exit 0 )
    [ 4]                                      80 examples, 0 failures         3 suites in 11.5978s      (pid 12229 exit 0 )
    [ 5]                                     101 examples, 0 failures         3 suites in 11.5977s      (pid 12230 exit 0 )
    [ 6]                                      55 examples, 0 failures         5 suites in 11.5976s      (pid 12231 exit 0 )
    [ 7]                                      49 examples, 0 failures         4 suites in 11.5975s      (pid 12232 exit 0 )
    [ 8]                                      57 examples, 0 failures         6 suites in 11.5974s      (pid 12233 exit 0 )
    [ 9]                                      31 examples, 0 failures         6 suites in 11.5973s      (pid 12234 exit 0 )
    [10]                                      46 examples, 0 failures         4 suites in 11.5972s      (pid 12235 exit 0 )
    [11]                                      55 examples, 0 failures         5 suites in 11.5971s      (pid 12236 exit 0 )
    [12]                                      57 examples, 0 failures         6 suites in 11.5968s      (pid 12237 exit 0 )
    [13]                                      70 examples, 0 failures         6 suites in 11.5967s      (pid 12238 exit 0 )
    [14]                                      57 examples, 0 failures         5 suites in 11.5962s      (pid 12239 exit 0 )
    [15]                                      47 examples, 0 failures         6 suites in 11.5951s      (pid 12240 exit 0 )
    [16]                                      56 examples, 0 failures         6 suites in 11.5933s      (pid 12241 exit 0 )
```

It can be up to 5x faster depending on the environment.

### Other information

If `fork` is not supported, parallelization is not possible.

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

