### PR TITLE
[feat]: add methods for app hook deliveries

### DIFF
--- a/lib/octokit/client/apps.rb
+++ b/lib/octokit/client/apps.rb
@@ -226,7 +226,7 @@ module Octokit
       #
       # @return [Array<Hash>] an array of hook deliveries
       def list_app_hook_deliveries(options = {})
-        paginate("app/hook/deliveries", options) do |data, last_response|
+        paginate('app/hook/deliveries', options) do |data, last_response|
           data.concat last_response.data
         end
       end

--- a/lib/octokit/client/apps.rb
+++ b/lib/octokit/client/apps.rb
@@ -217,6 +217,31 @@ module Octokit
       def delete_installation(installation, options = {})
         boolean_from_response :delete, "app/installations/#{installation}", options
       end
+
+      # Returns a list of webhook deliveries for the webhook configured for a GitHub App.
+      #
+      # @param options [Hash] A customizable set of options
+      #
+      # @see https://docs.github.com/en/rest/apps/webhooks#list-deliveries-for-an-app-webhook
+      #
+      # @return [Array<Hash>] an array of hook deliveries
+      def list_app_hook_deliveries(options = {})
+        paginate("app/hook/deliveries", options) do |data, last_response|
+          data.concat last_response.data
+        end
+      end
+
+      # Redeliver a delivery for the webhook configured for a GitHub App.
+      #
+      # @param delivery_id [Integer] The id of a GitHub App Hook Delivery
+      # @param options [Hash] A customizable set of options
+      #
+      # @see https://developer.github.com/v3/apps/#redeliver-a-delivery-for-an-app-webhook
+      #
+      # @return [Boolean] Success
+      def deliver_app_hook(delivery_id, options = {})
+        boolean_from_response :post, "app/hook/deliveries/#{delivery_id}/attempts", options
+      end
     end
   end
 end

