### PR TITLE
Add testing for the strings in the actual error message that propagates from Octokit::TooManyRequests

### DIFF
--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -849,7 +849,7 @@ describe Octokit::Client do
           content_type: 'application/json'
         },
         body: { message: 'API rate limit exceeded' }.to_json
-      expect { Octokit.get('/users/mojomobo') }.to raise_error Octokit::TooManyRequests
+      expect { Octokit.get('/users/mojomobo') }.to raise_error(Octokit::TooManyRequests, /API rate limit exceeded/)
 
       stub_get('/users/mojomobo').to_return \
         status: 403,
@@ -857,7 +857,7 @@ describe Octokit::Client do
           content_type: 'application/json'
         },
         body: { message: 'You have exceeded a secondary rate limit.' }.to_json
-      expect { Octokit.get('/users/mojomobo') }.to raise_error Octokit::TooManyRequests
+      expect { Octokit.get('/users/mojomobo') }.to raise_error(Octokit::TooManyRequests, /You have exceeded a secondary rate limit./)
 
       stub_get('/user').to_return \
         status: 403,


### PR DESCRIPTION
<!-- Issues are required for both bug fixes and features. -->
Resolves #1590 

----

## Behavior

### Before the change?
We were just checking that `Octokit::TooManyRequests` was being raised

* 

### After the change?
Now we also check that the error message raised contains a specific regex from Github

* 


### Other information


* 

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

