### PR TITLE
Add missing endpoints to Reactions

### DIFF
--- a/lib/octokit/client/reactions.rb
+++ b/lib/octokit/client/reactions.rb
@@ -150,6 +150,55 @@ module Octokit
       def delete_issue_reaction(repo, issue_id, reaction_id, options = {})
         boolean_from_response :delete, "#{Repository.path repo}/issues/#{issue_id}/reactions/#{reaction_id}", options
       end
+
+      # List reactions for a release
+      #
+      # @param repo [Integer, String, Hash, Repository] A GitHub repository
+      # @param id [Integer] The Release id
+      #
+      # @see https://docs.github.com/en/free-pro-team@latest/rest/reactions/reactions?apiVersion=2022-11-28#list-reactions-for-a-release
+      #
+      # @example
+      #   @client.release_reactions("octokit/octokit.rb", 1)
+      #
+      # @return [Array<Sawyer::Resource>] Array of Hashes representing the reactions.
+      def release_reactions(repo, release_id, options = {})
+        get "#{Repository.path repo}/releases/#{release_id}/reactions", options
+      end
+
+      # Create reaction for a release
+      #
+      # @param repo [Integer, String, Hash, Repository] A GitHub repository
+      # @param id [Integer] The Release id
+      # @param reaction [String] The Reaction
+      #
+      # @see https://docs.github.com/en/free-pro-team@latest/rest/reactions/reactions?apiVersion=2022-11-28#create-reaction-for-a-release
+      # @see https://developer.github.com/v3/reactions/#reaction-types
+      #
+      # @example
+      #   @client.create_release_reaction("octokit/octokit.rb", 1)
+      #
+      # @return [<Sawyer::Resource>] Hash representing the reaction.
+      def create_release_reaction(repo, release_id, reaction, options = {})
+        options = options.merge(content: reaction)
+        post "#{Repository.path repo}/releases/#{release_id}/reactions", options
+      end
+
+      # Delete a reaction for a release
+      #
+      # @param repo [Integer, String, Hash, Repository] A GitHub repository
+      # @param issue_id [Integer] The Release id
+      # @param reaction_id [Integer] The Reaction id
+      #
+      # @see https://docs.github.com/en/free-pro-team@latest/rest/reactions/reactions?apiVersion=2022-11-28#delete-a-release-reaction
+      #
+      # @example
+      #   @client.delete_release_reaction("octokit/octokit.rb", 1, 2)
+      #
+      # @return [Boolean] Return true if reaction was deleted, false otherwise.
+      def delete_release_reaction(repo, release_id, reaction_id, options = {})
+        boolean_from_response :delete, "#{Repository.path repo}/releases/#{release_id}/reactions/#{reaction_id}", options
+      end
     end
   end
 end

