### PR TITLE
Bump major versions to v7.0.0

### DIFF
--- a/lib/octokit/version.rb
+++ b/lib/octokit/version.rb
@@ -3,15 +3,15 @@
 module Octokit
   # Current major release.
   # @return [Integer]
-  MAJOR = 6
+  MAJOR = 7
 
   # Current minor release.
   # @return [Integer]
-  MINOR = 1
+  MINOR = 0
 
   # Current patch level.
   # @return [Integer]
-  PATCH = 1
+  PATCH = 0
 
   # Full release version.
   # @return [String]


### PR DESCRIPTION
Since #1596 has been merged, we should cut a new major release version. Once this change is merged, I'll follow the instructions [here](https://github.com/octokit/octokit.rb/blob/main/RELEASE.md) to create a new RubyGems release. 