### PR TITLE
Add support for Organization Secrets API

### DIFF
--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -11,6 +11,7 @@ require 'octokit/rate_limit'
 require 'octokit/repository'
 require 'octokit/user'
 require 'octokit/organization'
+require 'octokit/client/organization_secrets'
 require 'octokit/client/actions_artifacts'
 require 'octokit/client/actions_secrets'
 require 'octokit/client/actions_workflows'
@@ -116,6 +117,7 @@ module Octokit
     include Octokit::Client::OauthApplications
     include Octokit::Client::Objects
     include Octokit::Client::Organizations
+    include Octokit::Client::OrganizationSecrets
     include Octokit::Client::Pages
     include Octokit::Client::Projects
     include Octokit::Client::PubSubHubbub

--- a/lib/octokit/client/organization_secrets.rb
+++ b/lib/octokit/client/organization_secrets.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Octokit
+  class Client
+    # Methods for the Organization Secrets API
+    #
+    # @see https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28
+    module OrganizationSecrets
+      # Get organization public key for secrets encryption
+      #
+      # @param org [Integer, String, Hash, Organization] A GitHub organization
+      # @return [Hash] key_id and key
+      # @see https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#get-an-organization-public-key
+      def get_org_public_key(org)
+        get "#{Organization.path org}/actions/secrets/public-key"
+      end
+
+      # List organization secrets
+      #
+      # @param org [Integer, String, Hash, Organization] A GitHub organization
+      # @return [Hash] total_count and list of secrets (each item is hash with name, created_at and updated_at)
+      # @see https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#list-repository-organization-secrets
+      def list_org_secrets(org)
+        paginate "#{Organization.path org}/actions/secrets" do |data, last_response|
+          data.secrets.concat last_response.data.secrets
+        end
+      end
+
+      # Get an organization secret
+      #
+      # @param org [Integer, String, Hash, Organization] A GitHub organization
+      # @param name [String] Name of secret
+      # @return [Hash] name, created_at, updated_at, visibility, selected_repositories_url
+      # @see https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#get-an-organization-secret
+      def get_org_secret(org, name)
+        get "#{Organization.path org}/actions/secrets/#{name}"
+      end
+
+      # Create or update organization secrets
+      #
+      # @param org [Integer, String, Hash, Organization] A GitHub organization
+      # @param name [String] Name of secret
+      # @param options [Hash] encrypted_value, key_id, visibility, and selected_repository_ids
+      # @see https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#create-or-update-an-organization-secret
+      def create_or_update_org_secret(org, name, options)
+        put "#{Organization.path org}/actions/secrets/#{name}", options
+      end
+
+      # Delete an organization secret
+      #
+      # @param org [Integer, String, Hash, Organization] A GitHub organization
+      # @param name [String] Name of secret
+      # @see https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#delete-an-organization-secret
+      def delete_org_secret(org, name)
+        boolean_from_response :delete, "#{Organization.path org}/actions/secrets/#{name}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

This pull request implements support for Organization Secrets. 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Octokit did not support the Organization Secrets API, so I had to monkeypatch it in.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Octokit now has support for Organization Secrets. 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

This pull request is a draft. I still need to generate cassettes to finish writing tests.