--- a/spec/cassettes/Octokit_Client_Reactions/with_repository/with_release/_create_release_reaction/creates_a_reaction.json
+++ b/spec/cassettes/Octokit_Client_Reactions/with_repository/with_release/_create_release_reaction/creates_a_reaction.json
@@ -1,0 +1,105 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/user/repos",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJhdXRvX2luaXQiOnRydWUsIm5hbWUiOiJhbi1yZXBvIn0=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 401,
+          "message": "Unauthorized"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 06 Oct 2023 19:31:44 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "80"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Ratelimit-Limit": [
+            "60"
+          ],
+          "X-Ratelimit-Remaining": [
+            "54"
+          ],
+          "X-Ratelimit-Reset": [
+            "1696623381"
+          ],
+          "X-Ratelimit-Used": [
+            "6"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "EB06:EFB1:18C28C6:18FEB91:652060A0"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJtZXNzYWdlIjoiQmFkIGNyZWRlbnRpYWxzIiwiZG9jdW1lbnRhdGlvbl91\ncmwiOiJodHRwczovL2RvY3MuZ2l0aHViLmNvbS9yZXN0In0=\n"
+        }
+      },
+      "recorded_at": "Fri, 06 Oct 2023 19:31:44 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/cassettes/Octokit_Client_Reactions/with_repository/with_release/_create_release_reaction/creates_a_reaction.json
+++ b/spec/cassettes/Octokit_Client_Reactions/with_repository/with_release/_create_release_reaction/creates_a_reaction.json
@@ -3,6 +3,354 @@
     {
       "request": {
         "method": "post",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases/127002751/reactions",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJjb250ZW50IjoiKzEifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:19:02 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "998"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"8c207efcff733336b4706f4425891d883ee734ec7d9f5268863662d64ac0482c\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4992"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "8"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DD86:5CC1:DF0116:E1404F:653C0D26"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6MTc5OTg3ODg5LCJub2RlX2lkIjoiUkVBX2xBZk9LbUFWS3M0SGtl\naF96Z3E2WmJFIiwidXNlciI6eyJsb2dpbiI6IndKb2VubiIsImlkIjo3NTM4\nODg2OSwibm9kZV9pZCI6Ik1EUTZWWE5sY2pjMU16ZzRPRFk1IiwiYXZhdGFy\nX3VybCI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5jb20v\ndS83NTM4ODg2OT92PTQiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uIiwiaHRtbF91cmwiOiJo\ndHRwczovL2dpdGh1Yi5jb20vd0pvZW5uIiwiZm9sbG93ZXJzX3VybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2VycyIs\nImZvbGxvd2luZ191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vZ2lzdHN7L2dp\nc3RfaWR9Iiwic3RhcnJlZF91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3VzZXJzL3dKb2Vubi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwic3Vic2Ny\naXB0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dK\nb2Vubi9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9vcmdzIiwicmVwb3Nf\ndXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vcmVw\nb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vy\ncy93Sm9lbm4vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9yZWNl\naXZlZF9ldmVudHMiLCJ0eXBlIjoiVXNlciIsInNpdGVfYWRtaW4iOmZhbHNl\nfSwiY29udGVudCI6IisxIiwiY3JlYXRlZF9hdCI6IjIwMjMtMTAtMjdUMTk6\nMTk6MDJaIn0=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:19:02 GMT"
+    },
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases/127002751/reactions",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJjb250ZW50IjoiKzEifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:19:03 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"8c207efcff733336b4706f4425891d883ee734ec7d9f5268863662d64ac0482c\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4991"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "9"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DD90:111AA:B272A8:B4A254:653C0D26"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJpZCI6MTc5OTg3ODg5LCJub2RlX2lkIjoiUkVBX2xBZk9LbUFWS3M0SGtl\naF96Z3E2WmJFIiwidXNlciI6eyJsb2dpbiI6IndKb2VubiIsImlkIjo3NTM4\nODg2OSwibm9kZV9pZCI6Ik1EUTZWWE5sY2pjMU16ZzRPRFk1IiwiYXZhdGFy\nX3VybCI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5jb20v\ndS83NTM4ODg2OT92PTQiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uIiwiaHRtbF91cmwiOiJo\ndHRwczovL2dpdGh1Yi5jb20vd0pvZW5uIiwiZm9sbG93ZXJzX3VybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2VycyIs\nImZvbGxvd2luZ191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vZ2lzdHN7L2dp\nc3RfaWR9Iiwic3RhcnJlZF91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3VzZXJzL3dKb2Vubi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwic3Vic2Ny\naXB0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dK\nb2Vubi9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9vcmdzIiwicmVwb3Nf\ndXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vcmVw\nb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vy\ncy93Sm9lbm4vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9yZWNl\naXZlZF9ldmVudHMiLCJ0eXBlIjoiVXNlciIsInNpdGVfYWRtaW4iOmZhbHNl\nfSwiY29udGVudCI6IisxIiwiY3JlYXRlZF9hdCI6IjIwMjMtMTAtMjdUMTk6\nMTk6MDJaIn0=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:19:02 GMT"
+    },
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases/127002889/reactions",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJjb250ZW50IjoiKzEifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:20:37 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "998"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"53af50d2b881fd52b604db75cb1971f92d03c3996e7cd7597f5eb6882ab65993\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4982"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "18"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DD9E:111AA:B38F26:B5C28B:653C0D85"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6MTc5OTg3ODk0LCJub2RlX2lkIjoiUkVBX2xBZk9LbUFYRDg0SGtl\na0p6Z3E2WmJZIiwidXNlciI6eyJsb2dpbiI6IndKb2VubiIsImlkIjo3NTM4\nODg2OSwibm9kZV9pZCI6Ik1EUTZWWE5sY2pjMU16ZzRPRFk1IiwiYXZhdGFy\nX3VybCI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5jb20v\ndS83NTM4ODg2OT92PTQiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uIiwiaHRtbF91cmwiOiJo\ndHRwczovL2dpdGh1Yi5jb20vd0pvZW5uIiwiZm9sbG93ZXJzX3VybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2VycyIs\nImZvbGxvd2luZ191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vZ2lzdHN7L2dp\nc3RfaWR9Iiwic3RhcnJlZF91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3VzZXJzL3dKb2Vubi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwic3Vic2Ny\naXB0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dK\nb2Vubi9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9vcmdzIiwicmVwb3Nf\ndXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vcmVw\nb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vy\ncy93Sm9lbm4vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9yZWNl\naXZlZF9ldmVudHMiLCJ0eXBlIjoiVXNlciIsInNpdGVfYWRtaW4iOmZhbHNl\nfSwiY29udGVudCI6IisxIiwiY3JlYXRlZF9hdCI6IjIwMjMtMTAtMjdUMTk6\nMjA6MzdaIn0=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:20:36 GMT"
+    },
+    {
+      "request": {
+        "method": "post",
         "uri": "https://api.github.com/user/repos",
         "body": {
           "encoding": "UTF-8",
@@ -28,36 +376,393 @@
       },
       "response": {
         "status": {
-          "code": 401,
-          "message": "Unauthorized"
+          "code": 201,
+          "message": "Created"
         },
         "headers": {
           "Server": [
             "GitHub.com"
           ],
           "Date": [
-            "Fri, 06 Oct 2023 19:31:44 GMT"
+            "Fri, 27 Oct 2023 19:22:10 GMT"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "Content-Length": [
-            "80"
+            "5150"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"40ac225ca4a6018fe5fff6ae06f71ec247472ce98af8d4a2cdcb8f27a2b09fbc\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            "public_repo, repo"
+          ],
+          "Location": [
+            "https://api.github.com/repos/wJoenn/an-repo"
           ],
           "X-Github-Media-Type": [
             "github.v3; format=json"
           ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
           "X-Ratelimit-Limit": [
-            "60"
+            "5000"
           ],
           "X-Ratelimit-Remaining": [
-            "54"
+            "4967"
           ],
           "X-Ratelimit-Reset": [
-            "1696623381"
+            "1698437937"
           ],
           "X-Ratelimit-Used": [
-            "6"
+            "33"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DDAE:CCF7:F08228:F2CAFA:653C0DE0"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6NzEwOTQwOTE0LCJub2RlX2lkIjoiUl9rZ0RPS21BWThnIiwibmFt\nZSI6ImFuLXJlcG8iLCJmdWxsX25hbWUiOiJ3Sm9lbm4vYW4tcmVwbyIsInBy\naXZhdGUiOmZhbHNlLCJvd25lciI6eyJsb2dpbiI6IndKb2VubiIsImlkIjo3\nNTM4ODg2OSwibm9kZV9pZCI6Ik1EUTZWWE5sY2pjMU16ZzRPRFk1IiwiYXZh\ndGFyX3VybCI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5j\nb20vdS83NTM4ODg2OT92PTQiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uIiwiaHRtbF91cmwi\nOiJodHRwczovL2dpdGh1Yi5jb20vd0pvZW5uIiwiZm9sbG93ZXJzX3VybCI6\nImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2Vy\ncyIsImZvbGxvd2luZ191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Vz\nZXJzL3dKb2Vubi9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vZ2lzdHN7\nL2dpc3RfaWR9Iiwic3RhcnJlZF91cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3VzZXJzL3dKb2Vubi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwic3Vi\nc2NyaXB0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9vcmdzIiwicmVw\nb3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4v\ncmVwb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy93Sm9lbm4vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50\nc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9y\nZWNlaXZlZF9ldmVudHMiLCJ0eXBlIjoiVXNlciIsInNpdGVfYWRtaW4iOmZh\nbHNlfSwiaHRtbF91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vd0pvZW5uL2Fu\nLXJlcG8iLCJkZXNjcmlwdGlvbiI6bnVsbCwiZm9yayI6ZmFsc2UsInVybCI6\nImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8i\nLCJmb3Jrc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dK\nb2Vubi9hbi1yZXBvL2ZvcmtzIiwia2V5c191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2tleXN7L2tleV9pZH0i\nLCJjb2xsYWJvcmF0b3JzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3Mvd0pvZW5uL2FuLXJlcG8vY29sbGFib3JhdG9yc3svY29sbGFib3Jh\ndG9yfSIsInRlYW1zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3Mvd0pvZW5uL2FuLXJlcG8vdGVhbXMiLCJob29rc191cmwiOiJodHRwczov\nL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2hvb2tzIiwi\naXNzdWVfZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3Mvd0pvZW5uL2FuLXJlcG8vaXNzdWVzL2V2ZW50c3svbnVtYmVyfSIsImV2\nZW50c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vu\nbi9hbi1yZXBvL2V2ZW50cyIsImFzc2lnbmVlc191cmwiOiJodHRwczovL2Fw\naS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2Fzc2lnbmVlc3sv\ndXNlcn0iLCJicmFuY2hlc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2JyYW5jaGVzey9icmFuY2h9IiwidGFn\nc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9h\nbi1yZXBvL3RhZ3MiLCJibG9ic191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2dpdC9ibG9ic3svc2hhfSIsImdp\ndF90YWdzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3Mvd0pv\nZW5uL2FuLXJlcG8vZ2l0L3RhZ3N7L3NoYX0iLCJnaXRfcmVmc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2dp\ndC9yZWZzey9zaGF9IiwidHJlZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9naXQvdHJlZXN7L3NoYX0iLCJz\ndGF0dXNlc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dK\nb2Vubi9hbi1yZXBvL3N0YXR1c2VzL3tzaGF9IiwibGFuZ3VhZ2VzX3VybCI6\nImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8v\nbGFuZ3VhZ2VzIiwic3RhcmdhemVyc191cmwiOiJodHRwczovL2FwaS5naXRo\ndWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL3N0YXJnYXplcnMiLCJjb250\ncmlidXRvcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93\nSm9lbm4vYW4tcmVwby9jb250cmlidXRvcnMiLCJzdWJzY3JpYmVyc191cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBv\nL3N1YnNjcmliZXJzIiwic3Vic2NyaXB0aW9uX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8vc3Vic2NyaXB0aW9u\nIiwiY29tbWl0c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9z\nL3dKb2Vubi9hbi1yZXBvL2NvbW1pdHN7L3NoYX0iLCJnaXRfY29tbWl0c191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1y\nZXBvL2dpdC9jb21taXRzey9zaGF9IiwiY29tbWVudHNfdXJsIjoiaHR0cHM6\nLy9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9jb21tZW50\nc3svbnVtYmVyfSIsImlzc3VlX2NvbW1lbnRfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9pc3N1ZXMvY29tbWVu\ndHN7L251bWJlcn0iLCJjb250ZW50c191cmwiOiJodHRwczovL2FwaS5naXRo\ndWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2NvbnRlbnRzL3srcGF0aH0i\nLCJjb21wYXJlX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3Mv\nd0pvZW5uL2FuLXJlcG8vY29tcGFyZS97YmFzZX0uLi57aGVhZH0iLCJtZXJn\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4v\nYW4tcmVwby9tZXJnZXMiLCJhcmNoaXZlX3VybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8ve2FyY2hpdmVfZm9ybWF0\nfXsvcmVmfSIsImRvd25sb2Fkc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2Rvd25sb2FkcyIsImlzc3Vlc191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1y\nZXBvL2lzc3Vlc3svbnVtYmVyfSIsInB1bGxzX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8vcHVsbHN7L251bWJl\ncn0iLCJtaWxlc3RvbmVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3Mvd0pvZW5uL2FuLXJlcG8vbWlsZXN0b25lc3svbnVtYmVyfSIsIm5v\ndGlmaWNhdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy93Sm9lbm4vYW4tcmVwby9ub3RpZmljYXRpb25zez9zaW5jZSxhbGwscGFy\ndGljaXBhdGluZ30iLCJsYWJlbHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9sYWJlbHN7L25hbWV9IiwicmVs\nZWFzZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9l\nbm4vYW4tcmVwby9yZWxlYXNlc3svaWR9IiwiZGVwbG95bWVudHNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9k\nZXBsb3ltZW50cyIsImNyZWF0ZWRfYXQiOiIyMDIzLTEwLTI3VDE5OjIyOjA5\nWiIsInVwZGF0ZWRfYXQiOiIyMDIzLTEwLTI3VDE5OjIyOjEwWiIsInB1c2hl\nZF9hdCI6IjIwMjMtMTAtMjdUMTk6MjI6MTBaIiwiZ2l0X3VybCI6ImdpdDov\nL2dpdGh1Yi5jb20vd0pvZW5uL2FuLXJlcG8uZ2l0Iiwic3NoX3VybCI6Imdp\ndEBnaXRodWIuY29tOndKb2Vubi9hbi1yZXBvLmdpdCIsImNsb25lX3VybCI6\nImh0dHBzOi8vZ2l0aHViLmNvbS93Sm9lbm4vYW4tcmVwby5naXQiLCJzdm5f\ndXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL3dKb2Vubi9hbi1yZXBvIiwiaG9t\nZXBhZ2UiOm51bGwsInNpemUiOjAsInN0YXJnYXplcnNfY291bnQiOjAsIndh\ndGNoZXJzX2NvdW50IjowLCJsYW5ndWFnZSI6bnVsbCwiaGFzX2lzc3VlcyI6\ndHJ1ZSwiaGFzX3Byb2plY3RzIjp0cnVlLCJoYXNfZG93bmxvYWRzIjp0cnVl\nLCJoYXNfd2lraSI6dHJ1ZSwiaGFzX3BhZ2VzIjpmYWxzZSwiaGFzX2Rpc2N1\nc3Npb25zIjpmYWxzZSwiZm9ya3NfY291bnQiOjAsIm1pcnJvcl91cmwiOm51\nbGwsImFyY2hpdmVkIjpmYWxzZSwiZGlzYWJsZWQiOmZhbHNlLCJvcGVuX2lz\nc3Vlc19jb3VudCI6MCwibGljZW5zZSI6bnVsbCwiYWxsb3dfZm9ya2luZyI6\ndHJ1ZSwiaXNfdGVtcGxhdGUiOmZhbHNlLCJ3ZWJfY29tbWl0X3NpZ25vZmZf\ncmVxdWlyZWQiOmZhbHNlLCJ0b3BpY3MiOltdLCJ2aXNpYmlsaXR5IjoicHVi\nbGljIiwiZm9ya3MiOjAsIm9wZW5faXNzdWVzIjowLCJ3YXRjaGVycyI6MCwi\nZGVmYXVsdF9icmFuY2giOiJtYWluIiwicGVybWlzc2lvbnMiOnsiYWRtaW4i\nOnRydWUsIm1haW50YWluIjp0cnVlLCJwdXNoIjp0cnVlLCJ0cmlhZ2UiOnRy\ndWUsInB1bGwiOnRydWV9LCJhbGxvd19zcXVhc2hfbWVyZ2UiOnRydWUsImFs\nbG93X21lcmdlX2NvbW1pdCI6dHJ1ZSwiYWxsb3dfcmViYXNlX21lcmdlIjp0\ncnVlLCJhbGxvd19hdXRvX21lcmdlIjpmYWxzZSwiZGVsZXRlX2JyYW5jaF9v\nbl9tZXJnZSI6ZmFsc2UsImFsbG93X3VwZGF0ZV9icmFuY2giOmZhbHNlLCJ1\nc2Vfc3F1YXNoX3ByX3RpdGxlX2FzX2RlZmF1bHQiOmZhbHNlLCJzcXVhc2hf\nbWVyZ2VfY29tbWl0X21lc3NhZ2UiOiJDT01NSVRfTUVTU0FHRVMiLCJzcXVh\nc2hfbWVyZ2VfY29tbWl0X3RpdGxlIjoiQ09NTUlUX09SX1BSX1RJVExFIiwi\nbWVyZ2VfY29tbWl0X21lc3NhZ2UiOiJQUl9USVRMRSIsIm1lcmdlX2NvbW1p\ndF90aXRsZSI6Ik1FUkdFX01FU1NBR0UiLCJuZXR3b3JrX2NvdW50IjowLCJz\ndWJzY3JpYmVyc19jb3VudCI6MH0=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:22:09 GMT"
+    },
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJ0YWdfbmFtZSI6InYxLjAuMCJ9\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:22:11 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "1605"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"e58ababdad8209ca2ba2fa45741c2ce04ecce7cbe8122d117f4669845cc4b238\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            "repo"
+          ],
+          "Location": [
+            "https://api.github.com/repos/wJoenn/an-repo/releases/127003047"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4966"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "34"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DD6E:13397:ED0630:EF4971:653C0DE2"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJ1cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9h\nbi1yZXBvL3JlbGVhc2VzLzEyNzAwMzA0NyIsImFzc2V0c191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL3JlbGVh\nc2VzLzEyNzAwMzA0Ny9hc3NldHMiLCJ1cGxvYWRfdXJsIjoiaHR0cHM6Ly91\ncGxvYWRzLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8vcmVsZWFz\nZXMvMTI3MDAzMDQ3L2Fzc2V0c3s/bmFtZSxsYWJlbH0iLCJodG1sX3VybCI6\nImh0dHBzOi8vZ2l0aHViLmNvbS93Sm9lbm4vYW4tcmVwby9yZWxlYXNlcy90\nYWcvdjEuMC4wIiwiaWQiOjEyNzAwMzA0NywiYXV0aG9yIjp7ImxvZ2luIjoi\nd0pvZW5uIiwiaWQiOjc1Mzg4ODY5LCJub2RlX2lkIjoiTURRNlZYTmxjamMx\nTXpnNE9EWTUiLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1\nYnVzZXJjb250ZW50LmNvbS91Lzc1Mzg4ODY5P3Y9NCIsImdyYXZhdGFyX2lk\nIjoiIiwidXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9l\nbm4iLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS93Sm9lbm4iLCJm\nb2xsb3dlcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93\nSm9lbm4vZm9sbG93ZXJzIiwiZm9sbG93aW5nX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2luZ3svb3RoZXJfdXNl\ncn0iLCJnaXN0c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9naXN0c3svZ2lzdF9pZH0iLCJzdGFycmVkX3VybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL3N0YXJyZWR7L293bmVy\nfXsvcmVwb30iLCJzdWJzY3JpcHRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vdXNlcnMvd0pvZW5uL3N1YnNjcmlwdGlvbnMiLCJvcmdhbml6\nYXRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pv\nZW5uL29yZ3MiLCJyZXBvc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3VzZXJzL3dKb2Vubi9yZXBvcyIsImV2ZW50c191cmwiOiJodHRwczovL2Fw\naS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9ldmVudHN7L3ByaXZhY3l9Iiwi\ncmVjZWl2ZWRfZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ndXNlcnMvd0pvZW5uL3JlY2VpdmVkX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwi\nc2l0ZV9hZG1pbiI6ZmFsc2V9LCJub2RlX2lkIjoiUkVfa3dET0ttQVk4czRI\na2VtbiIsInRhZ19uYW1lIjoidjEuMC4wIiwidGFyZ2V0X2NvbW1pdGlzaCI6\nIm1haW4iLCJuYW1lIjpudWxsLCJkcmFmdCI6ZmFsc2UsInByZXJlbGVhc2Ui\nOmZhbHNlLCJjcmVhdGVkX2F0IjoiMjAyMy0xMC0yN1QxOToyMjoxMFoiLCJw\ndWJsaXNoZWRfYXQiOiIyMDIzLTEwLTI3VDE5OjIyOjExWiIsImFzc2V0cyI6\nW10sInRhcmJhbGxfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy93Sm9lbm4vYW4tcmVwby90YXJiYWxsL3YxLjAuMCIsInppcGJhbGxfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVw\nby96aXBiYWxsL3YxLjAuMCIsImJvZHkiOm51bGx9\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:22:10 GMT"
+    },
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases/127003047/reactions",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJjb250ZW50IjoiKzEifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:22:11 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "998"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"5d8b09c6e9b4dd9e583e9f8415814bab9db0596670ea4e69b312b9acd3c81d91\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4965"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "35"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DD78:338D:E10C41:E351C5:653C0DE3"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6MTc5OTg3ODk4LCJub2RlX2lkIjoiUkVBX2xBZk9LbUFZOHM0SGtl\nbW56Z3E2WmJvIiwidXNlciI6eyJsb2dpbiI6IndKb2VubiIsImlkIjo3NTM4\nODg2OSwibm9kZV9pZCI6Ik1EUTZWWE5sY2pjMU16ZzRPRFk1IiwiYXZhdGFy\nX3VybCI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5jb20v\ndS83NTM4ODg2OT92PTQiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uIiwiaHRtbF91cmwiOiJo\ndHRwczovL2dpdGh1Yi5jb20vd0pvZW5uIiwiZm9sbG93ZXJzX3VybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2VycyIs\nImZvbGxvd2luZ191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vZ2lzdHN7L2dp\nc3RfaWR9Iiwic3RhcnJlZF91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3VzZXJzL3dKb2Vubi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwic3Vic2Ny\naXB0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dK\nb2Vubi9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9vcmdzIiwicmVwb3Nf\ndXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vcmVw\nb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vy\ncy93Sm9lbm4vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9yZWNl\naXZlZF9ldmVudHMiLCJ0eXBlIjoiVXNlciIsInNpdGVfYWRtaW4iOmZhbHNl\nfSwiY29udGVudCI6IisxIiwiY3JlYXRlZF9hdCI6IjIwMjMtMTAtMjdUMTk6\nMjI6MTFaIn0=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:22:10 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:22:11 GMT"
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            "delete_repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4964"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "36"
           ],
           "X-Ratelimit-Resource": [
             "core"
@@ -90,15 +795,15 @@
             "Accept-Encoding, Accept, X-Requested-With"
           ],
           "X-Github-Request-Id": [
-            "EB06:EFB1:18C28C6:18FEB91:652060A0"
+            "DD86:5CC1:E1BC62:E40311:653C0DE3"
           ]
         },
         "body": {
           "encoding": "UTF-8",
-          "base64_string": "eyJtZXNzYWdlIjoiQmFkIGNyZWRlbnRpYWxzIiwiZG9jdW1lbnRhdGlvbl91\ncmwiOiJodHRwczovL2RvY3MuZ2l0aHViLmNvbS9yZXN0In0=\n"
+          "base64_string": ""
         }
       },
-      "recorded_at": "Fri, 06 Oct 2023 19:31:44 GMT"
+      "recorded_at": "Fri, 27 Oct 2023 19:22:11 GMT"
     }
   ],
   "recorded_with": "VCR 6.2.0"