--- a/spec/cassettes/Octokit_Client_Apps/_deliver_app_hook/schedules_a_webhook_for_redelivery.json
+++ b/spec/cassettes/Octokit_Client_Apps/_deliver_app_hook/schedules_a_webhook_for_redelivery.json
@@ -2,11 +2,11 @@
   "http_interactions": [
     {
       "request": {
-        "method": "get",
-        "uri": "https://api.github.com/app/hook/deliveries",
+        "method": "post",
+        "uri": "https://api.github.com/app/hook/deliveries/55148726666/attempts",
         "body": {
-          "encoding": "US-ASCII",
-          "base64_string": ""
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
         },
         "headers": {
           "Accept": [
@@ -28,24 +28,27 @@
       },
       "response": {
         "status": {
-          "code": 401,
-          "message": "Unauthorized"
+          "code": 202,
+          "message": "Accepted"
         },
         "headers": {
           "Server": [
             "GitHub.com"
           ],
           "Date": [
-            "Thu, 07 Sep 2023 02:10:54 GMT"
+            "Sat, 09 Sep 2023 18:40:05 GMT"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "Content-Length": [
-            "102"
+            "2"
           ],
           "X-Github-Media-Type": [
             "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
           ],
           "Access-Control-Expose-Headers": [
             "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
@@ -75,15 +78,15 @@
             "Accept-Encoding, Accept, X-Requested-With"
           ],
           "X-Github-Request-Id": [
-            "DA62:7F31:5A0662:B7CFE9:64F9312E"
+            "E90B:7D5B:A273CE:14E6D87:64FCBC05"
           ]
         },
         "body": {
           "encoding": "UTF-8",
-          "base64_string": "eyJtZXNzYWdlIjoiQSBKU09OIHdlYiB0b2tlbiBjb3VsZCBub3QgYmUgZGVj\nb2RlZCIsImRvY3VtZW50YXRpb25fdXJsIjoiaHR0cHM6Ly9kb2NzLmdpdGh1\nYi5jb20vcmVzdCJ9\n"
+          "base64_string": "e30=\n"
         }
       },
-      "recorded_at": "Thu, 07 Sep 2023 02:10:54 GMT"
+      "recorded_at": "Sat, 09 Sep 2023 18:40:05 GMT"
     }
   ],
   "recorded_with": "VCR 6.2.0"

--- a/spec/cassettes/Octokit_Client_Apps/_list_app_hook_deliveries/allows_auto_pagination.json
+++ b/spec/cassettes/Octokit_Client_Apps/_list_app_hook_deliveries/allows_auto_pagination.json
@@ -1,0 +1,299 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/app/hook/deliveries?per_page=1",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.1.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "Bearer <JWT_BEARER_TOKEN>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Sat, 09 Sep 2023 18:59:12 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "public, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"434eb576d26ef703603e5ce3d2c6a30d1a3cb328649a3a4861731968039aade9\""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "Link": [
+            "<https://api.github.com/app/hook/deliveries?per_page=1&cursor=v1_55148726666>; rel=\"next\""
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "EA06:858B:89CA93:11BBEE5:64FCC080"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "W3siaWQiOjU1MTQ4OTE0ODgwLCJndWlkIjoiMjI4NDhjMzAtNGYzZi0xMWVl\nLTk3NjAtYWIyOWUwODUxZTQwIiwiZGVsaXZlcmVkX2F0IjoiMjAyMy0wOS0w\nOVQxODo0MDowNVoiLCJyZWRlbGl2ZXJ5Ijp0cnVlLCJkdXJhdGlvbiI6MC4w\nMiwic3RhdHVzIjoiSW52YWxpZCBIVFRQIFJlc3BvbnNlOiA0MDMiLCJzdGF0\ndXNfY29kZSI6NDAzLCJldmVudCI6Imluc3RhbGxhdGlvbiIsImFjdGlvbiI6\nImNyZWF0ZWQiLCJpbnN0YWxsYXRpb25faWQiOm51bGwsInJlcG9zaXRvcnlf\naWQiOm51bGwsInVybCI6IiJ9XQ==\n"
+        }
+      },
+      "recorded_at": "Sat, 09 Sep 2023 18:59:12 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/app/hook/deliveries?cursor=v1_55148726666&per_page=1",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.1.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "Bearer <JWT_BEARER_TOKEN>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Sat, 09 Sep 2023 18:59:12 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "public, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"d793b85aa9a11757539e13947001960e08f01cdfac3eb82555c3f09ebd75757d\""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "Link": [
+            "<https://api.github.com/app/hook/deliveries?cursor=v1_55148717893&per_page=1>; rel=\"next\", <https://api.github.com/app/hook/deliveries?cursor=v1_55148914880&per_page=1>; rel=\"prev\""
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "EA07:583E:6B1BA5F:D8E3EF7:64FCC080"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "W3siaWQiOjU1MTQ4NzI2NjY2LCJndWlkIjoiMjI4NDhjMzAtNGYzZi0xMWVl\nLTk3NjAtYWIyOWUwODUxZTQwIiwiZGVsaXZlcmVkX2F0IjoiMjAyMy0wOS0w\nOVQxODozMTo0OFoiLCJyZWRlbGl2ZXJ5IjpmYWxzZSwiZHVyYXRpb24iOjAu\nMDIsInN0YXR1cyI6IkludmFsaWQgSFRUUCBSZXNwb25zZTogNDAzIiwic3Rh\ndHVzX2NvZGUiOjQwMywiZXZlbnQiOiJpbnN0YWxsYXRpb24iLCJhY3Rpb24i\nOiJjcmVhdGVkIiwiaW5zdGFsbGF0aW9uX2lkIjpudWxsLCJyZXBvc2l0b3J5\nX2lkIjpudWxsLCJ1cmwiOiIifV0=\n"
+        }
+      },
+      "recorded_at": "Sat, 09 Sep 2023 18:59:12 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/app/hook/deliveries?cursor=v1_55148717893&per_page=1",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.1.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "Bearer <JWT_BEARER_TOKEN>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Sat, 09 Sep 2023 18:59:12 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "public, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"4e957686c38a9fa67d69a84396ddd98cc030a218bcd30f06c1941afa24403519\""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "Link": [
+            "<https://api.github.com/app/hook/deliveries?cursor=v1_55148726666&per_page=1>; rel=\"prev\""
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "EA08:1A57:8A291E:11C7271:64FCC080"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "W3siaWQiOjU1MTQ4NzE3ODkzLCJndWlkIjoiMTZiMmJhZDAtNGYzZi0xMWVl\nLTk5ZDgtN2U5NzYxMTM2ZWIyIiwiZGVsaXZlcmVkX2F0IjoiMjAyMy0wOS0w\nOVQxODozMToyOFoiLCJyZWRlbGl2ZXJ5IjpmYWxzZSwiZHVyYXRpb24iOjAu\nMDIsInN0YXR1cyI6IkludmFsaWQgSFRUUCBSZXNwb25zZTogNDAzIiwic3Rh\ndHVzX2NvZGUiOjQwMywiZXZlbnQiOiJwaW5nIiwiYWN0aW9uIjpudWxsLCJp\nbnN0YWxsYXRpb25faWQiOm51bGwsInJlcG9zaXRvcnlfaWQiOm51bGwsInVy\nbCI6IiJ9XQ==\n"
+        }
+      },
+      "recorded_at": "Sat, 09 Sep 2023 18:59:12 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/cassettes/Octokit_Client_Apps/_list_app_hook_deliveries/lists_hook_deliveries_for_an_app.json
+++ b/spec/cassettes/Octokit_Client_Apps/_list_app_hook_deliveries/lists_hook_deliveries_for_an_app.json
@@ -1,0 +1,100 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/app/hook/deliveries",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.1.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "Bearer <JWT_BEARER_TOKEN>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Sat, 09 Sep 2023 18:32:58 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "public, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"e0e9922de21504b56848d2e239e774b69c8dfb237840d87dcc1aa74ede3db907\""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "E7BA:9419:A85A3F:15A699F:64FCBA5A"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "W3siaWQiOjU1MTQ4NzI2NjY2LCJndWlkIjoiMjI4NDhjMzAtNGYzZi0xMWVl\nLTk3NjAtYWIyOWUwODUxZTQwIiwiZGVsaXZlcmVkX2F0IjoiMjAyMy0wOS0w\nOVQxODozMTo0OFoiLCJyZWRlbGl2ZXJ5IjpmYWxzZSwiZHVyYXRpb24iOjAu\nMDIsInN0YXR1cyI6IkludmFsaWQgSFRUUCBSZXNwb25zZTogNDAzIiwic3Rh\ndHVzX2NvZGUiOjQwMywiZXZlbnQiOiJpbnN0YWxsYXRpb24iLCJhY3Rpb24i\nOiJjcmVhdGVkIiwiaW5zdGFsbGF0aW9uX2lkIjpudWxsLCJyZXBvc2l0b3J5\nX2lkIjpudWxsLCJ1cmwiOiIifSx7ImlkIjo1NTE0ODcxNzg5MywiZ3VpZCI6\nIjE2YjJiYWQwLTRmM2YtMTFlZS05OWQ4LTdlOTc2MTEzNmViMiIsImRlbGl2\nZXJlZF9hdCI6IjIwMjMtMDktMDlUMTg6MzE6MjhaIiwicmVkZWxpdmVyeSI6\nZmFsc2UsImR1cmF0aW9uIjowLjAyLCJzdGF0dXMiOiJJbnZhbGlkIEhUVFAg\nUmVzcG9uc2U6IDQwMyIsInN0YXR1c19jb2RlIjo0MDMsImV2ZW50IjoicGlu\nZyIsImFjdGlvbiI6bnVsbCwiaW5zdGFsbGF0aW9uX2lkIjpudWxsLCJyZXBv\nc2l0b3J5X2lkIjpudWxsLCJ1cmwiOiIifV0=\n"
+        }
+      },
+      "recorded_at": "Sat, 09 Sep 2023 18:32:58 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/cassettes/Octokit_Client_Apps/with_app_installation/_list_app_hook_deliveries/lists_hook_deliveries_for_an_app.json
+++ b/spec/cassettes/Octokit_Client_Apps/with_app_installation/_list_app_hook_deliveries/lists_hook_deliveries_for_an_app.json
@@ -1,0 +1,90 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/app/hook/deliveries",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.1.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "Bearer <JWT_BEARER_TOKEN>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 401,
+          "message": "Unauthorized"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Thu, 07 Sep 2023 02:10:54 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "102"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "DA62:7F31:5A0662:B7CFE9:64F9312E"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJtZXNzYWdlIjoiQSBKU09OIHdlYiB0b2tlbiBjb3VsZCBub3QgYmUgZGVj\nb2RlZCIsImRvY3VtZW50YXRpb25fdXJsIjoiaHR0cHM6Ly9kb2NzLmdpdGh1\nYi5jb20vcmVzdCJ9\n"
+        }
+      },
+      "recorded_at": "Thu, 07 Sep 2023 02:10:54 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/octokit/client/apps_spec.rb
+++ b/spec/octokit/client/apps_spec.rb
@@ -182,6 +182,22 @@ describe Octokit::Client::Apps do
     end
   end # .find_user_installation
 
