### PR TITLE
Add support for Actions Environment Secret Management

### DIFF
--- a/lib/octokit/client/actions_secrets.rb
+++ b/lib/octokit/client/actions_secrets.rb
@@ -54,6 +54,59 @@ module Octokit
       def delete_actions_secret(repo, name)
         boolean_from_response :delete, "#{Repository.path repo}/actions/secrets/#{name}"
       end
+
+      # Get environment public key for secrets encryption
+      #
+      # @param repo [Integer, String, Hash, Repository] A GitHub repository
+      # @param environment [String] Name of environment
+      # @return [Hash] key_id and key
+      # @see https://docs.github.com/en/rest/actions/secrets#get-an-environment-public-key
+      def get_actions_environment_public_key(repo, environment)
+        get "#{Repository.path repo}/environments/#{environment}/secrets/public-key"
+      end
+
+      # List environment secrets
+      #
+      # @param repo [Integer, String, Hash, Repository] A GitHub repository
+      # @param environment [String] Name of environment
+      # @return [Hash] total_count and list of secrets (each item is hash with name, created_at and updated_at)
+      # @see https://developer.github.com/v3/actions/secrets/#list-environment-secrets
+      def list_actions_environment_secrets(repo, environment)
+        paginate "#{Repository.path repo}/environments/#{environment}/secrets" do |data, last_response |
+          data.secrets.concat last_response.data.secrets
+        end
+      end
+
+      # Get an environment secret
+      #
+      # @param repo [Integer, String, Hash, Repository] A GitHub repository
+      # @param environment [String] Name of environment
+      # @param name [String] Name of secret
+      # @return [Hash] name, created_at and updated_at
+      # @see https://docs.github.com/en/rest/actions/secrets#get-an-environment-secret
+      def get_actions_environment_secret(repo, environment, name)
+        get "#{Repository.path repo}/environments/#{environment}/secrets/#{name}"
+      end
+
+      # Create or update an environment secret
+      #
+      # @param repo [Integer, String, Hash, Repository] A GitHub repository
+      # @param environment [String] Name of environment
+      # @param name [String] Name of secret
+      # @param options [Hash] encrypted_value and key_id
+      # @see https://docs.github.com/en/rest/actions/secrets#create-or-update-an-environment-secret
+      def create_or_update_actions_environment_secret(repo, environment, name, options)
+        put "#{Repository.path repo}/environments/#{environment}/secrets/#{name}", options
+      end
+
+      # Delete environment secret
+      # @param repo [Integer, String, Hash, Repository] A GitHub repository
+      # @param environment [String] Name of environment
+      # @param name [String] Name of secret
+      # @see https://docs.github.com/en/rest/actions/secrets#delete-an-environment-secret
+      def delete_actions_environment_secret(repo, environment, name)
+        boolean_from_response :delete, "#{Repository.path repo}/environments/#{environment}/secrets/#{name}"
+      end
     end
   end
 end

--- a/lib/octokit/client/actions_secrets.rb
+++ b/lib/octokit/client/actions_secrets.rb
@@ -72,7 +72,7 @@ module Octokit
       # @return [Hash] total_count and list of secrets (each item is hash with name, created_at and updated_at)
       # @see https://developer.github.com/v3/actions/secrets/#list-environment-secrets
       def list_actions_environment_secrets(repo, environment)
-        paginate "#{Repository.path repo}/environments/#{environment}/secrets" do |data, last_response |
+        paginate "#{Repository.path repo}/environments/#{environment}/secrets" do |data, last_response|
           data.secrets.concat last_response.data.secrets
         end
       end