--- a/spec/cassettes/Octokit_Client_Reactions/with_repository/with_release/_delete_release_reaction/deletes_the_reaction.json
+++ b/spec/cassettes/Octokit_Client_Reactions/with_repository/with_release/_delete_release_reaction/deletes_the_reaction.json
@@ -1,0 +1,105 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/user/repos",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJhdXRvX2luaXQiOnRydWUsIm5hbWUiOiJhbi1yZXBvIn0=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 401,
+          "message": "Unauthorized"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 06 Oct 2023 19:31:43 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "80"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Ratelimit-Limit": [
+            "60"
+          ],
+          "X-Ratelimit-Remaining": [
+            "56"
+          ],
+          "X-Ratelimit-Reset": [
+            "1696623381"
+          ],
+          "X-Ratelimit-Used": [
+            "4"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "EB02:5F08:1AAEBB1:1AEAE30:6520609F"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJtZXNzYWdlIjoiQmFkIGNyZWRlbnRpYWxzIiwiZG9jdW1lbnRhdGlvbl91\ncmwiOiJodHRwczovL2RvY3MuZ2l0aHViLmNvbS9yZXN0In0=\n"
+        }
+      },
+      "recorded_at": "Fri, 06 Oct 2023 19:31:44 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/cassettes/Octokit_Client_Reactions/with_repository/with_release/_delete_release_reaction/deletes_the_reaction.json
+++ b/spec/cassettes/Octokit_Client_Reactions/with_repository/with_release/_delete_release_reaction/deletes_the_reaction.json
@@ -3,10 +3,10 @@
     {
       "request": {
         "method": "post",
-        "uri": "https://api.github.com/user/repos",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases/127002757/reactions",
         "body": {
           "encoding": "UTF-8",
-          "base64_string": "eyJhdXRvX2luaXQiOnRydWUsIm5hbWUiOiJhbi1yZXBvIn0=\n"
+          "base64_string": "eyJjb250ZW50IjoiKzEifQ==\n"
         },
         "headers": {
           "Accept": [
@@ -28,36 +28,161 @@
       },
       "response": {
         "status": {
-          "code": 401,
-          "message": "Unauthorized"
+          "code": 201,
+          "message": "Created"
         },
         "headers": {
           "Server": [
             "GitHub.com"
           ],
           "Date": [
-            "Fri, 06 Oct 2023 19:31:43 GMT"
+            "Fri, 27 Oct 2023 19:19:06 GMT"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "Content-Length": [
-            "80"
+            "998"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"5b39e114967e17d3039027c0555aaf9091ad752b04df3a269335f2a81826082f\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
           ],
           "X-Github-Media-Type": [
             "github.v3; format=json"
           ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
           "X-Ratelimit-Limit": [
-            "60"
+            "5000"
           ],
           "X-Ratelimit-Remaining": [
-            "56"
+            "4987"
           ],
           "X-Ratelimit-Reset": [
-            "1696623381"
+            "1698437937"
           ],
           "X-Ratelimit-Used": [
-            "4"
+            "13"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DDB8:3385:B3AA1A:B5D52F:653C0D2A"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6MTc5OTg3ODkwLCJub2RlX2lkIjoiUkVBX2xBZk9LbUFWUDg0SGtl\naUZ6Z3E2WmJJIiwidXNlciI6eyJsb2dpbiI6IndKb2VubiIsImlkIjo3NTM4\nODg2OSwibm9kZV9pZCI6Ik1EUTZWWE5sY2pjMU16ZzRPRFk1IiwiYXZhdGFy\nX3VybCI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5jb20v\ndS83NTM4ODg2OT92PTQiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uIiwiaHRtbF91cmwiOiJo\ndHRwczovL2dpdGh1Yi5jb20vd0pvZW5uIiwiZm9sbG93ZXJzX3VybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2VycyIs\nImZvbGxvd2luZ191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vZ2lzdHN7L2dp\nc3RfaWR9Iiwic3RhcnJlZF91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3VzZXJzL3dKb2Vubi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwic3Vic2Ny\naXB0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dK\nb2Vubi9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9vcmdzIiwicmVwb3Nf\ndXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vcmVw\nb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vy\ncy93Sm9lbm4vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9yZWNl\naXZlZF9ldmVudHMiLCJ0eXBlIjoiVXNlciIsInNpdGVfYWRtaW4iOmZhbHNl\nfSwiY29udGVudCI6IisxIiwiY3JlYXRlZF9hdCI6IjIwMjMtMTAtMjdUMTk6\nMTk6MDZaIn0=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:19:05 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/issues/127002757/reactions/179987890",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 404,
+          "message": "Not Found"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:19:06 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            "repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4986"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "14"
           ],
           "X-Ratelimit-Resource": [
             "core"
@@ -90,15 +215,800 @@
             "Accept-Encoding, Accept, X-Requested-With"
           ],
           "X-Github-Request-Id": [
-            "EB02:5F08:1AAEBB1:1AEAE30:6520609F"
+            "DDC2:13397:EA3BE4:EC779C:653C0D2A"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJtZXNzYWdlIjoiTm90IEZvdW5kIiwiZG9jdW1lbnRhdGlvbl91cmwiOiJo\ndHRwczovL2RvY3MuZ2l0aHViLmNvbS9yZXN0L3JlYWN0aW9ucy9yZWFjdGlv\nbnMjZGVsZXRlLWFuLWlzc3VlLXJlYWN0aW9uIn0=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:19:06 GMT"
+    },
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases/127002895/reactions",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJjb250ZW50IjoiKzEifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:20:40 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "998"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"36bcb56392b1b02536e33fc4df352265de60e6d85d655ee48043265e5a321b0f\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4978"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "22"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DD76:1B8D:61E2E3:632EA3:653C0D88"
           ]
         },
         "body": {
           "encoding": "UTF-8",
-          "base64_string": "eyJtZXNzYWdlIjoiQmFkIGNyZWRlbnRpYWxzIiwiZG9jdW1lbnRhdGlvbl91\ncmwiOiJodHRwczovL2RvY3MuZ2l0aHViLmNvbS9yZXN0In0=\n"
+          "base64_string": "eyJpZCI6MTc5OTg3ODk1LCJub2RlX2lkIjoiUkVBX2xBZk9LbUFYRzg0SGtl\na1B6Z3E2WmJjIiwidXNlciI6eyJsb2dpbiI6IndKb2VubiIsImlkIjo3NTM4\nODg2OSwibm9kZV9pZCI6Ik1EUTZWWE5sY2pjMU16ZzRPRFk1IiwiYXZhdGFy\nX3VybCI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5jb20v\ndS83NTM4ODg2OT92PTQiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uIiwiaHRtbF91cmwiOiJo\ndHRwczovL2dpdGh1Yi5jb20vd0pvZW5uIiwiZm9sbG93ZXJzX3VybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2VycyIs\nImZvbGxvd2luZ191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vZ2lzdHN7L2dp\nc3RfaWR9Iiwic3RhcnJlZF91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3VzZXJzL3dKb2Vubi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwic3Vic2Ny\naXB0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dK\nb2Vubi9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9vcmdzIiwicmVwb3Nf\ndXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vcmVw\nb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vy\ncy93Sm9lbm4vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9yZWNl\naXZlZF9ldmVudHMiLCJ0eXBlIjoiVXNlciIsInNpdGVfYWRtaW4iOmZhbHNl\nfSwiY29udGVudCI6IisxIiwiY3JlYXRlZF9hdCI6IjIwMjMtMTAtMjdUMTk6\nMjA6NDBaIn0=\n"
         }
       },
-      "recorded_at": "Fri, 06 Oct 2023 19:31:44 GMT"
+      "recorded_at": "Fri, 27 Oct 2023 19:20:39 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/issues/127002895/reactions/179987895",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 404,
+          "message": "Not Found"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:20:40 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            "repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4977"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "23"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "DD82:6EB2:B3EBB3:B61EDE:653C0D88"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "eyJtZXNzYWdlIjoiTm90IEZvdW5kIiwiZG9jdW1lbnRhdGlvbl91cmwiOiJo\ndHRwczovL2RvY3MuZ2l0aHViLmNvbS9yZXN0L3JlYWN0aW9ucy9yZWFjdGlv\nbnMjZGVsZXRlLWFuLWlzc3VlLXJlYWN0aW9uIn0=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:20:40 GMT"
+    },
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/user/repos",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJhdXRvX2luaXQiOnRydWUsIm5hbWUiOiJhbi1yZXBvIn0=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:22:13 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "5150"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"51dce5f69690fcfd886e2399ee8bc67095dc1ed65873ef7494c7ac815c07652c\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            "public_repo, repo"
+          ],
+          "Location": [
+            "https://api.github.com/repos/wJoenn/an-repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4963"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "37"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DD8E:0FCF:93AFCB:958C8B:653C0DE4"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6NzEwOTQwOTI2LCJub2RlX2lkIjoiUl9rZ0RPS21BWV9nIiwibmFt\nZSI6ImFuLXJlcG8iLCJmdWxsX25hbWUiOiJ3Sm9lbm4vYW4tcmVwbyIsInBy\naXZhdGUiOmZhbHNlLCJvd25lciI6eyJsb2dpbiI6IndKb2VubiIsImlkIjo3\nNTM4ODg2OSwibm9kZV9pZCI6Ik1EUTZWWE5sY2pjMU16ZzRPRFk1IiwiYXZh\ndGFyX3VybCI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5j\nb20vdS83NTM4ODg2OT92PTQiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uIiwiaHRtbF91cmwi\nOiJodHRwczovL2dpdGh1Yi5jb20vd0pvZW5uIiwiZm9sbG93ZXJzX3VybCI6\nImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2Vy\ncyIsImZvbGxvd2luZ191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Vz\nZXJzL3dKb2Vubi9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vZ2lzdHN7\nL2dpc3RfaWR9Iiwic3RhcnJlZF91cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3VzZXJzL3dKb2Vubi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwic3Vi\nc2NyaXB0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9vcmdzIiwicmVw\nb3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4v\ncmVwb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy93Sm9lbm4vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50\nc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9y\nZWNlaXZlZF9ldmVudHMiLCJ0eXBlIjoiVXNlciIsInNpdGVfYWRtaW4iOmZh\nbHNlfSwiaHRtbF91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vd0pvZW5uL2Fu\nLXJlcG8iLCJkZXNjcmlwdGlvbiI6bnVsbCwiZm9yayI6ZmFsc2UsInVybCI6\nImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8i\nLCJmb3Jrc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dK\nb2Vubi9hbi1yZXBvL2ZvcmtzIiwia2V5c191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2tleXN7L2tleV9pZH0i\nLCJjb2xsYWJvcmF0b3JzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3Mvd0pvZW5uL2FuLXJlcG8vY29sbGFib3JhdG9yc3svY29sbGFib3Jh\ndG9yfSIsInRlYW1zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3Mvd0pvZW5uL2FuLXJlcG8vdGVhbXMiLCJob29rc191cmwiOiJodHRwczov\nL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2hvb2tzIiwi\naXNzdWVfZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3Mvd0pvZW5uL2FuLXJlcG8vaXNzdWVzL2V2ZW50c3svbnVtYmVyfSIsImV2\nZW50c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vu\nbi9hbi1yZXBvL2V2ZW50cyIsImFzc2lnbmVlc191cmwiOiJodHRwczovL2Fw\naS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2Fzc2lnbmVlc3sv\ndXNlcn0iLCJicmFuY2hlc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2JyYW5jaGVzey9icmFuY2h9IiwidGFn\nc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9h\nbi1yZXBvL3RhZ3MiLCJibG9ic191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2dpdC9ibG9ic3svc2hhfSIsImdp\ndF90YWdzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3Mvd0pv\nZW5uL2FuLXJlcG8vZ2l0L3RhZ3N7L3NoYX0iLCJnaXRfcmVmc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2dp\ndC9yZWZzey9zaGF9IiwidHJlZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9naXQvdHJlZXN7L3NoYX0iLCJz\ndGF0dXNlc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dK\nb2Vubi9hbi1yZXBvL3N0YXR1c2VzL3tzaGF9IiwibGFuZ3VhZ2VzX3VybCI6\nImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8v\nbGFuZ3VhZ2VzIiwic3RhcmdhemVyc191cmwiOiJodHRwczovL2FwaS5naXRo\ndWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL3N0YXJnYXplcnMiLCJjb250\ncmlidXRvcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93\nSm9lbm4vYW4tcmVwby9jb250cmlidXRvcnMiLCJzdWJzY3JpYmVyc191cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBv\nL3N1YnNjcmliZXJzIiwic3Vic2NyaXB0aW9uX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8vc3Vic2NyaXB0aW9u\nIiwiY29tbWl0c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9z\nL3dKb2Vubi9hbi1yZXBvL2NvbW1pdHN7L3NoYX0iLCJnaXRfY29tbWl0c191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1y\nZXBvL2dpdC9jb21taXRzey9zaGF9IiwiY29tbWVudHNfdXJsIjoiaHR0cHM6\nLy9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9jb21tZW50\nc3svbnVtYmVyfSIsImlzc3VlX2NvbW1lbnRfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9pc3N1ZXMvY29tbWVu\ndHN7L251bWJlcn0iLCJjb250ZW50c191cmwiOiJodHRwczovL2FwaS5naXRo\ndWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2NvbnRlbnRzL3srcGF0aH0i\nLCJjb21wYXJlX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3Mv\nd0pvZW5uL2FuLXJlcG8vY29tcGFyZS97YmFzZX0uLi57aGVhZH0iLCJtZXJn\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4v\nYW4tcmVwby9tZXJnZXMiLCJhcmNoaXZlX3VybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8ve2FyY2hpdmVfZm9ybWF0\nfXsvcmVmfSIsImRvd25sb2Fkc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2Rvd25sb2FkcyIsImlzc3Vlc191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1y\nZXBvL2lzc3Vlc3svbnVtYmVyfSIsInB1bGxzX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8vcHVsbHN7L251bWJl\ncn0iLCJtaWxlc3RvbmVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3Mvd0pvZW5uL2FuLXJlcG8vbWlsZXN0b25lc3svbnVtYmVyfSIsIm5v\ndGlmaWNhdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy93Sm9lbm4vYW4tcmVwby9ub3RpZmljYXRpb25zez9zaW5jZSxhbGwscGFy\ndGljaXBhdGluZ30iLCJsYWJlbHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9sYWJlbHN7L25hbWV9IiwicmVs\nZWFzZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9l\nbm4vYW4tcmVwby9yZWxlYXNlc3svaWR9IiwiZGVwbG95bWVudHNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9k\nZXBsb3ltZW50cyIsImNyZWF0ZWRfYXQiOiIyMDIzLTEwLTI3VDE5OjIyOjEz\nWiIsInVwZGF0ZWRfYXQiOiIyMDIzLTEwLTI3VDE5OjIyOjEzWiIsInB1c2hl\nZF9hdCI6IjIwMjMtMTAtMjdUMTk6MjI6MTNaIiwiZ2l0X3VybCI6ImdpdDov\nL2dpdGh1Yi5jb20vd0pvZW5uL2FuLXJlcG8uZ2l0Iiwic3NoX3VybCI6Imdp\ndEBnaXRodWIuY29tOndKb2Vubi9hbi1yZXBvLmdpdCIsImNsb25lX3VybCI6\nImh0dHBzOi8vZ2l0aHViLmNvbS93Sm9lbm4vYW4tcmVwby5naXQiLCJzdm5f\ndXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL3dKb2Vubi9hbi1yZXBvIiwiaG9t\nZXBhZ2UiOm51bGwsInNpemUiOjAsInN0YXJnYXplcnNfY291bnQiOjAsIndh\ndGNoZXJzX2NvdW50IjowLCJsYW5ndWFnZSI6bnVsbCwiaGFzX2lzc3VlcyI6\ndHJ1ZSwiaGFzX3Byb2plY3RzIjp0cnVlLCJoYXNfZG93bmxvYWRzIjp0cnVl\nLCJoYXNfd2lraSI6dHJ1ZSwiaGFzX3BhZ2VzIjpmYWxzZSwiaGFzX2Rpc2N1\nc3Npb25zIjpmYWxzZSwiZm9ya3NfY291bnQiOjAsIm1pcnJvcl91cmwiOm51\nbGwsImFyY2hpdmVkIjpmYWxzZSwiZGlzYWJsZWQiOmZhbHNlLCJvcGVuX2lz\nc3Vlc19jb3VudCI6MCwibGljZW5zZSI6bnVsbCwiYWxsb3dfZm9ya2luZyI6\ndHJ1ZSwiaXNfdGVtcGxhdGUiOmZhbHNlLCJ3ZWJfY29tbWl0X3NpZ25vZmZf\ncmVxdWlyZWQiOmZhbHNlLCJ0b3BpY3MiOltdLCJ2aXNpYmlsaXR5IjoicHVi\nbGljIiwiZm9ya3MiOjAsIm9wZW5faXNzdWVzIjowLCJ3YXRjaGVycyI6MCwi\nZGVmYXVsdF9icmFuY2giOiJtYWluIiwicGVybWlzc2lvbnMiOnsiYWRtaW4i\nOnRydWUsIm1haW50YWluIjp0cnVlLCJwdXNoIjp0cnVlLCJ0cmlhZ2UiOnRy\ndWUsInB1bGwiOnRydWV9LCJhbGxvd19zcXVhc2hfbWVyZ2UiOnRydWUsImFs\nbG93X21lcmdlX2NvbW1pdCI6dHJ1ZSwiYWxsb3dfcmViYXNlX21lcmdlIjp0\ncnVlLCJhbGxvd19hdXRvX21lcmdlIjpmYWxzZSwiZGVsZXRlX2JyYW5jaF9v\nbl9tZXJnZSI6ZmFsc2UsImFsbG93X3VwZGF0ZV9icmFuY2giOmZhbHNlLCJ1\nc2Vfc3F1YXNoX3ByX3RpdGxlX2FzX2RlZmF1bHQiOmZhbHNlLCJzcXVhc2hf\nbWVyZ2VfY29tbWl0X21lc3NhZ2UiOiJDT01NSVRfTUVTU0FHRVMiLCJzcXVh\nc2hfbWVyZ2VfY29tbWl0X3RpdGxlIjoiQ09NTUlUX09SX1BSX1RJVExFIiwi\nbWVyZ2VfY29tbWl0X21lc3NhZ2UiOiJQUl9USVRMRSIsIm1lcmdlX2NvbW1p\ndF90aXRsZSI6Ik1FUkdFX01FU1NBR0UiLCJuZXR3b3JrX2NvdW50IjowLCJz\ndWJzY3JpYmVyc19jb3VudCI6MH0=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:22:13 GMT"
+    },
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJ0YWdfbmFtZSI6InYxLjAuMCJ9\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:22:14 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "1605"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"0b4485f387157827b5fa052a384d6b5e46f895b9b8a4cf395b9c7a7c0b601578\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            "repo"
+          ],
+          "Location": [
+            "https://api.github.com/repos/wJoenn/an-repo/releases/127003058"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4962"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "38"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DDA2:F519:C9CA31:CC0948:653C0DE5"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJ1cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9h\nbi1yZXBvL3JlbGVhc2VzLzEyNzAwMzA1OCIsImFzc2V0c191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL3JlbGVh\nc2VzLzEyNzAwMzA1OC9hc3NldHMiLCJ1cGxvYWRfdXJsIjoiaHR0cHM6Ly91\ncGxvYWRzLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8vcmVsZWFz\nZXMvMTI3MDAzMDU4L2Fzc2V0c3s/bmFtZSxsYWJlbH0iLCJodG1sX3VybCI6\nImh0dHBzOi8vZ2l0aHViLmNvbS93Sm9lbm4vYW4tcmVwby9yZWxlYXNlcy90\nYWcvdjEuMC4wIiwiaWQiOjEyNzAwMzA1OCwiYXV0aG9yIjp7ImxvZ2luIjoi\nd0pvZW5uIiwiaWQiOjc1Mzg4ODY5LCJub2RlX2lkIjoiTURRNlZYTmxjamMx\nTXpnNE9EWTUiLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1\nYnVzZXJjb250ZW50LmNvbS91Lzc1Mzg4ODY5P3Y9NCIsImdyYXZhdGFyX2lk\nIjoiIiwidXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9l\nbm4iLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS93Sm9lbm4iLCJm\nb2xsb3dlcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93\nSm9lbm4vZm9sbG93ZXJzIiwiZm9sbG93aW5nX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2luZ3svb3RoZXJfdXNl\ncn0iLCJnaXN0c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9naXN0c3svZ2lzdF9pZH0iLCJzdGFycmVkX3VybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL3N0YXJyZWR7L293bmVy\nfXsvcmVwb30iLCJzdWJzY3JpcHRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vdXNlcnMvd0pvZW5uL3N1YnNjcmlwdGlvbnMiLCJvcmdhbml6\nYXRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pv\nZW5uL29yZ3MiLCJyZXBvc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3VzZXJzL3dKb2Vubi9yZXBvcyIsImV2ZW50c191cmwiOiJodHRwczovL2Fw\naS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9ldmVudHN7L3ByaXZhY3l9Iiwi\ncmVjZWl2ZWRfZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ndXNlcnMvd0pvZW5uL3JlY2VpdmVkX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwi\nc2l0ZV9hZG1pbiI6ZmFsc2V9LCJub2RlX2lkIjoiUkVfa3dET0ttQVlfczRI\na2VteSIsInRhZ19uYW1lIjoidjEuMC4wIiwidGFyZ2V0X2NvbW1pdGlzaCI6\nIm1haW4iLCJuYW1lIjpudWxsLCJkcmFmdCI6ZmFsc2UsInByZXJlbGVhc2Ui\nOmZhbHNlLCJjcmVhdGVkX2F0IjoiMjAyMy0xMC0yN1QxOToyMjoxM1oiLCJw\ndWJsaXNoZWRfYXQiOiIyMDIzLTEwLTI3VDE5OjIyOjE0WiIsImFzc2V0cyI6\nW10sInRhcmJhbGxfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy93Sm9lbm4vYW4tcmVwby90YXJiYWxsL3YxLjAuMCIsInppcGJhbGxfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVw\nby96aXBiYWxsL3YxLjAuMCIsImJvZHkiOm51bGx9\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:22:13 GMT"
+    },
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases/127003058/reactions",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJjb250ZW50IjoiKzEifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:22:14 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "998"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"1790d35e199606fb39bde2db05b16ea5ec4db86c7942b3ff49ffbf7a19d578b7\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4961"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "39"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DDA4:1B8D:62FA6E:6449DC:653C0DE6"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6MTc5OTg3ODk5LCJub2RlX2lkIjoiUkVBX2xBZk9LbUFZX3M0SGtl\nbXl6Z3E2WmJzIiwidXNlciI6eyJsb2dpbiI6IndKb2VubiIsImlkIjo3NTM4\nODg2OSwibm9kZV9pZCI6Ik1EUTZWWE5sY2pjMU16ZzRPRFk1IiwiYXZhdGFy\nX3VybCI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5jb20v\ndS83NTM4ODg2OT92PTQiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uIiwiaHRtbF91cmwiOiJo\ndHRwczovL2dpdGh1Yi5jb20vd0pvZW5uIiwiZm9sbG93ZXJzX3VybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2VycyIs\nImZvbGxvd2luZ191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vZ2lzdHN7L2dp\nc3RfaWR9Iiwic3RhcnJlZF91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3VzZXJzL3dKb2Vubi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwic3Vic2Ny\naXB0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dK\nb2Vubi9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9vcmdzIiwicmVwb3Nf\ndXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vcmVw\nb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vy\ncy93Sm9lbm4vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9yZWNl\naXZlZF9ldmVudHMiLCJ0eXBlIjoiVXNlciIsInNpdGVfYWRtaW4iOmZhbHNl\nfSwiY29udGVudCI6IisxIiwiY3JlYXRlZF9hdCI6IjIwMjMtMTAtMjdUMTk6\nMjI6MTRaIn0=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:22:14 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases/127003058/reactions/179987899",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:22:15 GMT"
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4960"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "40"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "DDAC:1BD6:E58112:E7C631:653C0DE6"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:22:14 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:22:15 GMT"
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            "delete_repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4959"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "41"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "DDB0:111AA:B4C184:B6F8E3:653C0DE7"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": ""
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:22:14 GMT"
     }
   ],
   "recorded_with": "VCR 6.2.0"