+    describe '.list_app_hook_deliveries', :vcr do
+      it 'lists hook deliveries for an app' do
+        response = @jwt_client.list_app_hook_deliveries
+        expect(response).to be_kind_of(Array)
+        expect(response.count).to eq 2
+      end
+    end #.list_app_hook_deliveries
+
+    describe '.deliver_app_hook', :vcr do
+      let(:delivery_id) { 55148726666 }
+      it 'schedules a webhook for redelivery' do
+        response = @jwt_client.deliver_app_hook(delivery_id)
+        expect(response).to be_truthy
+      end
+    end #.deliver_app_hook
+
   context 'with app installation', :vcr do
     let(:installation) { test_github_integration_installation }
 
@@ -278,12 +294,6 @@ describe Octokit::Client::Apps do
       end
     end # .delete_installation
 
-    describe '.list_app_hook_deliveries' do
-      it 'lists hook deliveries for an app' do
-        response = @jwt_client.list_app_hook_deliveries
-        expect(response).to be_kind_of(Array)
-      end
-    end
 
     context 'with app installation access token' do
       let(:installation_client) do

--- a/spec/octokit/client/apps_spec.rb
+++ b/spec/octokit/client/apps_spec.rb
@@ -182,29 +182,29 @@ describe Octokit::Client::Apps do
     end
   end # .find_user_installation
 
