### PR TITLE
Fix typo in `organizations.rb`

### DIFF
--- a/lib/octokit/client/organizations.rb
+++ b/lib/octokit/client/organizations.rb
@@ -71,7 +71,7 @@ module Octokit
       # Nonauthenticated calls to this method will return organizations that
       # the user is a public member.
       #
-      # Use an authenicated client to get both public and private organizations
+      # Use an authenticated client to get both public and private organizations
       # for a user.
       #
       # Calling this method on a `@client` will return that users organizations.


### PR DESCRIPTION
Fix a small typo in a comment in `lib/octokit/client/organizations.rb`.

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