--- a/spec/cassettes/Octokit_Client_Reactions/with_repository/with_release/_release_reactions/returns_an_Array_of_reactions.json
+++ b/spec/cassettes/Octokit_Client_Reactions/with_repository/with_release/_release_reactions/returns_an_Array_of_reactions.json
@@ -1,0 +1,105 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/user/repos",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJhdXRvX2luaXQiOnRydWUsIm5hbWUiOiJhbi1yZXBvIn0=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 401,
+          "message": "Unauthorized"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 06 Oct 2023 19:31:44 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "80"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Ratelimit-Limit": [
+            "60"
+          ],
+          "X-Ratelimit-Remaining": [
+            "55"
+          ],
+          "X-Ratelimit-Reset": [
+            "1696623381"
+          ],
+          "X-Ratelimit-Used": [
+            "5"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Vary": [
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Github-Request-Id": [
+            "EB04:0FCF:186EA04:18AA590:652060A0"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJtZXNzYWdlIjoiQmFkIGNyZWRlbnRpYWxzIiwiZG9jdW1lbnRhdGlvbl91\ncmwiOiJodHRwczovL2RvY3MuZ2l0aHViLmNvbS9yZXN0In0=\n"
+        }
+      },
+      "recorded_at": "Fri, 06 Oct 2023 19:31:44 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.2.0"
+}