--- a/spec/cassettes/Octokit_Client_ActionsSecrets/with_a_repository_environment_with_a_secret/_create_or_update_actions_environment_secret/updating_existing_secret_returns_204.json
+++ b/spec/cassettes/Octokit_Client_ActionsSecrets/with_a_repository_environment_with_a_secret/_create_or_update_actions_environment_secret/updating_existing_secret_returns_204.json
@@ -1,0 +1,910 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/user/repos",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJuYW1lIjoic2VjcmV0LXJlcG8ifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:41 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "5268"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"455e97704296a0273cfa4703ced668520ca8c913737e4cdb2363821a31f2f7fc\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "Location": [
+            "https://api.github.com/repos/hosom/secret-repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4917"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "83"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0407:5AE0:40ED52:84CE85:64DA74EC"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6Njc4NTIxMDk5LCJub2RlX2lkIjoiUl9rZ0RPS0hGcEN3IiwibmFt\nZSI6InNlY3JldC1yZXBvIiwiZnVsbF9uYW1lIjoiaG9zb20vc2VjcmV0LXJl\ncG8iLCJwcml2YXRlIjpmYWxzZSwib3duZXIiOnsibG9naW4iOiJob3NvbSIs\nImlkIjo1MDE3MzI0LCJub2RlX2lkIjoiTURRNlZYTmxjalV3TVRjek1qUT0i\nLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1YnVzZXJjb250\nZW50LmNvbS91LzUwMTczMjQ/dj00IiwiZ3JhdmF0YXJfaWQiOiIiLCJ1cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tIiwiaHRtbF91\ncmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9zb20iLCJmb2xsb3dlcnNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9mb2xsb3dl\ncnMiLCJmb2xsb3dpbmdfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy9ob3NvbS9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9naXN0c3sv\nZ2lzdF9pZH0iLCJzdGFycmVkX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vdXNlcnMvaG9zb20vc3RhcnJlZHsvb3duZXJ9ey9yZXBvfSIsInN1YnNj\ncmlwdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9o\nb3NvbS9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL29yZ3MiLCJyZXBvc191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlcG9z\nIiwiZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMv\naG9zb20vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlY2VpdmVk\nX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwic2l0ZV9hZG1pbiI6dHJ1ZX0sImh0\nbWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nIiwiZGVzY3JpcHRpb24iOm51bGwsImZvcmsiOmZhbHNlLCJ1cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvIiwi\nZm9ya3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3Nv\nbS9zZWNyZXQtcmVwby9mb3JrcyIsImtleXNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9rZXlzey9rZXlf\naWR9IiwiY29sbGFib3JhdG9yc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2NvbGxhYm9yYXRvcnN7L2Nv\nbGxhYm9yYXRvcn0iLCJ0ZWFtc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3RlYW1zIiwiaG9va3NfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQt\ncmVwby9ob29rcyIsImlzc3VlX2V2ZW50c191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2lzc3Vlcy9ldmVu\ndHN7L251bWJlcn0iLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9ldmVudHMiLCJhc3NpZ25l\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9hc3NpZ25lZXN7L3VzZXJ9IiwiYnJhbmNoZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9icmFuY2hlc3svYnJhbmNofSIsInRhZ3NfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby90YWdzIiwiYmxv\nYnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9naXQvYmxvYnN7L3NoYX0iLCJnaXRfdGFnc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2dpdC90YWdzey9zaGF9IiwiZ2l0X3JlZnNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvcmVmc3sv\nc2hhfSIsInRyZWVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vZ2l0L3RyZWVzey9zaGF9Iiwic3RhdHVz\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdGF0dXNlcy97c2hhfSIsImxhbmd1YWdlc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2xhbmd1YWdlcyIsInN0YXJnYXplcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9zdGFyZ2F6ZXJzIiwi\nY29udHJpYnV0b3JzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vY29udHJpYnV0b3JzIiwic3Vic2NyaWJl\ncnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdWJzY3JpYmVycyIsInN1YnNjcmlwdGlvbl91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL3N1YnNjcmlwdGlvbiIsImNvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9jb21taXRzey9zaGF9\nIiwiZ2l0X2NvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9y\nZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvY29tbWl0c3svc2hhfSIsImNv\nbW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vY29tbWVudHN7L251bWJlcn0iLCJpc3N1ZV9jb21t\nZW50X3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20v\nc2VjcmV0LXJlcG8vaXNzdWVzL2NvbW1lbnRzey9udW1iZXJ9IiwiY29udGVu\ndHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9jb250ZW50cy97K3BhdGh9IiwiY29tcGFyZV91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2NvbXBhcmUve2Jhc2V9Li4ue2hlYWR9IiwibWVyZ2VzX3VybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbWVy\nZ2VzIiwiYXJjaGl2ZV91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Jl\ncG9zL2hvc29tL3NlY3JldC1yZXBvL3thcmNoaXZlX2Zvcm1hdH17L3JlZn0i\nLCJkb3dubG9hZHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy9ob3NvbS9zZWNyZXQtcmVwby9kb3dubG9hZHMiLCJpc3N1ZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9pc3N1ZXN7L251bWJlcn0iLCJwdWxsc191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3B1bGxzey9udW1i\nZXJ9IiwibWlsZXN0b25lc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL21pbGVzdG9uZXN7L251bWJlcn0i\nLCJub3RpZmljYXRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbm90aWZpY2F0aW9uc3s/c2luY2Us\nYWxsLHBhcnRpY2lwYXRpbmd9IiwibGFiZWxzX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbGFiZWxzey9u\nYW1lfSIsInJlbGVhc2VzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vcmVsZWFzZXN7L2lkfSIsImRlcGxv\neW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vZGVwbG95bWVudHMiLCJjcmVhdGVkX2F0IjoiMjAy\nMy0wOC0xNFQxODozOTo0MVoiLCJ1cGRhdGVkX2F0IjoiMjAyMy0wOC0xNFQx\nODozOTo0MVoiLCJwdXNoZWRfYXQiOiIyMDIzLTA4LTE0VDE4OjM5OjQxWiIs\nImdpdF91cmwiOiJnaXQ6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nLmdpdCIsInNzaF91cmwiOiJnaXRAZ2l0aHViLmNvbTpob3NvbS9zZWNyZXQt\ncmVwby5naXQiLCJjbG9uZV91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9z\nb20vc2VjcmV0LXJlcG8uZ2l0Iiwic3ZuX3VybCI6Imh0dHBzOi8vZ2l0aHVi\nLmNvbS9ob3NvbS9zZWNyZXQtcmVwbyIsImhvbWVwYWdlIjpudWxsLCJzaXpl\nIjowLCJzdGFyZ2F6ZXJzX2NvdW50IjowLCJ3YXRjaGVyc19jb3VudCI6MCwi\nbGFuZ3VhZ2UiOm51bGwsImhhc19pc3N1ZXMiOnRydWUsImhhc19wcm9qZWN0\ncyI6dHJ1ZSwiaGFzX2Rvd25sb2FkcyI6dHJ1ZSwiaGFzX3dpa2kiOnRydWUs\nImhhc19wYWdlcyI6ZmFsc2UsImhhc19kaXNjdXNzaW9ucyI6ZmFsc2UsImZv\ncmtzX2NvdW50IjowLCJtaXJyb3JfdXJsIjpudWxsLCJhcmNoaXZlZCI6ZmFs\nc2UsImRpc2FibGVkIjpmYWxzZSwib3Blbl9pc3N1ZXNfY291bnQiOjAsImxp\nY2Vuc2UiOm51bGwsImFsbG93X2ZvcmtpbmciOnRydWUsImlzX3RlbXBsYXRl\nIjpmYWxzZSwid2ViX2NvbW1pdF9zaWdub2ZmX3JlcXVpcmVkIjpmYWxzZSwi\ndG9waWNzIjpbXSwidmlzaWJpbGl0eSI6InB1YmxpYyIsImZvcmtzIjowLCJv\ncGVuX2lzc3VlcyI6MCwid2F0Y2hlcnMiOjAsImRlZmF1bHRfYnJhbmNoIjoi\nbWFpbiIsInBlcm1pc3Npb25zIjp7ImFkbWluIjp0cnVlLCJtYWludGFpbiI6\ndHJ1ZSwicHVzaCI6dHJ1ZSwidHJpYWdlIjp0cnVlLCJwdWxsIjp0cnVlfSwi\nYWxsb3dfc3F1YXNoX21lcmdlIjp0cnVlLCJhbGxvd19tZXJnZV9jb21taXQi\nOnRydWUsImFsbG93X3JlYmFzZV9tZXJnZSI6dHJ1ZSwiYWxsb3dfYXV0b19t\nZXJnZSI6ZmFsc2UsImRlbGV0ZV9icmFuY2hfb25fbWVyZ2UiOmZhbHNlLCJh\nbGxvd191cGRhdGVfYnJhbmNoIjpmYWxzZSwidXNlX3NxdWFzaF9wcl90aXRs\nZV9hc19kZWZhdWx0IjpmYWxzZSwic3F1YXNoX21lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiQ09NTUlUX01FU1NBR0VTIiwic3F1YXNoX21lcmdlX2NvbW1pdF90\naXRsZSI6IkNPTU1JVF9PUl9QUl9USVRMRSIsIm1lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiUFJfVElUTEUiLCJtZXJnZV9jb21taXRfdGl0bGUiOiJNRVJHRV9N\nRVNTQUdFIiwibmV0d29ya19jb3VudCI6MCwic3Vic2NyaWJlcnNfY291bnQi\nOjB9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:41 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678521099/environments/production",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:42 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"d50f518f51c9743d40fb2f2f93d5ed63a4a73516a94e528506e846e82daa75d1\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4916"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "84"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0408:13ED:3B5DF1:79943F:64DA74ED"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJpZCI6MTI0MTUzMzEzMCwibm9kZV9pZCI6IkVOX2t3RE9LSEZwQzg1S0FF\ncksiLCJuYW1lIjoicHJvZHVjdGlvbiIsInVybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vZW52aXJvbm1lbnRz\nL3Byb2R1Y3Rpb24iLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9o\nb3NvbS9zZWNyZXQtcmVwby9kZXBsb3ltZW50cy9hY3Rpdml0eV9sb2c/ZW52\naXJvbm1lbnRzX2ZpbHRlcj1wcm9kdWN0aW9uIiwiY3JlYXRlZF9hdCI6IjIw\nMjMtMDgtMTRUMTg6Mzk6NDJaIiwidXBkYXRlZF9hdCI6IjIwMjMtMDgtMTRU\nMTg6Mzk6NDJaIiwiY2FuX2FkbWluc19ieXBhc3MiOnRydWUsInByb3RlY3Rp\nb25fcnVsZXMiOltdLCJkZXBsb3ltZW50X2JyYW5jaF9wb2xpY3kiOm51bGx9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:42 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/678521099/environments/production/secrets/public-key",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:42 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"187d706adc4a73267a5628637125ec7a8ac2c20a62b4ec43796540cdd46723d6\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4915"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "85"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0409:395A:47D326:9292FF:64DA74EE"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJrZXkiOiJmMUxqYUxN\ndnN6UG1ZWFZxbGtmMjZ3M1ZOQUQ1V3dZUWpldFAyZUNiYXdZPSJ9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:42 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678521099/environments/production/secrets/secret_name",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiJBT3RrT25nU05sL2EwcFNqalJzMExnaExBWk5YVGZzdTU3a2JBUXVp\nekFTTzVDMTd3NytvOHZzRnlaZElaRDlmT1U2Y0xCclN0NkJydHFTcCJ9\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:42 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"9119ad6048eb0d7ef12164fef9f6d494518da56ecf65bfba14c2443cbc115b98\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4914"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "86"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "040A:0B11:44F2FD:8CCCB8:64DA74EE"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:42 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678521099/environments/production/secrets/secret_name2",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiIvRmFoekZtUHVsM3V5UVNDWEZiUTg1VFJ5TEg1WnkwR05Bb0I3NGdI\nT0FOSkdISVZyZnlRVEFGc2w0SC9IZUt3YzgzbW1TZzVIR3lTUm9wd0xBPT0i\nfQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:42 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"9119ad6048eb0d7ef12164fef9f6d494518da56ecf65bfba14c2443cbc115b98\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4913"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "87"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "040B:6959:3EB582:80481B:64DA74EE"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:42 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/678521099/environments/production/secrets/public-key",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:42 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"187d706adc4a73267a5628637125ec7a8ac2c20a62b4ec43796540cdd46723d6\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4912"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "88"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "040C:33B0:3F5FCE:819272:64DA74EE"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJrZXkiOiJmMUxqYUxN\ndnN6UG1ZWFZxbGtmMjZ3M1ZOQUQ1V3dZUWpldFAyZUNiYXdZPSJ9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:42 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678521099/environments/production/secrets/secret_name",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiIwZ1pPZ2xvOHBtbHlJdk9XMEFtdTdhNVBNWWxqaGp4U1Nla2dtM1pw\najJBMlZVQ3RRbFNsU1UxYS94V2hDTnZLSDdqRkJ5QWFERktKIn0=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:42 GMT"
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4911"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "89"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "040D:58B8:3C3436:7B4A8E:64DA74EE"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:42 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/hosom/secret-repo",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:43 GMT"
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4910"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "90"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "040E:33B0:3F6046:81935E:64DA74EE"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:43 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/cassettes/Octokit_Client_ActionsSecrets/with_a_repository_environment_with_a_secret/_delete_actions_environment_secret/delete_existing_secret.json
+++ b/spec/cassettes/Octokit_Client_ActionsSecrets/with_a_repository_environment_with_a_secret/_delete_actions_environment_secret/delete_existing_secret.json
@@ -1,0 +1,794 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/user/repos",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJuYW1lIjoic2VjcmV0LXJlcG8ifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:39 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "5268"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"8a4deaac4c53ea146821f282822dd51d79ea9349f7cf19904d447cfc4f07b477\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "Location": [
+            "https://api.github.com/repos/hosom/secret-repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4924"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "76"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0400:4F29:3B2D3B:79388B:64DA74EA"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6Njc4NTIxMDg2LCJub2RlX2lkIjoiUl9rZ0RPS0hGb19nIiwibmFt\nZSI6InNlY3JldC1yZXBvIiwiZnVsbF9uYW1lIjoiaG9zb20vc2VjcmV0LXJl\ncG8iLCJwcml2YXRlIjpmYWxzZSwib3duZXIiOnsibG9naW4iOiJob3NvbSIs\nImlkIjo1MDE3MzI0LCJub2RlX2lkIjoiTURRNlZYTmxjalV3TVRjek1qUT0i\nLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1YnVzZXJjb250\nZW50LmNvbS91LzUwMTczMjQ/dj00IiwiZ3JhdmF0YXJfaWQiOiIiLCJ1cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tIiwiaHRtbF91\ncmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9zb20iLCJmb2xsb3dlcnNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9mb2xsb3dl\ncnMiLCJmb2xsb3dpbmdfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy9ob3NvbS9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9naXN0c3sv\nZ2lzdF9pZH0iLCJzdGFycmVkX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vdXNlcnMvaG9zb20vc3RhcnJlZHsvb3duZXJ9ey9yZXBvfSIsInN1YnNj\ncmlwdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9o\nb3NvbS9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL29yZ3MiLCJyZXBvc191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlcG9z\nIiwiZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMv\naG9zb20vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlY2VpdmVk\nX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwic2l0ZV9hZG1pbiI6dHJ1ZX0sImh0\nbWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nIiwiZGVzY3JpcHRpb24iOm51bGwsImZvcmsiOmZhbHNlLCJ1cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvIiwi\nZm9ya3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3Nv\nbS9zZWNyZXQtcmVwby9mb3JrcyIsImtleXNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9rZXlzey9rZXlf\naWR9IiwiY29sbGFib3JhdG9yc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2NvbGxhYm9yYXRvcnN7L2Nv\nbGxhYm9yYXRvcn0iLCJ0ZWFtc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3RlYW1zIiwiaG9va3NfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQt\ncmVwby9ob29rcyIsImlzc3VlX2V2ZW50c191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2lzc3Vlcy9ldmVu\ndHN7L251bWJlcn0iLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9ldmVudHMiLCJhc3NpZ25l\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9hc3NpZ25lZXN7L3VzZXJ9IiwiYnJhbmNoZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9icmFuY2hlc3svYnJhbmNofSIsInRhZ3NfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby90YWdzIiwiYmxv\nYnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9naXQvYmxvYnN7L3NoYX0iLCJnaXRfdGFnc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2dpdC90YWdzey9zaGF9IiwiZ2l0X3JlZnNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvcmVmc3sv\nc2hhfSIsInRyZWVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vZ2l0L3RyZWVzey9zaGF9Iiwic3RhdHVz\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdGF0dXNlcy97c2hhfSIsImxhbmd1YWdlc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2xhbmd1YWdlcyIsInN0YXJnYXplcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9zdGFyZ2F6ZXJzIiwi\nY29udHJpYnV0b3JzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vY29udHJpYnV0b3JzIiwic3Vic2NyaWJl\ncnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdWJzY3JpYmVycyIsInN1YnNjcmlwdGlvbl91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL3N1YnNjcmlwdGlvbiIsImNvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9jb21taXRzey9zaGF9\nIiwiZ2l0X2NvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9y\nZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvY29tbWl0c3svc2hhfSIsImNv\nbW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vY29tbWVudHN7L251bWJlcn0iLCJpc3N1ZV9jb21t\nZW50X3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20v\nc2VjcmV0LXJlcG8vaXNzdWVzL2NvbW1lbnRzey9udW1iZXJ9IiwiY29udGVu\ndHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9jb250ZW50cy97K3BhdGh9IiwiY29tcGFyZV91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2NvbXBhcmUve2Jhc2V9Li4ue2hlYWR9IiwibWVyZ2VzX3VybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbWVy\nZ2VzIiwiYXJjaGl2ZV91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Jl\ncG9zL2hvc29tL3NlY3JldC1yZXBvL3thcmNoaXZlX2Zvcm1hdH17L3JlZn0i\nLCJkb3dubG9hZHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy9ob3NvbS9zZWNyZXQtcmVwby9kb3dubG9hZHMiLCJpc3N1ZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9pc3N1ZXN7L251bWJlcn0iLCJwdWxsc191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3B1bGxzey9udW1i\nZXJ9IiwibWlsZXN0b25lc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL21pbGVzdG9uZXN7L251bWJlcn0i\nLCJub3RpZmljYXRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbm90aWZpY2F0aW9uc3s/c2luY2Us\nYWxsLHBhcnRpY2lwYXRpbmd9IiwibGFiZWxzX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbGFiZWxzey9u\nYW1lfSIsInJlbGVhc2VzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vcmVsZWFzZXN7L2lkfSIsImRlcGxv\neW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vZGVwbG95bWVudHMiLCJjcmVhdGVkX2F0IjoiMjAy\nMy0wOC0xNFQxODozOTozOFoiLCJ1cGRhdGVkX2F0IjoiMjAyMy0wOC0xNFQx\nODozOTozOVoiLCJwdXNoZWRfYXQiOiIyMDIzLTA4LTE0VDE4OjM5OjM5WiIs\nImdpdF91cmwiOiJnaXQ6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nLmdpdCIsInNzaF91cmwiOiJnaXRAZ2l0aHViLmNvbTpob3NvbS9zZWNyZXQt\ncmVwby5naXQiLCJjbG9uZV91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9z\nb20vc2VjcmV0LXJlcG8uZ2l0Iiwic3ZuX3VybCI6Imh0dHBzOi8vZ2l0aHVi\nLmNvbS9ob3NvbS9zZWNyZXQtcmVwbyIsImhvbWVwYWdlIjpudWxsLCJzaXpl\nIjowLCJzdGFyZ2F6ZXJzX2NvdW50IjowLCJ3YXRjaGVyc19jb3VudCI6MCwi\nbGFuZ3VhZ2UiOm51bGwsImhhc19pc3N1ZXMiOnRydWUsImhhc19wcm9qZWN0\ncyI6dHJ1ZSwiaGFzX2Rvd25sb2FkcyI6dHJ1ZSwiaGFzX3dpa2kiOnRydWUs\nImhhc19wYWdlcyI6ZmFsc2UsImhhc19kaXNjdXNzaW9ucyI6ZmFsc2UsImZv\ncmtzX2NvdW50IjowLCJtaXJyb3JfdXJsIjpudWxsLCJhcmNoaXZlZCI6ZmFs\nc2UsImRpc2FibGVkIjpmYWxzZSwib3Blbl9pc3N1ZXNfY291bnQiOjAsImxp\nY2Vuc2UiOm51bGwsImFsbG93X2ZvcmtpbmciOnRydWUsImlzX3RlbXBsYXRl\nIjpmYWxzZSwid2ViX2NvbW1pdF9zaWdub2ZmX3JlcXVpcmVkIjpmYWxzZSwi\ndG9waWNzIjpbXSwidmlzaWJpbGl0eSI6InB1YmxpYyIsImZvcmtzIjowLCJv\ncGVuX2lzc3VlcyI6MCwid2F0Y2hlcnMiOjAsImRlZmF1bHRfYnJhbmNoIjoi\nbWFpbiIsInBlcm1pc3Npb25zIjp7ImFkbWluIjp0cnVlLCJtYWludGFpbiI6\ndHJ1ZSwicHVzaCI6dHJ1ZSwidHJpYWdlIjp0cnVlLCJwdWxsIjp0cnVlfSwi\nYWxsb3dfc3F1YXNoX21lcmdlIjp0cnVlLCJhbGxvd19tZXJnZV9jb21taXQi\nOnRydWUsImFsbG93X3JlYmFzZV9tZXJnZSI6dHJ1ZSwiYWxsb3dfYXV0b19t\nZXJnZSI6ZmFsc2UsImRlbGV0ZV9icmFuY2hfb25fbWVyZ2UiOmZhbHNlLCJh\nbGxvd191cGRhdGVfYnJhbmNoIjpmYWxzZSwidXNlX3NxdWFzaF9wcl90aXRs\nZV9hc19kZWZhdWx0IjpmYWxzZSwic3F1YXNoX21lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiQ09NTUlUX01FU1NBR0VTIiwic3F1YXNoX21lcmdlX2NvbW1pdF90\naXRsZSI6IkNPTU1JVF9PUl9QUl9USVRMRSIsIm1lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiUFJfVElUTEUiLCJtZXJnZV9jb21taXRfdGl0bGUiOiJNRVJHRV9N\nRVNTQUdFIiwibmV0d29ya19jb3VudCI6MCwic3Vic2NyaWJlcnNfY291bnQi\nOjF9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:39 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678521086/environments/production",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:39 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"b6d35dde2d6acb7cd831e77ebd3ede3433e56b741e9f9d0774f21f140416e83a\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4923"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "77"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0401:07ED:3B6453:79C52C:64DA74EB"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJpZCI6MTI0MTUzMzA0Niwibm9kZV9pZCI6IkVOX2t3RE9LSEZvX3M1S0FF\ncDIiLCJuYW1lIjoicHJvZHVjdGlvbiIsInVybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vZW52aXJvbm1lbnRz\nL3Byb2R1Y3Rpb24iLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9o\nb3NvbS9zZWNyZXQtcmVwby9kZXBsb3ltZW50cy9hY3Rpdml0eV9sb2c/ZW52\naXJvbm1lbnRzX2ZpbHRlcj1wcm9kdWN0aW9uIiwiY3JlYXRlZF9hdCI6IjIw\nMjMtMDgtMTRUMTg6Mzk6MzlaIiwidXBkYXRlZF9hdCI6IjIwMjMtMDgtMTRU\nMTg6Mzk6MzlaIiwiY2FuX2FkbWluc19ieXBhc3MiOnRydWUsInByb3RlY3Rp\nb25fcnVsZXMiOltdLCJkZXBsb3ltZW50X2JyYW5jaF9wb2xpY3kiOm51bGx9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:39 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/678521086/environments/production/secrets/public-key",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:39 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"f776c20d0733a15ec3ec04626d3a0a7ca749a912ddcf1f6868bea506b0da624f\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4922"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "78"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0402:063B:3B52CB:797236:64DA74EB"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJrZXkiOiJuUTI3RklP\neWdlTlREbjdOcVlHaUxnTm1iQlJsWXJJMXAvSWZwNEw0Ym1jPSJ9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:40 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678521086/environments/production/secrets/secret_name",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiJMSTNLd3J4Z1BlTEd0Tm1Jc1QvNUlGb09ZMCtyQWNvbjcweVBEcVY0\nN0V5YmhtWEJ1dGlxZzRUVEtuRHBGbno5VW9CUVl4L1VDYm9PR2syOSJ9\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:40 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"9119ad6048eb0d7ef12164fef9f6d494518da56ecf65bfba14c2443cbc115b98\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4921"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "79"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0403:67D1:1BEE95:39942C:64DA74EC"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:40 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678521086/environments/production/secrets/secret_name2",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiIwVC9ZMmRmSzFZM0JXeW02ZVRrblN0cEpzdTlNWWEybkVnMUU0U0Zr\nbUJOVThJeUNWR1Z4bSt2QW41Y3M4UFh3b2VXSmgrN1E2L2tnUGRNSldnPT0i\nfQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:40 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"9119ad6048eb0d7ef12164fef9f6d494518da56ecf65bfba14c2443cbc115b98\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4920"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "80"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0404:5AE0:40EC80:84CCE7:64DA74EC"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:40 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repositories/678521086/environments/production/secrets/secret_name",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:40 GMT"
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4919"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "81"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "0405:3B05:49013C:94F24E:64DA74EC"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:40 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/hosom/secret-repo",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:39:40 GMT"
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4918"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "82"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "0406:6C8A:3E4E30:7F7A57:64DA74EC"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:39:40 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/cassettes/Octokit_Client_ActionsSecrets/with_a_repository_environment_with_a_secret/_get_actions_environment_secret/return_timestamps_related_to_one_secret.json
+++ b/spec/cassettes/Octokit_Client_ActionsSecrets/with_a_repository_environment_with_a_secret/_get_actions_environment_secret/return_timestamps_related_to_one_secret.json
@@ -1,0 +1,807 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/user/repos",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJuYW1lIjoic2VjcmV0LXJlcG8ifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:36:55 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "5268"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"7064c841a1f1062c46855851e58d3308b73e9b12ac2d1f2687883fafb4fa179d\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "Location": [
+            "https://api.github.com/repos/hosom/secret-repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4931"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "69"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0400:4F29:3A4C4F:776F58:64DA7446"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6Njc4NTIwMTY0LCJub2RlX2lkIjoiUl9rZ0RPS0hGbFpBIiwibmFt\nZSI6InNlY3JldC1yZXBvIiwiZnVsbF9uYW1lIjoiaG9zb20vc2VjcmV0LXJl\ncG8iLCJwcml2YXRlIjpmYWxzZSwib3duZXIiOnsibG9naW4iOiJob3NvbSIs\nImlkIjo1MDE3MzI0LCJub2RlX2lkIjoiTURRNlZYTmxjalV3TVRjek1qUT0i\nLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1YnVzZXJjb250\nZW50LmNvbS91LzUwMTczMjQ/dj00IiwiZ3JhdmF0YXJfaWQiOiIiLCJ1cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tIiwiaHRtbF91\ncmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9zb20iLCJmb2xsb3dlcnNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9mb2xsb3dl\ncnMiLCJmb2xsb3dpbmdfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy9ob3NvbS9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9naXN0c3sv\nZ2lzdF9pZH0iLCJzdGFycmVkX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vdXNlcnMvaG9zb20vc3RhcnJlZHsvb3duZXJ9ey9yZXBvfSIsInN1YnNj\ncmlwdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9o\nb3NvbS9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL29yZ3MiLCJyZXBvc191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlcG9z\nIiwiZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMv\naG9zb20vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlY2VpdmVk\nX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwic2l0ZV9hZG1pbiI6dHJ1ZX0sImh0\nbWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nIiwiZGVzY3JpcHRpb24iOm51bGwsImZvcmsiOmZhbHNlLCJ1cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvIiwi\nZm9ya3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3Nv\nbS9zZWNyZXQtcmVwby9mb3JrcyIsImtleXNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9rZXlzey9rZXlf\naWR9IiwiY29sbGFib3JhdG9yc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2NvbGxhYm9yYXRvcnN7L2Nv\nbGxhYm9yYXRvcn0iLCJ0ZWFtc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3RlYW1zIiwiaG9va3NfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQt\ncmVwby9ob29rcyIsImlzc3VlX2V2ZW50c191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2lzc3Vlcy9ldmVu\ndHN7L251bWJlcn0iLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9ldmVudHMiLCJhc3NpZ25l\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9hc3NpZ25lZXN7L3VzZXJ9IiwiYnJhbmNoZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9icmFuY2hlc3svYnJhbmNofSIsInRhZ3NfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby90YWdzIiwiYmxv\nYnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9naXQvYmxvYnN7L3NoYX0iLCJnaXRfdGFnc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2dpdC90YWdzey9zaGF9IiwiZ2l0X3JlZnNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvcmVmc3sv\nc2hhfSIsInRyZWVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vZ2l0L3RyZWVzey9zaGF9Iiwic3RhdHVz\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdGF0dXNlcy97c2hhfSIsImxhbmd1YWdlc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2xhbmd1YWdlcyIsInN0YXJnYXplcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9zdGFyZ2F6ZXJzIiwi\nY29udHJpYnV0b3JzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vY29udHJpYnV0b3JzIiwic3Vic2NyaWJl\ncnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdWJzY3JpYmVycyIsInN1YnNjcmlwdGlvbl91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL3N1YnNjcmlwdGlvbiIsImNvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9jb21taXRzey9zaGF9\nIiwiZ2l0X2NvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9y\nZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvY29tbWl0c3svc2hhfSIsImNv\nbW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vY29tbWVudHN7L251bWJlcn0iLCJpc3N1ZV9jb21t\nZW50X3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20v\nc2VjcmV0LXJlcG8vaXNzdWVzL2NvbW1lbnRzey9udW1iZXJ9IiwiY29udGVu\ndHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9jb250ZW50cy97K3BhdGh9IiwiY29tcGFyZV91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2NvbXBhcmUve2Jhc2V9Li4ue2hlYWR9IiwibWVyZ2VzX3VybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbWVy\nZ2VzIiwiYXJjaGl2ZV91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Jl\ncG9zL2hvc29tL3NlY3JldC1yZXBvL3thcmNoaXZlX2Zvcm1hdH17L3JlZn0i\nLCJkb3dubG9hZHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy9ob3NvbS9zZWNyZXQtcmVwby9kb3dubG9hZHMiLCJpc3N1ZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9pc3N1ZXN7L251bWJlcn0iLCJwdWxsc191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3B1bGxzey9udW1i\nZXJ9IiwibWlsZXN0b25lc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL21pbGVzdG9uZXN7L251bWJlcn0i\nLCJub3RpZmljYXRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbm90aWZpY2F0aW9uc3s/c2luY2Us\nYWxsLHBhcnRpY2lwYXRpbmd9IiwibGFiZWxzX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbGFiZWxzey9u\nYW1lfSIsInJlbGVhc2VzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vcmVsZWFzZXN7L2lkfSIsImRlcGxv\neW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vZGVwbG95bWVudHMiLCJjcmVhdGVkX2F0IjoiMjAy\nMy0wOC0xNFQxODozNjo1NFoiLCJ1cGRhdGVkX2F0IjoiMjAyMy0wOC0xNFQx\nODozNjo1NVoiLCJwdXNoZWRfYXQiOiIyMDIzLTA4LTE0VDE4OjM2OjU1WiIs\nImdpdF91cmwiOiJnaXQ6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nLmdpdCIsInNzaF91cmwiOiJnaXRAZ2l0aHViLmNvbTpob3NvbS9zZWNyZXQt\ncmVwby5naXQiLCJjbG9uZV91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9z\nb20vc2VjcmV0LXJlcG8uZ2l0Iiwic3ZuX3VybCI6Imh0dHBzOi8vZ2l0aHVi\nLmNvbS9ob3NvbS9zZWNyZXQtcmVwbyIsImhvbWVwYWdlIjpudWxsLCJzaXpl\nIjowLCJzdGFyZ2F6ZXJzX2NvdW50IjowLCJ3YXRjaGVyc19jb3VudCI6MCwi\nbGFuZ3VhZ2UiOm51bGwsImhhc19pc3N1ZXMiOnRydWUsImhhc19wcm9qZWN0\ncyI6dHJ1ZSwiaGFzX2Rvd25sb2FkcyI6dHJ1ZSwiaGFzX3dpa2kiOnRydWUs\nImhhc19wYWdlcyI6ZmFsc2UsImhhc19kaXNjdXNzaW9ucyI6ZmFsc2UsImZv\ncmtzX2NvdW50IjowLCJtaXJyb3JfdXJsIjpudWxsLCJhcmNoaXZlZCI6ZmFs\nc2UsImRpc2FibGVkIjpmYWxzZSwib3Blbl9pc3N1ZXNfY291bnQiOjAsImxp\nY2Vuc2UiOm51bGwsImFsbG93X2ZvcmtpbmciOnRydWUsImlzX3RlbXBsYXRl\nIjpmYWxzZSwid2ViX2NvbW1pdF9zaWdub2ZmX3JlcXVpcmVkIjpmYWxzZSwi\ndG9waWNzIjpbXSwidmlzaWJpbGl0eSI6InB1YmxpYyIsImZvcmtzIjowLCJv\ncGVuX2lzc3VlcyI6MCwid2F0Y2hlcnMiOjAsImRlZmF1bHRfYnJhbmNoIjoi\nbWFpbiIsInBlcm1pc3Npb25zIjp7ImFkbWluIjp0cnVlLCJtYWludGFpbiI6\ndHJ1ZSwicHVzaCI6dHJ1ZSwidHJpYWdlIjp0cnVlLCJwdWxsIjp0cnVlfSwi\nYWxsb3dfc3F1YXNoX21lcmdlIjp0cnVlLCJhbGxvd19tZXJnZV9jb21taXQi\nOnRydWUsImFsbG93X3JlYmFzZV9tZXJnZSI6dHJ1ZSwiYWxsb3dfYXV0b19t\nZXJnZSI6ZmFsc2UsImRlbGV0ZV9icmFuY2hfb25fbWVyZ2UiOmZhbHNlLCJh\nbGxvd191cGRhdGVfYnJhbmNoIjpmYWxzZSwidXNlX3NxdWFzaF9wcl90aXRs\nZV9hc19kZWZhdWx0IjpmYWxzZSwic3F1YXNoX21lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiQ09NTUlUX01FU1NBR0VTIiwic3F1YXNoX21lcmdlX2NvbW1pdF90\naXRsZSI6IkNPTU1JVF9PUl9QUl9USVRMRSIsIm1lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiUFJfVElUTEUiLCJtZXJnZV9jb21taXRfdGl0bGUiOiJNRVJHRV9N\nRVNTQUdFIiwibmV0d29ya19jb3VudCI6MCwic3Vic2NyaWJlcnNfY291bnQi\nOjB9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:36:55 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678520164/environments/production",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:36:55 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"23a2434befd1615d3e23d3fe64b072e67611c7c47d9c9fbc7dd6d2710ebbe761\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4930"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "70"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0401:07ED:3A93C5:781A15:64DA7447"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJpZCI6MTI0MTUyNzEwOCwibm9kZV9pZCI6IkVOX2t3RE9LSEZsWk01S0FE\nTkUiLCJuYW1lIjoicHJvZHVjdGlvbiIsInVybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vZW52aXJvbm1lbnRz\nL3Byb2R1Y3Rpb24iLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9o\nb3NvbS9zZWNyZXQtcmVwby9kZXBsb3ltZW50cy9hY3Rpdml0eV9sb2c/ZW52\naXJvbm1lbnRzX2ZpbHRlcj1wcm9kdWN0aW9uIiwiY3JlYXRlZF9hdCI6IjIw\nMjMtMDgtMTRUMTg6MzY6NTVaIiwidXBkYXRlZF9hdCI6IjIwMjMtMDgtMTRU\nMTg6MzY6NTVaIiwiY2FuX2FkbWluc19ieXBhc3MiOnRydWUsInByb3RlY3Rp\nb25fcnVsZXMiOltdLCJkZXBsb3ltZW50X2JyYW5jaF9wb2xpY3kiOm51bGx9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:36:55 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/678520164/environments/production/secrets/public-key",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:36:55 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"5a204d0f7d1e5d33c40f7886ac98a3b47e9b97ee4e961666352c8970e89e3669\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4929"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "71"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0402:063B:3A90CF:77E6DB:64DA7447"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJrZXkiOiJhSlltMUVH\ncDdKbVFpeFR6WTdhTFBtTi9NSzdwc2RETlA2NWs3eHJmbXh3PSJ9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:36:55 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678520164/environments/production/secrets/secret_name",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiJWUGttMkpZR2sra3o2cHpKbllrNEUyTkxheVBFZ3d1amozekpkdTNB\neHlEdGplR3ZEZ1ExMktXU0xBcXVWbktURXBNZTlRc2Z3YVVFMEY3eSJ9\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:36:55 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"9119ad6048eb0d7ef12164fef9f6d494518da56ecf65bfba14c2443cbc115b98\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4928"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "72"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0403:67D1:1B2CD8:380666:64DA7447"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:36:55 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678520164/environments/production/secrets/secret_name2",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiJCZnBTUW5CK1VSa002RU8vVm9uMHVkMmFGVWNjakJXRE0wOWRJelVa\nRm1yaHVSSWJFcVU5UFpVRlEyamxnYUJEdlBYTnZ3OStPbFJKcFlmaVR3PT0i\nfQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:36:56 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"9119ad6048eb0d7ef12164fef9f6d494518da56ecf65bfba14c2443cbc115b98\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4927"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "73"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0404:5AE0:400FCD:83094D:64DA7447"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:36:56 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/678520164/environments/production/secrets/secret_name",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:36:56 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"afd0e0da64fee355310757b8e192eadf7e86775d647e10f33ac09e71657b0623\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4926"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "74"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0405:3B05:481C97:931E34:64DA7448"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJuYW1lIjoiU0VDUkVUX05BTUUiLCJjcmVhdGVkX2F0IjoiMjAyMy0wOC0x\nNFQxODozNjo1NloiLCJ1cGRhdGVkX2F0IjoiMjAyMy0wOC0xNFQxODozNjo1\nNloifQ==\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:36:56 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/hosom/secret-repo",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:36:56 GMT"
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4925"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "75"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "0406:6C8A:3D872D:7DE288:64DA7448"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:36:56 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/cassettes/Octokit_Client_ActionsSecrets/with_a_repository_environment_with_a_secret/_list_actions_environment_secrets/auto-paginates_the_results.json
+++ b/spec/cassettes/Octokit_Client_ActionsSecrets/with_a_repository_environment_with_a_secret/_list_actions_environment_secrets/auto-paginates_the_results.json
@@ -1,0 +1,929 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/user/repos",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJuYW1lIjoic2VjcmV0LXJlcG8ifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:46 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "5268"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"9a38eb7212f11a246e37f35de4953b573d92f3c9f670a2cee624a003792241dc\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "Location": [
+            "https://api.github.com/repos/hosom/secret-repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4948"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "52"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0407:7435:4CE620:9C527A:64DA7311"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6Njc4NTE4NDkzLCJub2RlX2lkIjoiUl9rZ0RPS0hGZTNRIiwibmFt\nZSI6InNlY3JldC1yZXBvIiwiZnVsbF9uYW1lIjoiaG9zb20vc2VjcmV0LXJl\ncG8iLCJwcml2YXRlIjpmYWxzZSwib3duZXIiOnsibG9naW4iOiJob3NvbSIs\nImlkIjo1MDE3MzI0LCJub2RlX2lkIjoiTURRNlZYTmxjalV3TVRjek1qUT0i\nLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1YnVzZXJjb250\nZW50LmNvbS91LzUwMTczMjQ/dj00IiwiZ3JhdmF0YXJfaWQiOiIiLCJ1cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tIiwiaHRtbF91\ncmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9zb20iLCJmb2xsb3dlcnNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9mb2xsb3dl\ncnMiLCJmb2xsb3dpbmdfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy9ob3NvbS9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9naXN0c3sv\nZ2lzdF9pZH0iLCJzdGFycmVkX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vdXNlcnMvaG9zb20vc3RhcnJlZHsvb3duZXJ9ey9yZXBvfSIsInN1YnNj\ncmlwdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9o\nb3NvbS9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL29yZ3MiLCJyZXBvc191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlcG9z\nIiwiZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMv\naG9zb20vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlY2VpdmVk\nX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwic2l0ZV9hZG1pbiI6dHJ1ZX0sImh0\nbWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nIiwiZGVzY3JpcHRpb24iOm51bGwsImZvcmsiOmZhbHNlLCJ1cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvIiwi\nZm9ya3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3Nv\nbS9zZWNyZXQtcmVwby9mb3JrcyIsImtleXNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9rZXlzey9rZXlf\naWR9IiwiY29sbGFib3JhdG9yc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2NvbGxhYm9yYXRvcnN7L2Nv\nbGxhYm9yYXRvcn0iLCJ0ZWFtc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3RlYW1zIiwiaG9va3NfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQt\ncmVwby9ob29rcyIsImlzc3VlX2V2ZW50c191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2lzc3Vlcy9ldmVu\ndHN7L251bWJlcn0iLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9ldmVudHMiLCJhc3NpZ25l\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9hc3NpZ25lZXN7L3VzZXJ9IiwiYnJhbmNoZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9icmFuY2hlc3svYnJhbmNofSIsInRhZ3NfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby90YWdzIiwiYmxv\nYnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9naXQvYmxvYnN7L3NoYX0iLCJnaXRfdGFnc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2dpdC90YWdzey9zaGF9IiwiZ2l0X3JlZnNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvcmVmc3sv\nc2hhfSIsInRyZWVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vZ2l0L3RyZWVzey9zaGF9Iiwic3RhdHVz\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdGF0dXNlcy97c2hhfSIsImxhbmd1YWdlc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2xhbmd1YWdlcyIsInN0YXJnYXplcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9zdGFyZ2F6ZXJzIiwi\nY29udHJpYnV0b3JzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vY29udHJpYnV0b3JzIiwic3Vic2NyaWJl\ncnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdWJzY3JpYmVycyIsInN1YnNjcmlwdGlvbl91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL3N1YnNjcmlwdGlvbiIsImNvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9jb21taXRzey9zaGF9\nIiwiZ2l0X2NvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9y\nZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvY29tbWl0c3svc2hhfSIsImNv\nbW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vY29tbWVudHN7L251bWJlcn0iLCJpc3N1ZV9jb21t\nZW50X3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20v\nc2VjcmV0LXJlcG8vaXNzdWVzL2NvbW1lbnRzey9udW1iZXJ9IiwiY29udGVu\ndHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9jb250ZW50cy97K3BhdGh9IiwiY29tcGFyZV91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2NvbXBhcmUve2Jhc2V9Li4ue2hlYWR9IiwibWVyZ2VzX3VybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbWVy\nZ2VzIiwiYXJjaGl2ZV91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Jl\ncG9zL2hvc29tL3NlY3JldC1yZXBvL3thcmNoaXZlX2Zvcm1hdH17L3JlZn0i\nLCJkb3dubG9hZHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy9ob3NvbS9zZWNyZXQtcmVwby9kb3dubG9hZHMiLCJpc3N1ZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9pc3N1ZXN7L251bWJlcn0iLCJwdWxsc191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3B1bGxzey9udW1i\nZXJ9IiwibWlsZXN0b25lc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL21pbGVzdG9uZXN7L251bWJlcn0i\nLCJub3RpZmljYXRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbm90aWZpY2F0aW9uc3s/c2luY2Us\nYWxsLHBhcnRpY2lwYXRpbmd9IiwibGFiZWxzX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbGFiZWxzey9u\nYW1lfSIsInJlbGVhc2VzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vcmVsZWFzZXN7L2lkfSIsImRlcGxv\neW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vZGVwbG95bWVudHMiLCJjcmVhdGVkX2F0IjoiMjAy\nMy0wOC0xNFQxODozMTo0NVoiLCJ1cGRhdGVkX2F0IjoiMjAyMy0wOC0xNFQx\nODozMTo0NVoiLCJwdXNoZWRfYXQiOiIyMDIzLTA4LTE0VDE4OjMxOjQ1WiIs\nImdpdF91cmwiOiJnaXQ6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nLmdpdCIsInNzaF91cmwiOiJnaXRAZ2l0aHViLmNvbTpob3NvbS9zZWNyZXQt\ncmVwby5naXQiLCJjbG9uZV91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9z\nb20vc2VjcmV0LXJlcG8uZ2l0Iiwic3ZuX3VybCI6Imh0dHBzOi8vZ2l0aHVi\nLmNvbS9ob3NvbS9zZWNyZXQtcmVwbyIsImhvbWVwYWdlIjpudWxsLCJzaXpl\nIjowLCJzdGFyZ2F6ZXJzX2NvdW50IjowLCJ3YXRjaGVyc19jb3VudCI6MCwi\nbGFuZ3VhZ2UiOm51bGwsImhhc19pc3N1ZXMiOnRydWUsImhhc19wcm9qZWN0\ncyI6dHJ1ZSwiaGFzX2Rvd25sb2FkcyI6dHJ1ZSwiaGFzX3dpa2kiOnRydWUs\nImhhc19wYWdlcyI6ZmFsc2UsImhhc19kaXNjdXNzaW9ucyI6ZmFsc2UsImZv\ncmtzX2NvdW50IjowLCJtaXJyb3JfdXJsIjpudWxsLCJhcmNoaXZlZCI6ZmFs\nc2UsImRpc2FibGVkIjpmYWxzZSwib3Blbl9pc3N1ZXNfY291bnQiOjAsImxp\nY2Vuc2UiOm51bGwsImFsbG93X2ZvcmtpbmciOnRydWUsImlzX3RlbXBsYXRl\nIjpmYWxzZSwid2ViX2NvbW1pdF9zaWdub2ZmX3JlcXVpcmVkIjpmYWxzZSwi\ndG9waWNzIjpbXSwidmlzaWJpbGl0eSI6InB1YmxpYyIsImZvcmtzIjowLCJv\ncGVuX2lzc3VlcyI6MCwid2F0Y2hlcnMiOjAsImRlZmF1bHRfYnJhbmNoIjoi\nbWFpbiIsInBlcm1pc3Npb25zIjp7ImFkbWluIjp0cnVlLCJtYWludGFpbiI6\ndHJ1ZSwicHVzaCI6dHJ1ZSwidHJpYWdlIjp0cnVlLCJwdWxsIjp0cnVlfSwi\nYWxsb3dfc3F1YXNoX21lcmdlIjp0cnVlLCJhbGxvd19tZXJnZV9jb21taXQi\nOnRydWUsImFsbG93X3JlYmFzZV9tZXJnZSI6dHJ1ZSwiYWxsb3dfYXV0b19t\nZXJnZSI6ZmFsc2UsImRlbGV0ZV9icmFuY2hfb25fbWVyZ2UiOmZhbHNlLCJh\nbGxvd191cGRhdGVfYnJhbmNoIjpmYWxzZSwidXNlX3NxdWFzaF9wcl90aXRs\nZV9hc19kZWZhdWx0IjpmYWxzZSwic3F1YXNoX21lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiQ09NTUlUX01FU1NBR0VTIiwic3F1YXNoX21lcmdlX2NvbW1pdF90\naXRsZSI6IkNPTU1JVF9PUl9QUl9USVRMRSIsIm1lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiUFJfVElUTEUiLCJtZXJnZV9jb21taXRfdGl0bGUiOiJNRVJHRV9N\nRVNTQUdFIiwibmV0d29ya19jb3VudCI6MCwic3Vic2NyaWJlcnNfY291bnQi\nOjB9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:46 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678518493/environments/production",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:46 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"3c87d5437994ca2d0df8d464e868dfa81c9aa067644ba5c12a273fddde043e7e\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4947"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "53"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0408:1586:3FC849:821BBD:64DA7312"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJpZCI6MTI0MTUxNTAzMiwibm9kZV9pZCI6IkVOX2t3RE9LSEZlM2M1S0FB\nUVkiLCJuYW1lIjoicHJvZHVjdGlvbiIsInVybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vZW52aXJvbm1lbnRz\nL3Byb2R1Y3Rpb24iLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9o\nb3NvbS9zZWNyZXQtcmVwby9kZXBsb3ltZW50cy9hY3Rpdml0eV9sb2c/ZW52\naXJvbm1lbnRzX2ZpbHRlcj1wcm9kdWN0aW9uIiwiY3JlYXRlZF9hdCI6IjIw\nMjMtMDgtMTRUMTg6MzE6NDZaIiwidXBkYXRlZF9hdCI6IjIwMjMtMDgtMTRU\nMTg6MzE6NDZaIiwiY2FuX2FkbWluc19ieXBhc3MiOnRydWUsInByb3RlY3Rp\nb25fcnVsZXMiOltdLCJkZXBsb3ltZW50X2JyYW5jaF9wb2xpY3kiOm51bGx9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:46 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/678518493/environments/production/secrets/public-key",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:46 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"ecd6a8a8ab65005b16134cf570a98aba4aa756f92854834f9cc9befcc2aec521\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4946"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "54"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0409:042F:4F461A:A0EC0C:64DA7312"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJrZXkiOiJNQnpoaEYw\nSHpBeFdyaTZTNEFvZmZwV0NFczI0THFhQ21yL1N4YU9yc2lZPSJ9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:46 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678518493/environments/production/secrets/secret_name",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiJmWDBDeFFnbG92dUlWUWQwWFM1aTVtaEQxaEF2N0duUXhxZFVkQXlt\ncDJTRHVkVXdYZXlvbG8yZUYyWTc1Sm1UREY2bXlhZnAvM0ZRdWY4NyJ9\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:46 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"9119ad6048eb0d7ef12164fef9f6d494518da56ecf65bfba14c2443cbc115b98\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4945"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "55"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "040A:6923:3F55F1:81409E:64DA7312"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:46 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678518493/environments/production/secrets/secret_name2",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiJpNjBUMXJkcDlqUnNUZUs0UVdTZE5uQzVMVnJCa0Z6Q1lublllVkJs\ndkhzc2VOTjZPMjNxcVh2ajE2VU12aXNLdEpuTzBHYU5QM1hRcGZPbllBPT0i\nfQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:46 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"9119ad6048eb0d7ef12164fef9f6d494518da56ecf65bfba14c2443cbc115b98\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4944"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "56"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "040B:4A68:45EB77:8E738C:64DA7312"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:46 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/678518493/environments/production/secrets?per_page=1",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:47 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"b74263dd6423563316e0165df2f8974bf39504ea0bd281c10fe6cf8d9c1f87f1\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "Link": [
+            "<https://api.github.com/repositories/678518493/environments/production/secrets?per_page=1&page=2>; rel=\"next\", <https://api.github.com/repositories/678518493/environments/production/secrets?per_page=1&page=2>; rel=\"last\""
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4943"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "57"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "040C:6A23:44C3D7:8C1B85:64DA7313"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJ0b3RhbF9jb3VudCI6Miwic2VjcmV0cyI6W3sibmFtZSI6IlNFQ1JFVF9O\nQU1FIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDgtMTRUMTg6MzE6NDdaIiwidXBk\nYXRlZF9hdCI6IjIwMjMtMDgtMTRUMTg6MzE6NDdaIn1dfQ==\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:47 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/678518493/environments/production/secrets?page=2&per_page=1",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:47 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"c88a031baaf830c295dfb67c76e88908047a5cfd2503b8232f410e412db767db\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "Link": [
+            "<https://api.github.com/repositories/678518493/environments/production/secrets?page=1&per_page=1>; rel=\"prev\", <https://api.github.com/repositories/678518493/environments/production/secrets?page=1&per_page=1>; rel=\"first\""
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4942"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "58"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "040D:32D8:3E277C:7EEDC0:64DA7313"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJ0b3RhbF9jb3VudCI6Miwic2VjcmV0cyI6W3sibmFtZSI6IlNFQ1JFVF9O\nQU1FMiIsImNyZWF0ZWRfYXQiOiIyMDIzLTA4LTE0VDE4OjMxOjQ3WiIsInVw\nZGF0ZWRfYXQiOiIyMDIzLTA4LTE0VDE4OjMxOjQ3WiJ9XX0=\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:47 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/hosom/secret-repo",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:47 GMT"
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4941"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "59"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "040E:6AD7:49F5D1:951639:64DA7313"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:47 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/cassettes/Octokit_Client_ActionsSecrets/with_a_repository_environment_with_a_secret/_list_actions_environment_secrets/paginates_the_results.json
+++ b/spec/cassettes/Octokit_Client_ActionsSecrets/with_a_repository_environment_with_a_secret/_list_actions_environment_secrets/paginates_the_results.json
@@ -1,0 +1,810 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/user/repos",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJuYW1lIjoic2VjcmV0LXJlcG8ifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:48 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "5268"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"84edda393d3b38c557f2f32c29e72fb73939e70bdddc5c7e184036f0e7a4b77b\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "Location": [
+            "https://api.github.com/repos/hosom/secret-repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4940"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "60"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "040F:5657:427F60:876735:64DA7313"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6Njc4NTE4NTAzLCJub2RlX2lkIjoiUl9rZ0RPS0hGZTV3IiwibmFt\nZSI6InNlY3JldC1yZXBvIiwiZnVsbF9uYW1lIjoiaG9zb20vc2VjcmV0LXJl\ncG8iLCJwcml2YXRlIjpmYWxzZSwib3duZXIiOnsibG9naW4iOiJob3NvbSIs\nImlkIjo1MDE3MzI0LCJub2RlX2lkIjoiTURRNlZYTmxjalV3TVRjek1qUT0i\nLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1YnVzZXJjb250\nZW50LmNvbS91LzUwMTczMjQ/dj00IiwiZ3JhdmF0YXJfaWQiOiIiLCJ1cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tIiwiaHRtbF91\ncmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9zb20iLCJmb2xsb3dlcnNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9mb2xsb3dl\ncnMiLCJmb2xsb3dpbmdfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy9ob3NvbS9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9naXN0c3sv\nZ2lzdF9pZH0iLCJzdGFycmVkX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vdXNlcnMvaG9zb20vc3RhcnJlZHsvb3duZXJ9ey9yZXBvfSIsInN1YnNj\ncmlwdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9o\nb3NvbS9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL29yZ3MiLCJyZXBvc191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlcG9z\nIiwiZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMv\naG9zb20vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlY2VpdmVk\nX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwic2l0ZV9hZG1pbiI6dHJ1ZX0sImh0\nbWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nIiwiZGVzY3JpcHRpb24iOm51bGwsImZvcmsiOmZhbHNlLCJ1cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvIiwi\nZm9ya3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3Nv\nbS9zZWNyZXQtcmVwby9mb3JrcyIsImtleXNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9rZXlzey9rZXlf\naWR9IiwiY29sbGFib3JhdG9yc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2NvbGxhYm9yYXRvcnN7L2Nv\nbGxhYm9yYXRvcn0iLCJ0ZWFtc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3RlYW1zIiwiaG9va3NfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQt\ncmVwby9ob29rcyIsImlzc3VlX2V2ZW50c191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2lzc3Vlcy9ldmVu\ndHN7L251bWJlcn0iLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9ldmVudHMiLCJhc3NpZ25l\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9hc3NpZ25lZXN7L3VzZXJ9IiwiYnJhbmNoZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9icmFuY2hlc3svYnJhbmNofSIsInRhZ3NfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby90YWdzIiwiYmxv\nYnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9naXQvYmxvYnN7L3NoYX0iLCJnaXRfdGFnc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2dpdC90YWdzey9zaGF9IiwiZ2l0X3JlZnNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvcmVmc3sv\nc2hhfSIsInRyZWVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vZ2l0L3RyZWVzey9zaGF9Iiwic3RhdHVz\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdGF0dXNlcy97c2hhfSIsImxhbmd1YWdlc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2xhbmd1YWdlcyIsInN0YXJnYXplcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9zdGFyZ2F6ZXJzIiwi\nY29udHJpYnV0b3JzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vY29udHJpYnV0b3JzIiwic3Vic2NyaWJl\ncnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdWJzY3JpYmVycyIsInN1YnNjcmlwdGlvbl91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL3N1YnNjcmlwdGlvbiIsImNvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9jb21taXRzey9zaGF9\nIiwiZ2l0X2NvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9y\nZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvY29tbWl0c3svc2hhfSIsImNv\nbW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vY29tbWVudHN7L251bWJlcn0iLCJpc3N1ZV9jb21t\nZW50X3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20v\nc2VjcmV0LXJlcG8vaXNzdWVzL2NvbW1lbnRzey9udW1iZXJ9IiwiY29udGVu\ndHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9jb250ZW50cy97K3BhdGh9IiwiY29tcGFyZV91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2NvbXBhcmUve2Jhc2V9Li4ue2hlYWR9IiwibWVyZ2VzX3VybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbWVy\nZ2VzIiwiYXJjaGl2ZV91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Jl\ncG9zL2hvc29tL3NlY3JldC1yZXBvL3thcmNoaXZlX2Zvcm1hdH17L3JlZn0i\nLCJkb3dubG9hZHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy9ob3NvbS9zZWNyZXQtcmVwby9kb3dubG9hZHMiLCJpc3N1ZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9pc3N1ZXN7L251bWJlcn0iLCJwdWxsc191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3B1bGxzey9udW1i\nZXJ9IiwibWlsZXN0b25lc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL21pbGVzdG9uZXN7L251bWJlcn0i\nLCJub3RpZmljYXRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbm90aWZpY2F0aW9uc3s/c2luY2Us\nYWxsLHBhcnRpY2lwYXRpbmd9IiwibGFiZWxzX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbGFiZWxzey9u\nYW1lfSIsInJlbGVhc2VzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vcmVsZWFzZXN7L2lkfSIsImRlcGxv\neW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vZGVwbG95bWVudHMiLCJjcmVhdGVkX2F0IjoiMjAy\nMy0wOC0xNFQxODozMTo0N1oiLCJ1cGRhdGVkX2F0IjoiMjAyMy0wOC0xNFQx\nODozMTo0OFoiLCJwdXNoZWRfYXQiOiIyMDIzLTA4LTE0VDE4OjMxOjQ4WiIs\nImdpdF91cmwiOiJnaXQ6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nLmdpdCIsInNzaF91cmwiOiJnaXRAZ2l0aHViLmNvbTpob3NvbS9zZWNyZXQt\ncmVwby5naXQiLCJjbG9uZV91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9z\nb20vc2VjcmV0LXJlcG8uZ2l0Iiwic3ZuX3VybCI6Imh0dHBzOi8vZ2l0aHVi\nLmNvbS9ob3NvbS9zZWNyZXQtcmVwbyIsImhvbWVwYWdlIjpudWxsLCJzaXpl\nIjowLCJzdGFyZ2F6ZXJzX2NvdW50IjowLCJ3YXRjaGVyc19jb3VudCI6MCwi\nbGFuZ3VhZ2UiOm51bGwsImhhc19pc3N1ZXMiOnRydWUsImhhc19wcm9qZWN0\ncyI6dHJ1ZSwiaGFzX2Rvd25sb2FkcyI6dHJ1ZSwiaGFzX3dpa2kiOnRydWUs\nImhhc19wYWdlcyI6ZmFsc2UsImhhc19kaXNjdXNzaW9ucyI6ZmFsc2UsImZv\ncmtzX2NvdW50IjowLCJtaXJyb3JfdXJsIjpudWxsLCJhcmNoaXZlZCI6ZmFs\nc2UsImRpc2FibGVkIjpmYWxzZSwib3Blbl9pc3N1ZXNfY291bnQiOjAsImxp\nY2Vuc2UiOm51bGwsImFsbG93X2ZvcmtpbmciOnRydWUsImlzX3RlbXBsYXRl\nIjpmYWxzZSwid2ViX2NvbW1pdF9zaWdub2ZmX3JlcXVpcmVkIjpmYWxzZSwi\ndG9waWNzIjpbXSwidmlzaWJpbGl0eSI6InB1YmxpYyIsImZvcmtzIjowLCJv\ncGVuX2lzc3VlcyI6MCwid2F0Y2hlcnMiOjAsImRlZmF1bHRfYnJhbmNoIjoi\nbWFpbiIsInBlcm1pc3Npb25zIjp7ImFkbWluIjp0cnVlLCJtYWludGFpbiI6\ndHJ1ZSwicHVzaCI6dHJ1ZSwidHJpYWdlIjp0cnVlLCJwdWxsIjp0cnVlfSwi\nYWxsb3dfc3F1YXNoX21lcmdlIjp0cnVlLCJhbGxvd19tZXJnZV9jb21taXQi\nOnRydWUsImFsbG93X3JlYmFzZV9tZXJnZSI6dHJ1ZSwiYWxsb3dfYXV0b19t\nZXJnZSI6ZmFsc2UsImRlbGV0ZV9icmFuY2hfb25fbWVyZ2UiOmZhbHNlLCJh\nbGxvd191cGRhdGVfYnJhbmNoIjpmYWxzZSwidXNlX3NxdWFzaF9wcl90aXRs\nZV9hc19kZWZhdWx0IjpmYWxzZSwic3F1YXNoX21lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiQ09NTUlUX01FU1NBR0VTIiwic3F1YXNoX21lcmdlX2NvbW1pdF90\naXRsZSI6IkNPTU1JVF9PUl9QUl9USVRMRSIsIm1lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiUFJfVElUTEUiLCJtZXJnZV9jb21taXRfdGl0bGUiOiJNRVJHRV9N\nRVNTQUdFIiwibmV0d29ya19jb3VudCI6MCwic3Vic2NyaWJlcnNfY291bnQi\nOjF9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:48 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678518503/environments/production",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:48 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"51d7f4e4d0f388d34948f39df69babff454a2daa6e70963494c63c159d9cabd7\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4939"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "61"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0410:511C:4116BB:84CD64:64DA7314"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJpZCI6MTI0MTUxNTExMSwibm9kZV9pZCI6IkVOX2t3RE9LSEZlNTg1S0FB\nUm4iLCJuYW1lIjoicHJvZHVjdGlvbiIsInVybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vZW52aXJvbm1lbnRz\nL3Byb2R1Y3Rpb24iLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9o\nb3NvbS9zZWNyZXQtcmVwby9kZXBsb3ltZW50cy9hY3Rpdml0eV9sb2c/ZW52\naXJvbm1lbnRzX2ZpbHRlcj1wcm9kdWN0aW9uIiwiY3JlYXRlZF9hdCI6IjIw\nMjMtMDgtMTRUMTg6MzE6NDhaIiwidXBkYXRlZF9hdCI6IjIwMjMtMDgtMTRU\nMTg6MzE6NDhaIiwiY2FuX2FkbWluc19ieXBhc3MiOnRydWUsInByb3RlY3Rp\nb25fcnVsZXMiOltdLCJkZXBsb3ltZW50X2JyYW5jaF9wb2xpY3kiOm51bGx9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:48 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/678518503/environments/production/secrets/public-key",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:48 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"b58d68c53b1c760669c9186694f2cd1d80dc6ec30046966a94662f2299335e17\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4938"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "62"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0411:5C33:4676C4:8F7692:64DA7314"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJrZXkiOiIydlZGZExh\nMUY4TGVWTkZhMk9tS3Aza3FMd1FKWUpObm5iVVNCZnBQL3hzPSJ9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:48 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678518503/environments/production/secrets/secret_name",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiJoalZhQXFOVFlqSE15a2ZjTldhY0ZCRUZuRnp1dDF6b1JWRERYVFM1\nNVJIRE1MTFUyeVgyaER4U0xCZHF5QXNCd05ONGYxaFEyMFgxV1ZFTyJ9\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:48 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"9119ad6048eb0d7ef12164fef9f6d494518da56ecf65bfba14c2443cbc115b98\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4937"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "63"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0412:315C:478723:910333:64DA7314"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:48 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678518503/environments/production/secrets/secret_name2",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiIwVmU2NUxicnl1UTJuS0tvNjZuNzJCd2d5bDJta3dKRzJwV3BTdURs\nNDNJOXhkd1IyejZabXdOZVV5WGRGVU9WSEYycS9qK2pkOExhVkZIQ1p3PT0i\nfQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:49 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"9119ad6048eb0d7ef12164fef9f6d494518da56ecf65bfba14c2443cbc115b98\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4936"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "64"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0413:928E:4AE439:9858DD:64DA7314"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:49 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/678518503/environments/production/secrets?per_page=1",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:49 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"59cd5d4f12d4979908b82b5a225173aca8ecee09b782dda93531bff2357dae20\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "Link": [
+            "<https://api.github.com/repositories/678518503/environments/production/secrets?per_page=1&page=2>; rel=\"next\", <https://api.github.com/repositories/678518503/environments/production/secrets?per_page=1&page=2>; rel=\"last\""
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4935"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "65"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0414:928E:4AE48E:98596C:64DA7315"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJ0b3RhbF9jb3VudCI6Miwic2VjcmV0cyI6W3sibmFtZSI6IlNFQ1JFVF9O\nQU1FIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDgtMTRUMTg6MzE6NDlaIiwidXBk\nYXRlZF9hdCI6IjIwMjMtMDgtMTRUMTg6MzE6NDlaIn1dfQ==\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:49 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/hosom/secret-repo",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:49 GMT"
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4934"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "66"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "0415:1C59:4C2C1E:9AD7E6:64DA7315"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:49 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/cassettes/Octokit_Client_ActionsSecrets/with_a_repository_environment_with_a_secret/_list_actions_environment_secrets/returns_list_of_two_secrets.json
+++ b/spec/cassettes/Octokit_Client_ActionsSecrets/with_a_repository_environment_with_a_secret/_list_actions_environment_secrets/returns_list_of_two_secrets.json
@@ -1,0 +1,807 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/user/repos",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJuYW1lIjoic2VjcmV0LXJlcG8ifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:44 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "5268"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"484d814f410e6177bf53baaede9122526cecafe26c775c33949c09971b5b4d88\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "Location": [
+            "https://api.github.com/repos/hosom/secret-repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4955"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "45"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0400:8464:4B2894:98CEC0:64DA730F"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6Njc4NTE4NDgyLCJub2RlX2lkIjoiUl9rZ0RPS0hGZTBnIiwibmFt\nZSI6InNlY3JldC1yZXBvIiwiZnVsbF9uYW1lIjoiaG9zb20vc2VjcmV0LXJl\ncG8iLCJwcml2YXRlIjpmYWxzZSwib3duZXIiOnsibG9naW4iOiJob3NvbSIs\nImlkIjo1MDE3MzI0LCJub2RlX2lkIjoiTURRNlZYTmxjalV3TVRjek1qUT0i\nLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1YnVzZXJjb250\nZW50LmNvbS91LzUwMTczMjQ/dj00IiwiZ3JhdmF0YXJfaWQiOiIiLCJ1cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tIiwiaHRtbF91\ncmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9zb20iLCJmb2xsb3dlcnNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9mb2xsb3dl\ncnMiLCJmb2xsb3dpbmdfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy9ob3NvbS9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9naXN0c3sv\nZ2lzdF9pZH0iLCJzdGFycmVkX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vdXNlcnMvaG9zb20vc3RhcnJlZHsvb3duZXJ9ey9yZXBvfSIsInN1YnNj\ncmlwdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9o\nb3NvbS9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL29yZ3MiLCJyZXBvc191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlcG9z\nIiwiZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMv\naG9zb20vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlY2VpdmVk\nX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwic2l0ZV9hZG1pbiI6dHJ1ZX0sImh0\nbWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nIiwiZGVzY3JpcHRpb24iOm51bGwsImZvcmsiOmZhbHNlLCJ1cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvIiwi\nZm9ya3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3Nv\nbS9zZWNyZXQtcmVwby9mb3JrcyIsImtleXNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9rZXlzey9rZXlf\naWR9IiwiY29sbGFib3JhdG9yc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2NvbGxhYm9yYXRvcnN7L2Nv\nbGxhYm9yYXRvcn0iLCJ0ZWFtc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3RlYW1zIiwiaG9va3NfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQt\ncmVwby9ob29rcyIsImlzc3VlX2V2ZW50c191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2lzc3Vlcy9ldmVu\ndHN7L251bWJlcn0iLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9ldmVudHMiLCJhc3NpZ25l\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9hc3NpZ25lZXN7L3VzZXJ9IiwiYnJhbmNoZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9icmFuY2hlc3svYnJhbmNofSIsInRhZ3NfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby90YWdzIiwiYmxv\nYnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9naXQvYmxvYnN7L3NoYX0iLCJnaXRfdGFnc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2dpdC90YWdzey9zaGF9IiwiZ2l0X3JlZnNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvcmVmc3sv\nc2hhfSIsInRyZWVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vZ2l0L3RyZWVzey9zaGF9Iiwic3RhdHVz\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdGF0dXNlcy97c2hhfSIsImxhbmd1YWdlc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2xhbmd1YWdlcyIsInN0YXJnYXplcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9zdGFyZ2F6ZXJzIiwi\nY29udHJpYnV0b3JzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vY29udHJpYnV0b3JzIiwic3Vic2NyaWJl\ncnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdWJzY3JpYmVycyIsInN1YnNjcmlwdGlvbl91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL3N1YnNjcmlwdGlvbiIsImNvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9jb21taXRzey9zaGF9\nIiwiZ2l0X2NvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9y\nZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvY29tbWl0c3svc2hhfSIsImNv\nbW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vY29tbWVudHN7L251bWJlcn0iLCJpc3N1ZV9jb21t\nZW50X3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20v\nc2VjcmV0LXJlcG8vaXNzdWVzL2NvbW1lbnRzey9udW1iZXJ9IiwiY29udGVu\ndHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9jb250ZW50cy97K3BhdGh9IiwiY29tcGFyZV91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2NvbXBhcmUve2Jhc2V9Li4ue2hlYWR9IiwibWVyZ2VzX3VybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbWVy\nZ2VzIiwiYXJjaGl2ZV91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Jl\ncG9zL2hvc29tL3NlY3JldC1yZXBvL3thcmNoaXZlX2Zvcm1hdH17L3JlZn0i\nLCJkb3dubG9hZHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy9ob3NvbS9zZWNyZXQtcmVwby9kb3dubG9hZHMiLCJpc3N1ZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9pc3N1ZXN7L251bWJlcn0iLCJwdWxsc191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3B1bGxzey9udW1i\nZXJ9IiwibWlsZXN0b25lc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL21pbGVzdG9uZXN7L251bWJlcn0i\nLCJub3RpZmljYXRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbm90aWZpY2F0aW9uc3s/c2luY2Us\nYWxsLHBhcnRpY2lwYXRpbmd9IiwibGFiZWxzX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbGFiZWxzey9u\nYW1lfSIsInJlbGVhc2VzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vcmVsZWFzZXN7L2lkfSIsImRlcGxv\neW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vZGVwbG95bWVudHMiLCJjcmVhdGVkX2F0IjoiMjAy\nMy0wOC0xNFQxODozMTo0M1oiLCJ1cGRhdGVkX2F0IjoiMjAyMy0wOC0xNFQx\nODozMTo0NFoiLCJwdXNoZWRfYXQiOiIyMDIzLTA4LTE0VDE4OjMxOjQzWiIs\nImdpdF91cmwiOiJnaXQ6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nLmdpdCIsInNzaF91cmwiOiJnaXRAZ2l0aHViLmNvbTpob3NvbS9zZWNyZXQt\ncmVwby5naXQiLCJjbG9uZV91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9z\nb20vc2VjcmV0LXJlcG8uZ2l0Iiwic3ZuX3VybCI6Imh0dHBzOi8vZ2l0aHVi\nLmNvbS9ob3NvbS9zZWNyZXQtcmVwbyIsImhvbWVwYWdlIjpudWxsLCJzaXpl\nIjowLCJzdGFyZ2F6ZXJzX2NvdW50IjowLCJ3YXRjaGVyc19jb3VudCI6MCwi\nbGFuZ3VhZ2UiOm51bGwsImhhc19pc3N1ZXMiOnRydWUsImhhc19wcm9qZWN0\ncyI6dHJ1ZSwiaGFzX2Rvd25sb2FkcyI6dHJ1ZSwiaGFzX3dpa2kiOnRydWUs\nImhhc19wYWdlcyI6ZmFsc2UsImhhc19kaXNjdXNzaW9ucyI6ZmFsc2UsImZv\ncmtzX2NvdW50IjowLCJtaXJyb3JfdXJsIjpudWxsLCJhcmNoaXZlZCI6ZmFs\nc2UsImRpc2FibGVkIjpmYWxzZSwib3Blbl9pc3N1ZXNfY291bnQiOjAsImxp\nY2Vuc2UiOm51bGwsImFsbG93X2ZvcmtpbmciOnRydWUsImlzX3RlbXBsYXRl\nIjpmYWxzZSwid2ViX2NvbW1pdF9zaWdub2ZmX3JlcXVpcmVkIjpmYWxzZSwi\ndG9waWNzIjpbXSwidmlzaWJpbGl0eSI6InB1YmxpYyIsImZvcmtzIjowLCJv\ncGVuX2lzc3VlcyI6MCwid2F0Y2hlcnMiOjAsImRlZmF1bHRfYnJhbmNoIjoi\nbWFpbiIsInBlcm1pc3Npb25zIjp7ImFkbWluIjp0cnVlLCJtYWludGFpbiI6\ndHJ1ZSwicHVzaCI6dHJ1ZSwidHJpYWdlIjp0cnVlLCJwdWxsIjp0cnVlfSwi\nYWxsb3dfc3F1YXNoX21lcmdlIjp0cnVlLCJhbGxvd19tZXJnZV9jb21taXQi\nOnRydWUsImFsbG93X3JlYmFzZV9tZXJnZSI6dHJ1ZSwiYWxsb3dfYXV0b19t\nZXJnZSI6ZmFsc2UsImRlbGV0ZV9icmFuY2hfb25fbWVyZ2UiOmZhbHNlLCJh\nbGxvd191cGRhdGVfYnJhbmNoIjpmYWxzZSwidXNlX3NxdWFzaF9wcl90aXRs\nZV9hc19kZWZhdWx0IjpmYWxzZSwic3F1YXNoX21lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiQ09NTUlUX01FU1NBR0VTIiwic3F1YXNoX21lcmdlX2NvbW1pdF90\naXRsZSI6IkNPTU1JVF9PUl9QUl9USVRMRSIsIm1lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiUFJfVElUTEUiLCJtZXJnZV9jb21taXRfdGl0bGUiOiJNRVJHRV9N\nRVNTQUdFIiwibmV0d29ya19jb3VudCI6MCwic3Vic2NyaWJlcnNfY291bnQi\nOjB9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:44 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678518482/environments/production",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:44 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"b180d128f67a8bb1b3f8a1a4cafcbcec0dd8c697b8ba09fc6d832ae54b7afac2\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4954"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "46"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0401:5FBB:45DE9B:8E4383:64DA7310"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJpZCI6MTI0MTUxNDk0MSwibm9kZV9pZCI6IkVOX2t3RE9LSEZlMHM1S0FB\nTzkiLCJuYW1lIjoicHJvZHVjdGlvbiIsInVybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vZW52aXJvbm1lbnRz\nL3Byb2R1Y3Rpb24iLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9o\nb3NvbS9zZWNyZXQtcmVwby9kZXBsb3ltZW50cy9hY3Rpdml0eV9sb2c/ZW52\naXJvbm1lbnRzX2ZpbHRlcj1wcm9kdWN0aW9uIiwiY3JlYXRlZF9hdCI6IjIw\nMjMtMDgtMTRUMTg6MzE6NDRaIiwidXBkYXRlZF9hdCI6IjIwMjMtMDgtMTRU\nMTg6MzE6NDRaIiwiY2FuX2FkbWluc19ieXBhc3MiOnRydWUsInByb3RlY3Rp\nb25fcnVsZXMiOltdLCJkZXBsb3ltZW50X2JyYW5jaF9wb2xpY3kiOm51bGx9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:44 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/678518482/environments/production/secrets/public-key",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:44 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"8151bd727cb185eb4828fb9ae06055074d6ec30d1973ac557d04a7b944f2b8f1\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4953"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "47"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0402:4345:41FC7D:869153:64DA7310"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJrZXkiOiJnZzN6cTE2\nQUNKclpJQWdRdG9ZL0gvWEQ2R3cwQnZ5WWEwY2xhbkFGdkdJPSJ9\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:44 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678518482/environments/production/secrets/secret_name",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiJKUVFrZmlNdjlmOTFYOUR5VXNnMGloVkZKV0lxVllKN3luVW1pOEFZ\nSEU2QXpqL1BKSktFd3RscFIzRENiOVIwMkw4SjFsL3FKajcrNEgycCJ9\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:44 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"9119ad6048eb0d7ef12164fef9f6d494518da56ecf65bfba14c2443cbc115b98\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4952"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "48"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0403:62B0:4381B1:8993F6:64DA7310"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:44 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/678518482/environments/production/secrets/secret_name2",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiJQYlQ1bGUrem5EM0V4eGhVYkF4OS9QSkRLdHVSajlJZjArOTBzRjNX\nYmg1bFBrdjFUNUFFd2NIZ05ka2UyT2tzazZ0ZDJQU1lJV2dhcUtTV3dnPT0i\nfQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:44 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"9119ad6048eb0d7ef12164fef9f6d494518da56ecf65bfba14c2443cbc115b98\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4951"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "49"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0404:042F:4F43C0:A0E716:64DA7310"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:44 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/678518482/environments/production/secrets",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:45 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"eead2f42a37a6e70e946a20011522cf19d89408db03a70816a0a0eb60ff6f535\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4950"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "50"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0405:0217:4BA0AF:99D3A8:64DA7310"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJ0b3RhbF9jb3VudCI6Miwic2VjcmV0cyI6W3sibmFtZSI6IlNFQ1JFVF9O\nQU1FIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDgtMTRUMTg6MzE6NDVaIiwidXBk\nYXRlZF9hdCI6IjIwMjMtMDgtMTRUMTg6MzE6NDVaIn0seyJuYW1lIjoiU0VD\nUkVUX05BTUUyIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDgtMTRUMTg6MzE6NDVa\nIiwidXBkYXRlZF9hdCI6IjIwMjMtMDgtMTRUMTg6MzE6NDVaIn1dfQ==\n"
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:45 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/hosom/secret-repo",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Mon, 14 Aug 2023 18:31:45 GMT"
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-13 14:03:46 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4949"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692040857"
+          ],
+          "X-Ratelimit-Used": [
+            "51"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "0406:0C8F:4187BD:859D18:64DA7311"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Mon, 14 Aug 2023 18:31:45 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/cassettes/Octokit_Client_ActionsSecrets/with_an_environment_without_a_secret/_create_or_update_actions_environment_secret/creating_secret_returns_201.json
+++ b/spec/cassettes/Octokit_Client_ActionsSecrets/with_an_environment_without_a_secret/_create_or_update_actions_environment_secret/creating_secret_returns_201.json
@@ -1,0 +1,575 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/user/repos",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJuYW1lIjoic2VjcmV0LXJlcG8ifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 22 Aug 2023 18:33:50 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "5268"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"11fd06b2c7094f7f517da415b9e5a81d80bcc3f369644bbabb798a4f90235c29\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-21 14:26:52 -0400"
+          ],
+          "Location": [
+            "https://api.github.com/repos/hosom/secret-repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4958"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692731476"
+          ],
+          "X-Ratelimit-Used": [
+            "42"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0404:3A3B:126EE29:258EE3A:64E4FF8D"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6NjgxNzc5NjA1LCJub2RlX2lkIjoiUl9rZ0RPS0tNaGxRIiwibmFt\nZSI6InNlY3JldC1yZXBvIiwiZnVsbF9uYW1lIjoiaG9zb20vc2VjcmV0LXJl\ncG8iLCJwcml2YXRlIjpmYWxzZSwib3duZXIiOnsibG9naW4iOiJob3NvbSIs\nImlkIjo1MDE3MzI0LCJub2RlX2lkIjoiTURRNlZYTmxjalV3TVRjek1qUT0i\nLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1YnVzZXJjb250\nZW50LmNvbS91LzUwMTczMjQ/dj00IiwiZ3JhdmF0YXJfaWQiOiIiLCJ1cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tIiwiaHRtbF91\ncmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9zb20iLCJmb2xsb3dlcnNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9mb2xsb3dl\ncnMiLCJmb2xsb3dpbmdfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy9ob3NvbS9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9naXN0c3sv\nZ2lzdF9pZH0iLCJzdGFycmVkX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vdXNlcnMvaG9zb20vc3RhcnJlZHsvb3duZXJ9ey9yZXBvfSIsInN1YnNj\ncmlwdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9o\nb3NvbS9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL29yZ3MiLCJyZXBvc191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlcG9z\nIiwiZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMv\naG9zb20vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlY2VpdmVk\nX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwic2l0ZV9hZG1pbiI6dHJ1ZX0sImh0\nbWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nIiwiZGVzY3JpcHRpb24iOm51bGwsImZvcmsiOmZhbHNlLCJ1cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvIiwi\nZm9ya3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3Nv\nbS9zZWNyZXQtcmVwby9mb3JrcyIsImtleXNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9rZXlzey9rZXlf\naWR9IiwiY29sbGFib3JhdG9yc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2NvbGxhYm9yYXRvcnN7L2Nv\nbGxhYm9yYXRvcn0iLCJ0ZWFtc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3RlYW1zIiwiaG9va3NfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQt\ncmVwby9ob29rcyIsImlzc3VlX2V2ZW50c191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2lzc3Vlcy9ldmVu\ndHN7L251bWJlcn0iLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9ldmVudHMiLCJhc3NpZ25l\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9hc3NpZ25lZXN7L3VzZXJ9IiwiYnJhbmNoZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9icmFuY2hlc3svYnJhbmNofSIsInRhZ3NfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby90YWdzIiwiYmxv\nYnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9naXQvYmxvYnN7L3NoYX0iLCJnaXRfdGFnc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2dpdC90YWdzey9zaGF9IiwiZ2l0X3JlZnNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvcmVmc3sv\nc2hhfSIsInRyZWVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vZ2l0L3RyZWVzey9zaGF9Iiwic3RhdHVz\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdGF0dXNlcy97c2hhfSIsImxhbmd1YWdlc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2xhbmd1YWdlcyIsInN0YXJnYXplcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9zdGFyZ2F6ZXJzIiwi\nY29udHJpYnV0b3JzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vY29udHJpYnV0b3JzIiwic3Vic2NyaWJl\ncnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdWJzY3JpYmVycyIsInN1YnNjcmlwdGlvbl91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL3N1YnNjcmlwdGlvbiIsImNvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9jb21taXRzey9zaGF9\nIiwiZ2l0X2NvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9y\nZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvY29tbWl0c3svc2hhfSIsImNv\nbW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vY29tbWVudHN7L251bWJlcn0iLCJpc3N1ZV9jb21t\nZW50X3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20v\nc2VjcmV0LXJlcG8vaXNzdWVzL2NvbW1lbnRzey9udW1iZXJ9IiwiY29udGVu\ndHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9jb250ZW50cy97K3BhdGh9IiwiY29tcGFyZV91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2NvbXBhcmUve2Jhc2V9Li4ue2hlYWR9IiwibWVyZ2VzX3VybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbWVy\nZ2VzIiwiYXJjaGl2ZV91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Jl\ncG9zL2hvc29tL3NlY3JldC1yZXBvL3thcmNoaXZlX2Zvcm1hdH17L3JlZn0i\nLCJkb3dubG9hZHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy9ob3NvbS9zZWNyZXQtcmVwby9kb3dubG9hZHMiLCJpc3N1ZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9pc3N1ZXN7L251bWJlcn0iLCJwdWxsc191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3B1bGxzey9udW1i\nZXJ9IiwibWlsZXN0b25lc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL21pbGVzdG9uZXN7L251bWJlcn0i\nLCJub3RpZmljYXRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbm90aWZpY2F0aW9uc3s/c2luY2Us\nYWxsLHBhcnRpY2lwYXRpbmd9IiwibGFiZWxzX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbGFiZWxzey9u\nYW1lfSIsInJlbGVhc2VzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vcmVsZWFzZXN7L2lkfSIsImRlcGxv\neW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vZGVwbG95bWVudHMiLCJjcmVhdGVkX2F0IjoiMjAy\nMy0wOC0yMlQxODozMzo0OVoiLCJ1cGRhdGVkX2F0IjoiMjAyMy0wOC0yMlQx\nODozMzo0OVoiLCJwdXNoZWRfYXQiOiIyMDIzLTA4LTIyVDE4OjMzOjQ5WiIs\nImdpdF91cmwiOiJnaXQ6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nLmdpdCIsInNzaF91cmwiOiJnaXRAZ2l0aHViLmNvbTpob3NvbS9zZWNyZXQt\ncmVwby5naXQiLCJjbG9uZV91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9z\nb20vc2VjcmV0LXJlcG8uZ2l0Iiwic3ZuX3VybCI6Imh0dHBzOi8vZ2l0aHVi\nLmNvbS9ob3NvbS9zZWNyZXQtcmVwbyIsImhvbWVwYWdlIjpudWxsLCJzaXpl\nIjowLCJzdGFyZ2F6ZXJzX2NvdW50IjowLCJ3YXRjaGVyc19jb3VudCI6MCwi\nbGFuZ3VhZ2UiOm51bGwsImhhc19pc3N1ZXMiOnRydWUsImhhc19wcm9qZWN0\ncyI6dHJ1ZSwiaGFzX2Rvd25sb2FkcyI6dHJ1ZSwiaGFzX3dpa2kiOnRydWUs\nImhhc19wYWdlcyI6ZmFsc2UsImhhc19kaXNjdXNzaW9ucyI6ZmFsc2UsImZv\ncmtzX2NvdW50IjowLCJtaXJyb3JfdXJsIjpudWxsLCJhcmNoaXZlZCI6ZmFs\nc2UsImRpc2FibGVkIjpmYWxzZSwib3Blbl9pc3N1ZXNfY291bnQiOjAsImxp\nY2Vuc2UiOm51bGwsImFsbG93X2ZvcmtpbmciOnRydWUsImlzX3RlbXBsYXRl\nIjpmYWxzZSwid2ViX2NvbW1pdF9zaWdub2ZmX3JlcXVpcmVkIjpmYWxzZSwi\ndG9waWNzIjpbXSwidmlzaWJpbGl0eSI6InB1YmxpYyIsImZvcmtzIjowLCJv\ncGVuX2lzc3VlcyI6MCwid2F0Y2hlcnMiOjAsImRlZmF1bHRfYnJhbmNoIjoi\nbWFpbiIsInBlcm1pc3Npb25zIjp7ImFkbWluIjp0cnVlLCJtYWludGFpbiI6\ndHJ1ZSwicHVzaCI6dHJ1ZSwidHJpYWdlIjp0cnVlLCJwdWxsIjp0cnVlfSwi\nYWxsb3dfc3F1YXNoX21lcmdlIjp0cnVlLCJhbGxvd19tZXJnZV9jb21taXQi\nOnRydWUsImFsbG93X3JlYmFzZV9tZXJnZSI6dHJ1ZSwiYWxsb3dfYXV0b19t\nZXJnZSI6ZmFsc2UsImRlbGV0ZV9icmFuY2hfb25fbWVyZ2UiOmZhbHNlLCJh\nbGxvd191cGRhdGVfYnJhbmNoIjpmYWxzZSwidXNlX3NxdWFzaF9wcl90aXRs\nZV9hc19kZWZhdWx0IjpmYWxzZSwic3F1YXNoX21lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiQ09NTUlUX01FU1NBR0VTIiwic3F1YXNoX21lcmdlX2NvbW1pdF90\naXRsZSI6IkNPTU1JVF9PUl9QUl9USVRMRSIsIm1lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiUFJfVElUTEUiLCJtZXJnZV9jb21taXRfdGl0bGUiOiJNRVJHRV9N\nRVNTQUdFIiwibmV0d29ya19jb3VudCI6MCwic3Vic2NyaWJlcnNfY291bnQi\nOjB9\n"
+        }
+      },
+      "recorded_at": "Tue, 22 Aug 2023 18:33:50 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/681779605/environments/zero",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 22 Aug 2023 18:33:50 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"5f20f49363301892a9d74a6a30e4dba50a3595759349fd18f2b06884c1c99470\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-21 14:26:52 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4957"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692731476"
+          ],
+          "X-Ratelimit-Used": [
+            "43"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0405:130C:13D8856:286298B:64E4FF8E"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJpZCI6MTI2MDk5NjY4NCwibm9kZV9pZCI6IkVOX2t3RE9LS01obGM1TEtV\naE0iLCJuYW1lIjoiemVybyIsInVybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vZW52aXJvbm1lbnRzL3plcm8i\nLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9ob3NvbS9zZWNyZXQt\ncmVwby9kZXBsb3ltZW50cy9hY3Rpdml0eV9sb2c/ZW52aXJvbm1lbnRzX2Zp\nbHRlcj16ZXJvIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDgtMjJUMTg6MzM6NTBa\nIiwidXBkYXRlZF9hdCI6IjIwMjMtMDgtMjJUMTg6MzM6NTBaIiwiY2FuX2Fk\nbWluc19ieXBhc3MiOnRydWUsInByb3RlY3Rpb25fcnVsZXMiOltdLCJkZXBs\nb3ltZW50X2JyYW5jaF9wb2xpY3kiOm51bGx9\n"
+        }
+      },
+      "recorded_at": "Tue, 22 Aug 2023 18:33:50 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/681779605/environments/zero/secrets/public-key",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 22 Aug 2023 18:33:50 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"29d6e66072491d1f9d5d97622f1536b83b0691a2f807a1229dc8c578308677a8\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-21 14:26:52 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4956"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692731476"
+          ],
+          "X-Ratelimit-Used": [
+            "44"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0406:8878:140C7B9:28C926D:64E4FF8E"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJrZXkiOiIwOHNjT3pH\nYUFnRVNDRmxqenBZc1c2K2Jnckx5ZDR5UWhLR1NsWG9kQ2pjPSJ9\n"
+        }
+      },
+      "recorded_at": "Tue, 22 Aug 2023 18:33:50 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/681779605/environments/zero/secrets/secret_name",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJlbmNyeXB0ZWRfdmFs\ndWUiOiI4aDRndnRwakNHYnpxMlM5d005S0M4RXlueUdLbXp2YUNYcXN5eFhh\nZDBsU3Q1dXFETlpTM3ZQOVM1Yko2eWhhZkMxSnpJV1FwMm4xNEJ5eCJ9\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 22 Aug 2023 18:33:50 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"b7c0897b189733a867d5afd1acd24293b348585922d1db6a5398f6a9f7ead844\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-21 14:26:52 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=write,environments=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4955"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692731476"
+          ],
+          "X-Ratelimit-Used": [
+            "45"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0407:8B42:13FC5E1:28A8DA0:64E4FF8E"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        }
+      },
+      "recorded_at": "Tue, 22 Aug 2023 18:33:50 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/hosom/secret-repo",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 22 Aug 2023 18:33:51 GMT"
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-21 14:26:52 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4954"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692731476"
+          ],
+          "X-Ratelimit-Used": [
+            "46"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "0408:0D4E:13D9637:285F98E:64E4FF8E"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Tue, 22 Aug 2023 18:33:51 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/cassettes/Octokit_Client_ActionsSecrets/with_an_environment_without_a_secret/_get_actions_environment_public_key/get_environment_specific_public_key_for_secrets_encryption.json
+++ b/spec/cassettes/Octokit_Client_ActionsSecrets/with_an_environment_without_a_secret/_get_actions_environment_public_key/get_environment_specific_public_key_for_secrets_encryption.json
@@ -1,0 +1,459 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/user/repos",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJuYW1lIjoic2VjcmV0LXJlcG8ifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 22 Aug 2023 18:33:51 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "5268"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"d94ae18a2b0329070df8a8b07dfc431b2c77fc475b89a72115ec2e28e17f1f6b\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-21 14:26:52 -0400"
+          ],
+          "Location": [
+            "https://api.github.com/repos/hosom/secret-repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4953"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692731476"
+          ],
+          "X-Ratelimit-Used": [
+            "47"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0409:130C:13D8A0A:2862CE9:64E4FF8F"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6NjgxNzc5NjEzLCJub2RlX2lkIjoiUl9rZ0RPS0tNaG5RIiwibmFt\nZSI6InNlY3JldC1yZXBvIiwiZnVsbF9uYW1lIjoiaG9zb20vc2VjcmV0LXJl\ncG8iLCJwcml2YXRlIjpmYWxzZSwib3duZXIiOnsibG9naW4iOiJob3NvbSIs\nImlkIjo1MDE3MzI0LCJub2RlX2lkIjoiTURRNlZYTmxjalV3TVRjek1qUT0i\nLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1YnVzZXJjb250\nZW50LmNvbS91LzUwMTczMjQ/dj00IiwiZ3JhdmF0YXJfaWQiOiIiLCJ1cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tIiwiaHRtbF91\ncmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9zb20iLCJmb2xsb3dlcnNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9mb2xsb3dl\ncnMiLCJmb2xsb3dpbmdfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy9ob3NvbS9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9naXN0c3sv\nZ2lzdF9pZH0iLCJzdGFycmVkX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vdXNlcnMvaG9zb20vc3RhcnJlZHsvb3duZXJ9ey9yZXBvfSIsInN1YnNj\ncmlwdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9o\nb3NvbS9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL29yZ3MiLCJyZXBvc191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlcG9z\nIiwiZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMv\naG9zb20vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlY2VpdmVk\nX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwic2l0ZV9hZG1pbiI6dHJ1ZX0sImh0\nbWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nIiwiZGVzY3JpcHRpb24iOm51bGwsImZvcmsiOmZhbHNlLCJ1cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvIiwi\nZm9ya3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3Nv\nbS9zZWNyZXQtcmVwby9mb3JrcyIsImtleXNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9rZXlzey9rZXlf\naWR9IiwiY29sbGFib3JhdG9yc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2NvbGxhYm9yYXRvcnN7L2Nv\nbGxhYm9yYXRvcn0iLCJ0ZWFtc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3RlYW1zIiwiaG9va3NfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQt\ncmVwby9ob29rcyIsImlzc3VlX2V2ZW50c191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2lzc3Vlcy9ldmVu\ndHN7L251bWJlcn0iLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9ldmVudHMiLCJhc3NpZ25l\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9hc3NpZ25lZXN7L3VzZXJ9IiwiYnJhbmNoZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9icmFuY2hlc3svYnJhbmNofSIsInRhZ3NfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby90YWdzIiwiYmxv\nYnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9naXQvYmxvYnN7L3NoYX0iLCJnaXRfdGFnc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2dpdC90YWdzey9zaGF9IiwiZ2l0X3JlZnNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvcmVmc3sv\nc2hhfSIsInRyZWVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vZ2l0L3RyZWVzey9zaGF9Iiwic3RhdHVz\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdGF0dXNlcy97c2hhfSIsImxhbmd1YWdlc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2xhbmd1YWdlcyIsInN0YXJnYXplcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9zdGFyZ2F6ZXJzIiwi\nY29udHJpYnV0b3JzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vY29udHJpYnV0b3JzIiwic3Vic2NyaWJl\ncnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdWJzY3JpYmVycyIsInN1YnNjcmlwdGlvbl91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL3N1YnNjcmlwdGlvbiIsImNvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9jb21taXRzey9zaGF9\nIiwiZ2l0X2NvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9y\nZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvY29tbWl0c3svc2hhfSIsImNv\nbW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vY29tbWVudHN7L251bWJlcn0iLCJpc3N1ZV9jb21t\nZW50X3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20v\nc2VjcmV0LXJlcG8vaXNzdWVzL2NvbW1lbnRzey9udW1iZXJ9IiwiY29udGVu\ndHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9jb250ZW50cy97K3BhdGh9IiwiY29tcGFyZV91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2NvbXBhcmUve2Jhc2V9Li4ue2hlYWR9IiwibWVyZ2VzX3VybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbWVy\nZ2VzIiwiYXJjaGl2ZV91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Jl\ncG9zL2hvc29tL3NlY3JldC1yZXBvL3thcmNoaXZlX2Zvcm1hdH17L3JlZn0i\nLCJkb3dubG9hZHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy9ob3NvbS9zZWNyZXQtcmVwby9kb3dubG9hZHMiLCJpc3N1ZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9pc3N1ZXN7L251bWJlcn0iLCJwdWxsc191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3B1bGxzey9udW1i\nZXJ9IiwibWlsZXN0b25lc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL21pbGVzdG9uZXN7L251bWJlcn0i\nLCJub3RpZmljYXRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbm90aWZpY2F0aW9uc3s/c2luY2Us\nYWxsLHBhcnRpY2lwYXRpbmd9IiwibGFiZWxzX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbGFiZWxzey9u\nYW1lfSIsInJlbGVhc2VzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vcmVsZWFzZXN7L2lkfSIsImRlcGxv\neW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vZGVwbG95bWVudHMiLCJjcmVhdGVkX2F0IjoiMjAy\nMy0wOC0yMlQxODozMzo1MVoiLCJ1cGRhdGVkX2F0IjoiMjAyMy0wOC0yMlQx\nODozMzo1MVoiLCJwdXNoZWRfYXQiOiIyMDIzLTA4LTIyVDE4OjMzOjUxWiIs\nImdpdF91cmwiOiJnaXQ6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nLmdpdCIsInNzaF91cmwiOiJnaXRAZ2l0aHViLmNvbTpob3NvbS9zZWNyZXQt\ncmVwby5naXQiLCJjbG9uZV91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9z\nb20vc2VjcmV0LXJlcG8uZ2l0Iiwic3ZuX3VybCI6Imh0dHBzOi8vZ2l0aHVi\nLmNvbS9ob3NvbS9zZWNyZXQtcmVwbyIsImhvbWVwYWdlIjpudWxsLCJzaXpl\nIjowLCJzdGFyZ2F6ZXJzX2NvdW50IjowLCJ3YXRjaGVyc19jb3VudCI6MCwi\nbGFuZ3VhZ2UiOm51bGwsImhhc19pc3N1ZXMiOnRydWUsImhhc19wcm9qZWN0\ncyI6dHJ1ZSwiaGFzX2Rvd25sb2FkcyI6dHJ1ZSwiaGFzX3dpa2kiOnRydWUs\nImhhc19wYWdlcyI6ZmFsc2UsImhhc19kaXNjdXNzaW9ucyI6ZmFsc2UsImZv\ncmtzX2NvdW50IjowLCJtaXJyb3JfdXJsIjpudWxsLCJhcmNoaXZlZCI6ZmFs\nc2UsImRpc2FibGVkIjpmYWxzZSwib3Blbl9pc3N1ZXNfY291bnQiOjAsImxp\nY2Vuc2UiOm51bGwsImFsbG93X2ZvcmtpbmciOnRydWUsImlzX3RlbXBsYXRl\nIjpmYWxzZSwid2ViX2NvbW1pdF9zaWdub2ZmX3JlcXVpcmVkIjpmYWxzZSwi\ndG9waWNzIjpbXSwidmlzaWJpbGl0eSI6InB1YmxpYyIsImZvcmtzIjowLCJv\ncGVuX2lzc3VlcyI6MCwid2F0Y2hlcnMiOjAsImRlZmF1bHRfYnJhbmNoIjoi\nbWFpbiIsInBlcm1pc3Npb25zIjp7ImFkbWluIjp0cnVlLCJtYWludGFpbiI6\ndHJ1ZSwicHVzaCI6dHJ1ZSwidHJpYWdlIjp0cnVlLCJwdWxsIjp0cnVlfSwi\nYWxsb3dfc3F1YXNoX21lcmdlIjp0cnVlLCJhbGxvd19tZXJnZV9jb21taXQi\nOnRydWUsImFsbG93X3JlYmFzZV9tZXJnZSI6dHJ1ZSwiYWxsb3dfYXV0b19t\nZXJnZSI6ZmFsc2UsImRlbGV0ZV9icmFuY2hfb25fbWVyZ2UiOmZhbHNlLCJh\nbGxvd191cGRhdGVfYnJhbmNoIjpmYWxzZSwidXNlX3NxdWFzaF9wcl90aXRs\nZV9hc19kZWZhdWx0IjpmYWxzZSwic3F1YXNoX21lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiQ09NTUlUX01FU1NBR0VTIiwic3F1YXNoX21lcmdlX2NvbW1pdF90\naXRsZSI6IkNPTU1JVF9PUl9QUl9USVRMRSIsIm1lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiUFJfVElUTEUiLCJtZXJnZV9jb21taXRfdGl0bGUiOiJNRVJHRV9N\nRVNTQUdFIiwibmV0d29ya19jb3VudCI6MCwic3Vic2NyaWJlcnNfY291bnQi\nOjF9\n"
+        }
+      },
+      "recorded_at": "Tue, 22 Aug 2023 18:33:51 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/681779613/environments/zero",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 22 Aug 2023 18:33:52 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"ace09bae42b7b344276f01bab06b4e8210d4db2b136fbbf9f41ddca36d13c639\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-21 14:26:52 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4952"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692731476"
+          ],
+          "X-Ratelimit-Used": [
+            "48"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "040A:5124:16C8145:2E32F97:64E4FF8F"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJpZCI6MTI2MDk5Njc2Miwibm9kZV9pZCI6IkVOX2t3RE9LS01obmM1TEtV\naWEiLCJuYW1lIjoiemVybyIsInVybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vZW52aXJvbm1lbnRzL3plcm8i\nLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9ob3NvbS9zZWNyZXQt\ncmVwby9kZXBsb3ltZW50cy9hY3Rpdml0eV9sb2c/ZW52aXJvbm1lbnRzX2Zp\nbHRlcj16ZXJvIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDgtMjJUMTg6MzM6NTJa\nIiwidXBkYXRlZF9hdCI6IjIwMjMtMDgtMjJUMTg6MzM6NTJaIiwiY2FuX2Fk\nbWluc19ieXBhc3MiOnRydWUsInByb3RlY3Rpb25fcnVsZXMiOltdLCJkZXBs\nb3ltZW50X2JyYW5jaF9wb2xpY3kiOm51bGx9\n"
+        }
+      },
+      "recorded_at": "Tue, 22 Aug 2023 18:33:52 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/681779613/environments/zero/secrets/public-key",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 22 Aug 2023 18:33:52 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"19db9835e544d0d5ff821298a4e68fd1f4ef641ba46e569deb4c53b456943f7f\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-21 14:26:52 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4951"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692731476"
+          ],
+          "X-Ratelimit-Used": [
+            "49"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "040B:7AF4:140AAC3:28C3A6C:64E4FF90"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJrZXlfaWQiOiI1NjgyNTAxNjcyNDI1NDk3NDMiLCJrZXkiOiJLbnBmSHVk\ncGFUc1J1OUhUellTeWJDditXLysvTENEK3l5RjNTUVpqdld3PSJ9\n"
+        }
+      },
+      "recorded_at": "Tue, 22 Aug 2023 18:33:52 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/hosom/secret-repo",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 22 Aug 2023 18:33:52 GMT"
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-21 14:26:52 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4950"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692731476"
+          ],
+          "X-Ratelimit-Used": [
+            "50"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "040C:5B77:17FC8CE:30A94F2:64E4FF90"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Tue, 22 Aug 2023 18:33:52 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/cassettes/Octokit_Client_ActionsSecrets/with_an_environment_without_a_secret/_list_actions_environment_secrets/returns_empty_list_of_secrets.json
+++ b/spec/cassettes/Octokit_Client_ActionsSecrets/with_an_environment_without_a_secret/_list_actions_environment_secrets/returns_empty_list_of_secrets.json
@@ -1,0 +1,459 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/user/repos",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJuYW1lIjoic2VjcmV0LXJlcG8ifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 22 Aug 2023 18:33:48 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "5268"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"13353e9b8ce66a10acb7a6cb6bf29574cd1b944ffb6283f99630a67df0e088a7\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-21 14:26:52 -0400"
+          ],
+          "Location": [
+            "https://api.github.com/repos/hosom/secret-repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4962"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692731476"
+          ],
+          "X-Ratelimit-Used": [
+            "38"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0400:0D4E:13D90F2:285EEFA:64E4FF8C"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6NjgxNzc5NTkyLCJub2RlX2lkIjoiUl9rZ0RPS0tNaGlBIiwibmFt\nZSI6InNlY3JldC1yZXBvIiwiZnVsbF9uYW1lIjoiaG9zb20vc2VjcmV0LXJl\ncG8iLCJwcml2YXRlIjpmYWxzZSwib3duZXIiOnsibG9naW4iOiJob3NvbSIs\nImlkIjo1MDE3MzI0LCJub2RlX2lkIjoiTURRNlZYTmxjalV3TVRjek1qUT0i\nLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1YnVzZXJjb250\nZW50LmNvbS91LzUwMTczMjQ/dj00IiwiZ3JhdmF0YXJfaWQiOiIiLCJ1cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tIiwiaHRtbF91\ncmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9zb20iLCJmb2xsb3dlcnNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9mb2xsb3dl\ncnMiLCJmb2xsb3dpbmdfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy9ob3NvbS9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9ob3NvbS9naXN0c3sv\nZ2lzdF9pZH0iLCJzdGFycmVkX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vdXNlcnMvaG9zb20vc3RhcnJlZHsvb3duZXJ9ey9yZXBvfSIsInN1YnNj\ncmlwdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9o\nb3NvbS9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL29yZ3MiLCJyZXBvc191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlcG9z\nIiwiZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMv\naG9zb20vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL2hvc29tL3JlY2VpdmVk\nX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwic2l0ZV9hZG1pbiI6dHJ1ZX0sImh0\nbWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nIiwiZGVzY3JpcHRpb24iOm51bGwsImZvcmsiOmZhbHNlLCJ1cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvIiwi\nZm9ya3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3Nv\nbS9zZWNyZXQtcmVwby9mb3JrcyIsImtleXNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9rZXlzey9rZXlf\naWR9IiwiY29sbGFib3JhdG9yc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2NvbGxhYm9yYXRvcnN7L2Nv\nbGxhYm9yYXRvcn0iLCJ0ZWFtc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3RlYW1zIiwiaG9va3NfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQt\ncmVwby9ob29rcyIsImlzc3VlX2V2ZW50c191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL2lzc3Vlcy9ldmVu\ndHN7L251bWJlcn0iLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9ldmVudHMiLCJhc3NpZ25l\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9hc3NpZ25lZXN7L3VzZXJ9IiwiYnJhbmNoZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9icmFuY2hlc3svYnJhbmNofSIsInRhZ3NfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby90YWdzIiwiYmxv\nYnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9naXQvYmxvYnN7L3NoYX0iLCJnaXRfdGFnc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2dpdC90YWdzey9zaGF9IiwiZ2l0X3JlZnNfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvcmVmc3sv\nc2hhfSIsInRyZWVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vZ2l0L3RyZWVzey9zaGF9Iiwic3RhdHVz\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdGF0dXNlcy97c2hhfSIsImxhbmd1YWdlc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2xhbmd1YWdlcyIsInN0YXJnYXplcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9zdGFyZ2F6ZXJzIiwi\nY29udHJpYnV0b3JzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvaG9zb20vc2VjcmV0LXJlcG8vY29udHJpYnV0b3JzIiwic3Vic2NyaWJl\ncnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9zdWJzY3JpYmVycyIsInN1YnNjcmlwdGlvbl91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL3N1YnNjcmlwdGlvbiIsImNvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9jb21taXRzey9zaGF9\nIiwiZ2l0X2NvbW1pdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9y\nZXBvcy9ob3NvbS9zZWNyZXQtcmVwby9naXQvY29tbWl0c3svc2hhfSIsImNv\nbW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vY29tbWVudHN7L251bWJlcn0iLCJpc3N1ZV9jb21t\nZW50X3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20v\nc2VjcmV0LXJlcG8vaXNzdWVzL2NvbW1lbnRzey9udW1iZXJ9IiwiY29udGVu\ndHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9z\nZWNyZXQtcmVwby9jb250ZW50cy97K3BhdGh9IiwiY29tcGFyZV91cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBv\nL2NvbXBhcmUve2Jhc2V9Li4ue2hlYWR9IiwibWVyZ2VzX3VybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbWVy\nZ2VzIiwiYXJjaGl2ZV91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Jl\ncG9zL2hvc29tL3NlY3JldC1yZXBvL3thcmNoaXZlX2Zvcm1hdH17L3JlZn0i\nLCJkb3dubG9hZHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy9ob3NvbS9zZWNyZXQtcmVwby9kb3dubG9hZHMiLCJpc3N1ZXNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9ob3NvbS9zZWNyZXQtcmVw\nby9pc3N1ZXN7L251bWJlcn0iLCJwdWxsc191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL3B1bGxzey9udW1i\nZXJ9IiwibWlsZXN0b25lc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3JlcG9zL2hvc29tL3NlY3JldC1yZXBvL21pbGVzdG9uZXN7L251bWJlcn0i\nLCJub3RpZmljYXRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbm90aWZpY2F0aW9uc3s/c2luY2Us\nYWxsLHBhcnRpY2lwYXRpbmd9IiwibGFiZWxzX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vbGFiZWxzey9u\nYW1lfSIsInJlbGVhc2VzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vcmVsZWFzZXN7L2lkfSIsImRlcGxv\neW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvaG9z\nb20vc2VjcmV0LXJlcG8vZGVwbG95bWVudHMiLCJjcmVhdGVkX2F0IjoiMjAy\nMy0wOC0yMlQxODozMzo0OFoiLCJ1cGRhdGVkX2F0IjoiMjAyMy0wOC0yMlQx\nODozMzo0OFoiLCJwdXNoZWRfYXQiOiIyMDIzLTA4LTIyVDE4OjMzOjQ4WiIs\nImdpdF91cmwiOiJnaXQ6Ly9naXRodWIuY29tL2hvc29tL3NlY3JldC1yZXBv\nLmdpdCIsInNzaF91cmwiOiJnaXRAZ2l0aHViLmNvbTpob3NvbS9zZWNyZXQt\ncmVwby5naXQiLCJjbG9uZV91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vaG9z\nb20vc2VjcmV0LXJlcG8uZ2l0Iiwic3ZuX3VybCI6Imh0dHBzOi8vZ2l0aHVi\nLmNvbS9ob3NvbS9zZWNyZXQtcmVwbyIsImhvbWVwYWdlIjpudWxsLCJzaXpl\nIjowLCJzdGFyZ2F6ZXJzX2NvdW50IjowLCJ3YXRjaGVyc19jb3VudCI6MCwi\nbGFuZ3VhZ2UiOm51bGwsImhhc19pc3N1ZXMiOnRydWUsImhhc19wcm9qZWN0\ncyI6dHJ1ZSwiaGFzX2Rvd25sb2FkcyI6dHJ1ZSwiaGFzX3dpa2kiOnRydWUs\nImhhc19wYWdlcyI6ZmFsc2UsImhhc19kaXNjdXNzaW9ucyI6ZmFsc2UsImZv\ncmtzX2NvdW50IjowLCJtaXJyb3JfdXJsIjpudWxsLCJhcmNoaXZlZCI6ZmFs\nc2UsImRpc2FibGVkIjpmYWxzZSwib3Blbl9pc3N1ZXNfY291bnQiOjAsImxp\nY2Vuc2UiOm51bGwsImFsbG93X2ZvcmtpbmciOnRydWUsImlzX3RlbXBsYXRl\nIjpmYWxzZSwid2ViX2NvbW1pdF9zaWdub2ZmX3JlcXVpcmVkIjpmYWxzZSwi\ndG9waWNzIjpbXSwidmlzaWJpbGl0eSI6InB1YmxpYyIsImZvcmtzIjowLCJv\ncGVuX2lzc3VlcyI6MCwid2F0Y2hlcnMiOjAsImRlZmF1bHRfYnJhbmNoIjoi\nbWFpbiIsInBlcm1pc3Npb25zIjp7ImFkbWluIjp0cnVlLCJtYWludGFpbiI6\ndHJ1ZSwicHVzaCI6dHJ1ZSwidHJpYWdlIjp0cnVlLCJwdWxsIjp0cnVlfSwi\nYWxsb3dfc3F1YXNoX21lcmdlIjp0cnVlLCJhbGxvd19tZXJnZV9jb21taXQi\nOnRydWUsImFsbG93X3JlYmFzZV9tZXJnZSI6dHJ1ZSwiYWxsb3dfYXV0b19t\nZXJnZSI6ZmFsc2UsImRlbGV0ZV9icmFuY2hfb25fbWVyZ2UiOmZhbHNlLCJh\nbGxvd191cGRhdGVfYnJhbmNoIjpmYWxzZSwidXNlX3NxdWFzaF9wcl90aXRs\nZV9hc19kZWZhdWx0IjpmYWxzZSwic3F1YXNoX21lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiQ09NTUlUX01FU1NBR0VTIiwic3F1YXNoX21lcmdlX2NvbW1pdF90\naXRsZSI6IkNPTU1JVF9PUl9QUl9USVRMRSIsIm1lcmdlX2NvbW1pdF9tZXNz\nYWdlIjoiUFJfVElUTEUiLCJtZXJnZV9jb21taXRfdGl0bGUiOiJNRVJHRV9N\nRVNTQUdFIiwibmV0d29ya19jb3VudCI6MCwic3Vic2NyaWJlcnNfY291bnQi\nOjF9\n"
+        }
+      },
+      "recorded_at": "Tue, 22 Aug 2023 18:33:48 GMT"
+    },
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://api.github.com/repositories/681779592/environments/zero",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 22 Aug 2023 18:33:49 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"a78104029e8d50b630b340ee25d579ece7af888abd54bd8bdbc731ccb05ec7f7\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-21 14:26:52 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4961"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692731476"
+          ],
+          "X-Ratelimit-Used": [
+            "39"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0401:080F:153E236:2B20453:64E4FF8C"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJpZCI6MTI2MDk5NjYyMiwibm9kZV9pZCI6IkVOX2t3RE9LS01oaU01TEtV\nZ08iLCJuYW1lIjoiemVybyIsInVybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vcmVwb3MvaG9zb20vc2VjcmV0LXJlcG8vZW52aXJvbm1lbnRzL3plcm8i\nLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9ob3NvbS9zZWNyZXQt\ncmVwby9kZXBsb3ltZW50cy9hY3Rpdml0eV9sb2c/ZW52aXJvbm1lbnRzX2Zp\nbHRlcj16ZXJvIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDgtMjJUMTg6MzM6NDha\nIiwidXBkYXRlZF9hdCI6IjIwMjMtMDgtMjJUMTg6MzM6NDhaIiwiY2FuX2Fk\nbWluc19ieXBhc3MiOnRydWUsInByb3RlY3Rpb25fcnVsZXMiOltdLCJkZXBs\nb3ltZW50X2JyYW5jaF9wb2xpY3kiOm51bGx9\n"
+        }
+      },
+      "recorded_at": "Tue, 22 Aug 2023 18:33:49 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repositories/681779592/environments/zero/secrets",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 22 Aug 2023 18:33:49 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"7f0805ae54fe481d7d52897b7bd52b62e8c228114e8f11ec39cf30101411418c\""
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-21 14:26:52 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "secrets=read,environments=read"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4960"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692731476"
+          ],
+          "X-Ratelimit-Used": [
+            "40"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "0402:6C12:1596899:2BDA179:64E4FF8D"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJ0b3RhbF9jb3VudCI6MCwic2VjcmV0cyI6W119\n"
+        }
+      },
+      "recorded_at": "Tue, 22 Aug 2023 18:33:49 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/hosom/secret-repo",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.0.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 22 Aug 2023 18:33:49 GMT"
+          ],
+          "Github-Authentication-Token-Expiration": [
+            "2023-09-21 14:26:52 -0400"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Accepted-Github-Permissions": [
+            "administration=write"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4959"
+          ],
+          "X-Ratelimit-Reset": [
+            "1692731476"
+          ],
+          "X-Ratelimit-Used": [
+            "41"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "0403:46CA:12FBA6B:26AAA86:64E4FF8D"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Tue, 22 Aug 2023 18:33:49 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/octokit/octokit.rb/issues/1611

----

### Before the change?

* Endpoints for environment secrets within Actions were not supported.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* All of the `actions_secret` methods have been mapped to equivalents that support `environments`.
    * `get_actions_environment_public_key` 
    * `list_actions_environment_secrets`
    * `get_actions_environment_secret`
    * `create_or_update_actions_environment_secret`
    * `delete_actions_environment_secret` 

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

No breaking changes here!

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

