### PR TITLE
Add comment for deprecation on create_pull_request_comment.

### DIFF
--- a/lib/octokit/client/pull_requests.rb
+++ b/lib/octokit/client/pull_requests.rb
@@ -199,11 +199,13 @@ module Octokit
       # @param path [String] Relative path of the file to comment on.
       # @param position [Integer] Line index in the diff to comment on.
       # @return [Sawyer::Resource] Hash representing the new comment
+      # @deprecated The position will be deprecated in the next major version. Please refer to the details below.
       # @see https://developer.github.com/v3/pulls/comments/#create-a-comment
       # @example
       #   @client.create_pull_request_comment("octokit/octokit.rb", 163, ":shipit:",
       #     "2d3201e4440903d8b04a5487842053ca4883e5f0", "lib/octokit/request.rb", 47)
       def create_pull_request_comment(repo, pull_id, body, commit_id, path, position, options = {})
+        octokit_warn 'Deprecated: The position will be deprecated in the next major version.'
         options.merge!({
                          body: body,
                          commit_id: commit_id,


### PR DESCRIPTION
[To rename the 'position' argument of create_pull_request_comment to 'line' and mark it as deprecated in advance.](https://github.com/octokit/octokit.rb/pull/1566#issuecomment-1547334434)

----

## Behavior

### After the change?

* Add comment for deprecation on create_pull_request_comment.


### Other information

* In the next major version, [this PR](https://github.com/octokit/octokit.rb/pull/1566) will be released.

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