--- a/spec/cassettes/Octokit_Client_Reactions/with_repository/with_release/_release_reactions/returns_an_Array_of_reactions.json
+++ b/spec/cassettes/Octokit_Client_Reactions/with_repository/with_release/_release_reactions/returns_an_Array_of_reactions.json
@@ -3,6 +3,354 @@
     {
       "request": {
         "method": "post",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases/127002745/reactions",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJjb250ZW50IjoiKzEifQ==\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:18:59 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "998"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"f1bd6019fdf0a00fad1b9b06f344a9f3f0443281e7d6b56320b4f433d55025f2\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4997"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "3"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DD80:D74E:CB514E:CD82AE:653C0D22"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6MTc5OTg3ODg4LCJub2RlX2lkIjoiUkVBX2xBZk9LbUFWRk00SGtl\naDV6Z3E2WmJBIiwidXNlciI6eyJsb2dpbiI6IndKb2VubiIsImlkIjo3NTM4\nODg2OSwibm9kZV9pZCI6Ik1EUTZWWE5sY2pjMU16ZzRPRFk1IiwiYXZhdGFy\nX3VybCI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5jb20v\ndS83NTM4ODg2OT92PTQiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uIiwiaHRtbF91cmwiOiJo\ndHRwczovL2dpdGh1Yi5jb20vd0pvZW5uIiwiZm9sbG93ZXJzX3VybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2VycyIs\nImZvbGxvd2luZ191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vZ2lzdHN7L2dp\nc3RfaWR9Iiwic3RhcnJlZF91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3VzZXJzL3dKb2Vubi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwic3Vic2Ny\naXB0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dK\nb2Vubi9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9vcmdzIiwicmVwb3Nf\ndXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vcmVw\nb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vy\ncy93Sm9lbm4vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9yZWNl\naXZlZF9ldmVudHMiLCJ0eXBlIjoiVXNlciIsInNpdGVfYWRtaW4iOmZhbHNl\nfSwiY29udGVudCI6IisxIiwiY3JlYXRlZF9hdCI6IjIwMjMtMTAtMjdUMTk6\nMTg6NThaIn0=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:18:58 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases/127002745/reactions",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:18:59 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"f4bf82b0a3c0a8011470305b68c261ddd5ca366e5423b493253c08e4ab0ff9c9\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4996"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "4"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DD8E:0FCF:914918:931E08:653C0D23"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "W3siaWQiOjE3OTk4Nzg4OCwibm9kZV9pZCI6IlJFQV9sQWZPS21BVkZNNEhr\nZWg1emdxNlpiQSIsInVzZXIiOnsibG9naW4iOiJ3Sm9lbm4iLCJpZCI6NzUz\nODg4NjksIm5vZGVfaWQiOiJNRFE2VlhObGNqYzFNemc0T0RZNSIsImF2YXRh\ncl91cmwiOiJodHRwczovL2F2YXRhcnMuZ2l0aHVidXNlcmNvbnRlbnQuY29t\nL3UvNzUzODg4Njk/dj00IiwiZ3JhdmF0YXJfaWQiOiIiLCJ1cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2VubiIsImh0bWxfdXJsIjoi\naHR0cHM6Ly9naXRodWIuY29tL3dKb2VubiIsImZvbGxvd2Vyc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9mb2xsb3dlcnMi\nLCJmb2xsb3dpbmdfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vy\ncy93Sm9lbm4vZm9sbG93aW5ney9vdGhlcl91c2VyfSIsImdpc3RzX3VybCI6\nImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2dpc3Rzey9n\naXN0X2lkfSIsInN0YXJyZWRfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNv\nbS91c2Vycy93Sm9lbm4vc3RhcnJlZHsvb3duZXJ9ey9yZXBvfSIsInN1YnNj\ncmlwdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93\nSm9lbm4vc3Vic2NyaXB0aW9ucyIsIm9yZ2FuaXphdGlvbnNfdXJsIjoiaHR0\ncHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vb3JncyIsInJlcG9z\nX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL3Jl\ncG9zIiwiZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNl\ncnMvd0pvZW5uL2V2ZW50c3svcHJpdmFjeX0iLCJyZWNlaXZlZF9ldmVudHNf\ndXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vcmVj\nZWl2ZWRfZXZlbnRzIiwidHlwZSI6IlVzZXIiLCJzaXRlX2FkbWluIjpmYWxz\nZX0sImNvbnRlbnQiOiIrMSIsImNyZWF0ZWRfYXQiOiIyMDIzLTEwLTI3VDE5\nOjE4OjU4WiJ9XQ==\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:18:58 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases/127002902/reactions",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:20:44 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"e215f317ac824fcf9eb320886d73a82d1d944b2193e20750d30971b9500c1b79\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4973"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "27"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DDA6:A793:645B77:65A75E:653C0D8C"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "W10=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:20:43 GMT"
+    },
+    {
+      "request": {
+        "method": "post",
         "uri": "https://api.github.com/user/repos",
         "body": {
           "encoding": "UTF-8",
@@ -28,36 +376,393 @@
       },
       "response": {
         "status": {
-          "code": 401,
-          "message": "Unauthorized"
+          "code": 201,
+          "message": "Created"
         },
         "headers": {
           "Server": [
             "GitHub.com"
           ],
           "Date": [
-            "Fri, 06 Oct 2023 19:31:44 GMT"
+            "Fri, 27 Oct 2023 19:22:07 GMT"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "Content-Length": [
-            "80"
+            "5150"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"ef6ac1f49fae7b940b48a585bc536c67ba114bca3c308cf9f7c8aed87c295cde\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            "public_repo, repo"
+          ],
+          "Location": [
+            "https://api.github.com/repos/wJoenn/an-repo"
           ],
           "X-Github-Media-Type": [
             "github.v3; format=json"
           ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
           "X-Ratelimit-Limit": [
-            "60"
+            "5000"
           ],
           "X-Ratelimit-Remaining": [
-            "55"
+            "4971"
           ],
           "X-Ratelimit-Reset": [
-            "1696623381"
+            "1698437937"
           ],
           "X-Ratelimit-Used": [
-            "5"
+            "29"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DD8A:9626:1028F58:104D604:653C0DDE"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJpZCI6NzEwOTQwODk1LCJub2RlX2lkIjoiUl9rZ0RPS21BWTN3IiwibmFt\nZSI6ImFuLXJlcG8iLCJmdWxsX25hbWUiOiJ3Sm9lbm4vYW4tcmVwbyIsInBy\naXZhdGUiOmZhbHNlLCJvd25lciI6eyJsb2dpbiI6IndKb2VubiIsImlkIjo3\nNTM4ODg2OSwibm9kZV9pZCI6Ik1EUTZWWE5sY2pjMU16ZzRPRFk1IiwiYXZh\ndGFyX3VybCI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5j\nb20vdS83NTM4ODg2OT92PTQiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uIiwiaHRtbF91cmwi\nOiJodHRwczovL2dpdGh1Yi5jb20vd0pvZW5uIiwiZm9sbG93ZXJzX3VybCI6\nImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2Vy\ncyIsImZvbGxvd2luZ191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Vz\nZXJzL3dKb2Vubi9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4vZ2lzdHN7\nL2dpc3RfaWR9Iiwic3RhcnJlZF91cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3VzZXJzL3dKb2Vubi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwic3Vi\nc2NyaXB0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9vcmdzIiwicmVw\nb3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9lbm4v\ncmVwb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy93Sm9lbm4vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50\nc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9y\nZWNlaXZlZF9ldmVudHMiLCJ0eXBlIjoiVXNlciIsInNpdGVfYWRtaW4iOmZh\nbHNlfSwiaHRtbF91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vd0pvZW5uL2Fu\nLXJlcG8iLCJkZXNjcmlwdGlvbiI6bnVsbCwiZm9yayI6ZmFsc2UsInVybCI6\nImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8i\nLCJmb3Jrc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dK\nb2Vubi9hbi1yZXBvL2ZvcmtzIiwia2V5c191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2tleXN7L2tleV9pZH0i\nLCJjb2xsYWJvcmF0b3JzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3Mvd0pvZW5uL2FuLXJlcG8vY29sbGFib3JhdG9yc3svY29sbGFib3Jh\ndG9yfSIsInRlYW1zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3Mvd0pvZW5uL2FuLXJlcG8vdGVhbXMiLCJob29rc191cmwiOiJodHRwczov\nL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2hvb2tzIiwi\naXNzdWVfZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3Mvd0pvZW5uL2FuLXJlcG8vaXNzdWVzL2V2ZW50c3svbnVtYmVyfSIsImV2\nZW50c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vu\nbi9hbi1yZXBvL2V2ZW50cyIsImFzc2lnbmVlc191cmwiOiJodHRwczovL2Fw\naS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2Fzc2lnbmVlc3sv\ndXNlcn0iLCJicmFuY2hlc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2JyYW5jaGVzey9icmFuY2h9IiwidGFn\nc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9h\nbi1yZXBvL3RhZ3MiLCJibG9ic191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2dpdC9ibG9ic3svc2hhfSIsImdp\ndF90YWdzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3Mvd0pv\nZW5uL2FuLXJlcG8vZ2l0L3RhZ3N7L3NoYX0iLCJnaXRfcmVmc191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2dp\ndC9yZWZzey9zaGF9IiwidHJlZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9naXQvdHJlZXN7L3NoYX0iLCJz\ndGF0dXNlc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dK\nb2Vubi9hbi1yZXBvL3N0YXR1c2VzL3tzaGF9IiwibGFuZ3VhZ2VzX3VybCI6\nImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8v\nbGFuZ3VhZ2VzIiwic3RhcmdhemVyc191cmwiOiJodHRwczovL2FwaS5naXRo\ndWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL3N0YXJnYXplcnMiLCJjb250\ncmlidXRvcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93\nSm9lbm4vYW4tcmVwby9jb250cmlidXRvcnMiLCJzdWJzY3JpYmVyc191cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBv\nL3N1YnNjcmliZXJzIiwic3Vic2NyaXB0aW9uX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8vc3Vic2NyaXB0aW9u\nIiwiY29tbWl0c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9z\nL3dKb2Vubi9hbi1yZXBvL2NvbW1pdHN7L3NoYX0iLCJnaXRfY29tbWl0c191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1y\nZXBvL2dpdC9jb21taXRzey9zaGF9IiwiY29tbWVudHNfdXJsIjoiaHR0cHM6\nLy9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9jb21tZW50\nc3svbnVtYmVyfSIsImlzc3VlX2NvbW1lbnRfdXJsIjoiaHR0cHM6Ly9hcGku\nZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9pc3N1ZXMvY29tbWVu\ndHN7L251bWJlcn0iLCJjb250ZW50c191cmwiOiJodHRwczovL2FwaS5naXRo\ndWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2NvbnRlbnRzL3srcGF0aH0i\nLCJjb21wYXJlX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3Mv\nd0pvZW5uL2FuLXJlcG8vY29tcGFyZS97YmFzZX0uLi57aGVhZH0iLCJtZXJn\nZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4v\nYW4tcmVwby9tZXJnZXMiLCJhcmNoaXZlX3VybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8ve2FyY2hpdmVfZm9ybWF0\nfXsvcmVmfSIsImRvd25sb2Fkc191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL2Rvd25sb2FkcyIsImlzc3Vlc191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1y\nZXBvL2lzc3Vlc3svbnVtYmVyfSIsInB1bGxzX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8vcHVsbHN7L251bWJl\ncn0iLCJtaWxlc3RvbmVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3Mvd0pvZW5uL2FuLXJlcG8vbWlsZXN0b25lc3svbnVtYmVyfSIsIm5v\ndGlmaWNhdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy93Sm9lbm4vYW4tcmVwby9ub3RpZmljYXRpb25zez9zaW5jZSxhbGwscGFy\ndGljaXBhdGluZ30iLCJsYWJlbHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9sYWJlbHN7L25hbWV9IiwicmVs\nZWFzZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9l\nbm4vYW4tcmVwby9yZWxlYXNlc3svaWR9IiwiZGVwbG95bWVudHNfdXJsIjoi\naHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVwby9k\nZXBsb3ltZW50cyIsImNyZWF0ZWRfYXQiOiIyMDIzLTEwLTI3VDE5OjIyOjA2\nWiIsInVwZGF0ZWRfYXQiOiIyMDIzLTEwLTI3VDE5OjIyOjA3WiIsInB1c2hl\nZF9hdCI6IjIwMjMtMTAtMjdUMTk6MjI6MDZaIiwiZ2l0X3VybCI6ImdpdDov\nL2dpdGh1Yi5jb20vd0pvZW5uL2FuLXJlcG8uZ2l0Iiwic3NoX3VybCI6Imdp\ndEBnaXRodWIuY29tOndKb2Vubi9hbi1yZXBvLmdpdCIsImNsb25lX3VybCI6\nImh0dHBzOi8vZ2l0aHViLmNvbS93Sm9lbm4vYW4tcmVwby5naXQiLCJzdm5f\ndXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL3dKb2Vubi9hbi1yZXBvIiwiaG9t\nZXBhZ2UiOm51bGwsInNpemUiOjAsInN0YXJnYXplcnNfY291bnQiOjAsIndh\ndGNoZXJzX2NvdW50IjowLCJsYW5ndWFnZSI6bnVsbCwiaGFzX2lzc3VlcyI6\ndHJ1ZSwiaGFzX3Byb2plY3RzIjp0cnVlLCJoYXNfZG93bmxvYWRzIjp0cnVl\nLCJoYXNfd2lraSI6dHJ1ZSwiaGFzX3BhZ2VzIjpmYWxzZSwiaGFzX2Rpc2N1\nc3Npb25zIjpmYWxzZSwiZm9ya3NfY291bnQiOjAsIm1pcnJvcl91cmwiOm51\nbGwsImFyY2hpdmVkIjpmYWxzZSwiZGlzYWJsZWQiOmZhbHNlLCJvcGVuX2lz\nc3Vlc19jb3VudCI6MCwibGljZW5zZSI6bnVsbCwiYWxsb3dfZm9ya2luZyI6\ndHJ1ZSwiaXNfdGVtcGxhdGUiOmZhbHNlLCJ3ZWJfY29tbWl0X3NpZ25vZmZf\ncmVxdWlyZWQiOmZhbHNlLCJ0b3BpY3MiOltdLCJ2aXNpYmlsaXR5IjoicHVi\nbGljIiwiZm9ya3MiOjAsIm9wZW5faXNzdWVzIjowLCJ3YXRjaGVycyI6MCwi\nZGVmYXVsdF9icmFuY2giOiJtYWluIiwicGVybWlzc2lvbnMiOnsiYWRtaW4i\nOnRydWUsIm1haW50YWluIjp0cnVlLCJwdXNoIjp0cnVlLCJ0cmlhZ2UiOnRy\ndWUsInB1bGwiOnRydWV9LCJhbGxvd19zcXVhc2hfbWVyZ2UiOnRydWUsImFs\nbG93X21lcmdlX2NvbW1pdCI6dHJ1ZSwiYWxsb3dfcmViYXNlX21lcmdlIjp0\ncnVlLCJhbGxvd19hdXRvX21lcmdlIjpmYWxzZSwiZGVsZXRlX2JyYW5jaF9v\nbl9tZXJnZSI6ZmFsc2UsImFsbG93X3VwZGF0ZV9icmFuY2giOmZhbHNlLCJ1\nc2Vfc3F1YXNoX3ByX3RpdGxlX2FzX2RlZmF1bHQiOmZhbHNlLCJzcXVhc2hf\nbWVyZ2VfY29tbWl0X21lc3NhZ2UiOiJDT01NSVRfTUVTU0FHRVMiLCJzcXVh\nc2hfbWVyZ2VfY29tbWl0X3RpdGxlIjoiQ09NTUlUX09SX1BSX1RJVExFIiwi\nbWVyZ2VfY29tbWl0X21lc3NhZ2UiOiJQUl9USVRMRSIsIm1lcmdlX2NvbW1p\ndF90aXRsZSI6Ik1FUkdFX01FU1NBR0UiLCJuZXR3b3JrX2NvdW50IjowLCJz\ndWJzY3JpYmVyc19jb3VudCI6MH0=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:22:06 GMT"
+    },
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJ0YWdfbmFtZSI6InYxLjAuMCJ9\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:22:07 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "1605"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"2e01f0b343dd06c21c5ba34f798ec6ee3a1128093a208a6a87df3f2922a892d1\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            "repo"
+          ],
+          "Location": [
+            "https://api.github.com/repos/wJoenn/an-repo/releases/127003044"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4970"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "30"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DD8C:CCF7:F07B70:F2C44F:653C0DDF"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "eyJ1cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9h\nbi1yZXBvL3JlbGVhc2VzLzEyNzAwMzA0NCIsImFzc2V0c191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zL3dKb2Vubi9hbi1yZXBvL3JlbGVh\nc2VzLzEyNzAwMzA0NC9hc3NldHMiLCJ1cGxvYWRfdXJsIjoiaHR0cHM6Ly91\ncGxvYWRzLmdpdGh1Yi5jb20vcmVwb3Mvd0pvZW5uL2FuLXJlcG8vcmVsZWFz\nZXMvMTI3MDAzMDQ0L2Fzc2V0c3s/bmFtZSxsYWJlbH0iLCJodG1sX3VybCI6\nImh0dHBzOi8vZ2l0aHViLmNvbS93Sm9lbm4vYW4tcmVwby9yZWxlYXNlcy90\nYWcvdjEuMC4wIiwiaWQiOjEyNzAwMzA0NCwiYXV0aG9yIjp7ImxvZ2luIjoi\nd0pvZW5uIiwiaWQiOjc1Mzg4ODY5LCJub2RlX2lkIjoiTURRNlZYTmxjamMx\nTXpnNE9EWTUiLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9hdmF0YXJzLmdpdGh1\nYnVzZXJjb250ZW50LmNvbS91Lzc1Mzg4ODY5P3Y9NCIsImdyYXZhdGFyX2lk\nIjoiIiwidXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93Sm9l\nbm4iLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS93Sm9lbm4iLCJm\nb2xsb3dlcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy93\nSm9lbm4vZm9sbG93ZXJzIiwiZm9sbG93aW5nX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL2ZvbGxvd2luZ3svb3RoZXJfdXNl\ncn0iLCJnaXN0c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nL3dKb2Vubi9naXN0c3svZ2lzdF9pZH0iLCJzdGFycmVkX3VybCI6Imh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pvZW5uL3N0YXJyZWR7L293bmVy\nfXsvcmVwb30iLCJzdWJzY3JpcHRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vdXNlcnMvd0pvZW5uL3N1YnNjcmlwdGlvbnMiLCJvcmdhbml6\nYXRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvd0pv\nZW5uL29yZ3MiLCJyZXBvc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3VzZXJzL3dKb2Vubi9yZXBvcyIsImV2ZW50c191cmwiOiJodHRwczovL2Fw\naS5naXRodWIuY29tL3VzZXJzL3dKb2Vubi9ldmVudHN7L3ByaXZhY3l9Iiwi\ncmVjZWl2ZWRfZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ndXNlcnMvd0pvZW5uL3JlY2VpdmVkX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwi\nc2l0ZV9hZG1pbiI6ZmFsc2V9LCJub2RlX2lkIjoiUkVfa3dET0ttQVkzODRI\na2VtayIsInRhZ19uYW1lIjoidjEuMC4wIiwidGFyZ2V0X2NvbW1pdGlzaCI6\nIm1haW4iLCJuYW1lIjpudWxsLCJkcmFmdCI6ZmFsc2UsInByZXJlbGVhc2Ui\nOmZhbHNlLCJjcmVhdGVkX2F0IjoiMjAyMy0xMC0yN1QxOToyMjowNloiLCJw\ndWJsaXNoZWRfYXQiOiIyMDIzLTEwLTI3VDE5OjIyOjA3WiIsImFzc2V0cyI6\nW10sInRhcmJhbGxfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBv\ncy93Sm9lbm4vYW4tcmVwby90YXJiYWxsL3YxLjAuMCIsInppcGJhbGxfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy93Sm9lbm4vYW4tcmVw\nby96aXBiYWxsL3YxLjAuMCIsImJvZHkiOm51bGx9\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:22:07 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo/releases/127003044/reactions",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:22:08 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "\"e215f317ac824fcf9eb320886d73a82d1d944b2193e20750d30971b9500c1b79\""
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4969"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "31"
+          ],
+          "X-Ratelimit-Resource": [
+            "core"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "DD9C:CCF7:F07E72:F2C739:653C0DE0"
+          ]
+        },
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "W10=\n"
+        }
+      },
+      "recorded_at": "Fri, 27 Oct 2023 19:22:07 GMT"
+    },
+    {
+      "request": {
+        "method": "delete",
+        "uri": "https://api.github.com/repos/wJoenn/an-repo",
+        "body": {
+          "encoding": "UTF-8",
+          "base64_string": "e30=\n"
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 7.2.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "token <<ACCESS_TOKEN>>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Fri, 27 Oct 2023 19:22:08 GMT"
+          ],
+          "X-Oauth-Scopes": [
+            "admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            "delete_repo"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4968"
+          ],
+          "X-Ratelimit-Reset": [
+            "1698437937"
+          ],
+          "X-Ratelimit-Used": [
+            "32"
           ],
           "X-Ratelimit-Resource": [
             "core"
@@ -90,15 +795,15 @@
             "Accept-Encoding, Accept, X-Requested-With"
           ],
           "X-Github-Request-Id": [
-            "EB04:0FCF:186EA04:18AA590:652060A0"
+            "DDA8:13397:ECFB06:EF3E4E:653C0DE0"
           ]
         },
         "body": {
           "encoding": "UTF-8",
-          "base64_string": "eyJtZXNzYWdlIjoiQmFkIGNyZWRlbnRpYWxzIiwiZG9jdW1lbnRhdGlvbl91\ncmwiOiJodHRwczovL2RvY3MuZ2l0aHViLmNvbS9yZXN0In0=\n"
+          "base64_string": ""
         }
       },
-      "recorded_at": "Fri, 06 Oct 2023 19:31:44 GMT"
+      "recorded_at": "Fri, 27 Oct 2023 19:22:08 GMT"
     }
   ],
   "recorded_with": "VCR 6.2.0"