-    describe '.list_app_hook_deliveries', :vcr do
-      it 'lists hook deliveries for an app' do
-        response = @jwt_client.list_app_hook_deliveries
-        expect(response).to be_kind_of(Array)
-        expect(response.count).to eq 2
-      end
+  describe '.list_app_hook_deliveries', :vcr do
+    it 'lists hook deliveries for an app' do
+      response = @jwt_client.list_app_hook_deliveries
+      expect(response).to be_kind_of(Array)
+      expect(response.count).to eq 2
+    end
 
-      it 'allows auto_pagination' do
-        @jwt_client.auto_paginate = true
-        response = @jwt_client.list_app_hook_deliveries(per_page: 1)
+    it 'allows auto_pagination' do
+      @jwt_client.auto_paginate = true
+      response = @jwt_client.list_app_hook_deliveries(per_page: 1)
 
-          expect(response).to be_kind_of(Array)
-          expect(response.count).to eq 3
-      end
-    end #.list_app_hook_deliveries
+      expect(response).to be_kind_of(Array)
+      expect(response.count).to eq 3
+    end
+  end # .list_app_hook_deliveries
 
-    describe '.deliver_app_hook', :vcr do
-      let(:delivery_id) { 55148726666 }
-      it 'schedules a webhook for redelivery' do
-        response = @jwt_client.deliver_app_hook(delivery_id)
-        expect(response).to be_truthy
-      end
-    end #.deliver_app_hook
+  describe '.deliver_app_hook', :vcr do
+    let(:delivery_id) { 55_148_726_666 }
+    it 'schedules a webhook for redelivery' do
+      response = @jwt_client.deliver_app_hook(delivery_id)
+      expect(response).to be_truthy
+    end
+  end # .deliver_app_hook
 
   context 'with app installation', :vcr do
     let(:installation) { test_github_integration_installation }
@@ -301,7 +301,6 @@ describe Octokit::Client::Apps do
         expect(response).to be_truthy
       end
     end # .delete_installation
-
 
     context 'with app installation access token' do
       let(:installation_client) do

--- a/spec/octokit/client/apps_spec.rb
+++ b/spec/octokit/client/apps_spec.rb
@@ -188,6 +188,14 @@ describe Octokit::Client::Apps do
         expect(response).to be_kind_of(Array)
         expect(response.count).to eq 2
       end
+
+      it 'allows auto_pagination' do
+        @jwt_client.auto_paginate = true
+        response = @jwt_client.list_app_hook_deliveries(per_page: 1)
+
+          expect(response).to be_kind_of(Array)
+          expect(response.count).to eq 3
+      end
     end #.list_app_hook_deliveries
 
     describe '.deliver_app_hook', :vcr do

--- a/spec/octokit/client/apps_spec.rb
+++ b/spec/octokit/client/apps_spec.rb
@@ -278,6 +278,13 @@ describe Octokit::Client::Apps do
       end
     end # .delete_installation
 
+    describe '.list_app_hook_deliveries' do
+      it 'lists hook deliveries for an app' do
+        response = @jwt_client.list_app_hook_deliveries
+        expect(response).to be_kind_of(Array)
+      end
+    end
+
     context 'with app installation access token' do
       let(:installation_client) do
         token = @jwt_client.create_app_installation_access_token(installation).token


### PR DESCRIPTION
Resolves #1619

----

### Before the change?

* The endpoints for /app/hooks are not yet implemented

### After the change?

* Implementations for listing app webhooks and retriggering delivery have been implemented

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

This is my first PR to Octokit and I wasn't able to get a test working using the JWT token, would appreciate some pointers here!

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
