### PR TITLE
Drop refs to `create_authorization` from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,15 +213,7 @@ user.login
 # => "defunkt"
 ```
 
-You can [create access tokens through your GitHub Account Settings](https://help.github.com/articles/creating-an-access-token-for-command-line-use)
-or with a basic authenticated Octokit client:
-
-```ruby
-client = Octokit::Client.new(:login => 'defunkt', :password => 'c0d3b4ssssss!')
-
-client.create_authorization(:scopes => ["user"], :note => "Name of token")
-# => <your new oauth token>
-```
+You can [create access tokens through your GitHub Account Settings](https://help.github.com/articles/creating-an-access-token-for-command-line-use).
 
 ### Two-Factor Authentication
 
@@ -235,18 +227,6 @@ client = Octokit::Client.new \
   :password => 'c0d3b4ssssss!'
 
 user = client.user("defunkt", :headers => { "X-GitHub-OTP" => "<your 2FA token>" })
-```
-
-As you can imagine, this gets annoying quickly since two-factor auth tokens are very short lived. So it is recommended to create an oauth token for the user to communicate with the API:
-
-```ruby
-client = Octokit::Client.new \
-  :login    => 'defunkt',
-  :password => 'c0d3b4ssssss!'
-
-client.create_authorization(:scopes => ["user"], :note => "Name of token",
-                            :headers => { "X-GitHub-OTP" => "<your 2FA token>" })
-# => <your new oauth token>
 ```
 
 ### Using a .netrc file


### PR DESCRIPTION
These should've come out in 017b0e3bc4aafed817142db3765d02e88d926228.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1639

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The docs refer to a method that no longer exists.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The docs won't refer to the missing method, though this adds no documentation to describe what replaced it, if anything.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