--- a/spec/octokit/client/reactions_spec.rb
+++ b/spec/octokit/client/reactions_spec.rb
@@ -148,7 +148,6 @@ describe Octokit::Client::Reactions do
     context 'with release' do
       before do
         @release = @client.create_release(@repo.full_name, 'v1.0.0')
-        @reaction = @client.create_release_reaction(@repo.full_name, @release.id, '+1')
       end
 
       describe '.release_reactions' do
@@ -169,8 +168,9 @@ describe Octokit::Client::Reactions do
 
       describe '.delete_release_reaction' do
         it 'deletes the reaction' do
-          @client.delete_issue_reaction(@repo.full_name, @release.id, @reaction.id)
-          assert_requested :delete, github_url("/repos/#{@repo.full_name}/releases/#{@release.id}/reactions/#{@reaction.id}")
+          reaction = @client.create_release_reaction(@repo.full_name, @release.id, '+1')
+          @client.delete_release_reaction(@repo.full_name, @release.id, reaction.id)
+          assert_requested :delete, github_url("/repos/#{@repo.full_name}/releases/#{@release.id}/reactions/#{reaction.id}")
         end
       end # .delete_release_reaction
     end # with release

--- a/spec/octokit/client/reactions_spec.rb
+++ b/spec/octokit/client/reactions_spec.rb
@@ -144,5 +144,35 @@ describe Octokit::Client::Reactions do
         end # .create_pull_request_review_comment_reaction
       end # with pull request review comment
     end # with pull request
+
+    context 'with release' do
+      before do
+        @release = @client.create_release(@repo.full_name, 'v1.0.0')
+        @reaction = @client.create_release_reaction(@repo.full_name, @release.id, '+1')
+      end
+
+      describe '.release_reactions' do
+        it 'returns an Array of reactions' do
+          reactions = @client.release_reactions(@repo.full_name, @release.id)
+          expect(reactions).to be_kind_of Array
+          assert_requested :get, github_url("/repos/#{@repo.full_name}/releases/#{@release.id}/reactions")
+        end
+      end # .release_reactions
+
+      describe '.create_release_reaction' do
+        it 'creates a reaction' do
+          reaction = @client.create_release_reaction(@repo.full_name, @release.id, '+1')
+          expect(reaction.content).to eql('+1')
+          assert_requested :post, github_url("/repos/#{@repo.full_name}/releases/#{@release.id}/reactions")
+        end
+      end # .create_release_reaction
+
+      describe '.delete_release_reaction' do
+        it 'deletes the reaction' do
+          @client.delete_issue_reaction(@repo.full_name, @release.id, @reaction.id)
+          assert_requested :delete, github_url("/repos/#{@repo.full_name}/releases/#{@release.id}/reactions/#{@reaction.id}")
+        end
+      end # .delete_release_reaction
+    end # with release
   end # with repository
 end


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1633

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* There were no endpoints to get a release's reactions, create a release reaction or delete a release reaction

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* I added those endpoints to the `Client::Reactions` module

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

I'm having an issue trying to run the tests I've written.
I've exported a `OCTOKIT_TEST_GITHUB_TOKEN` with a new token I've created before forking the app (the token has all the rights I could give it) but despite doing that I get a `Octokit::Unauthorized: POST https://api.github.com/user/repos: 401 - Bad credentials` error.

I've tried another token that I use in my personal repos and it fails too so I don't think the issue comes from the tokens but probably from something I haven't set up proprelly.

Because of that I haven't been able to assert passing tests and complete coverage yet.

My set up process was to fork the repo then
```bash
git clone ...
cd octokit.rb
script/bootstrap
export OCTOKIT_TEST_GITHUB_TOKEN=...
script/test
```
![image](https://github.com/octokit/octokit.rb/assets/75388869/32384779-6059-4964-9113-311573d38772)