### PR TITLE
Fix documentation for oauth_applications [ci skip]

### DIFF
--- a/lib/octokit/client/oauth_applications.rb
+++ b/lib/octokit/client/oauth_applications.rb
@@ -65,7 +65,7 @@ module Octokit
       #
       # @example
       #  client = Octokit::Client.new(:client_id => 'abcdefg12345', :client_secret => 'secret')
-      #  client.delete_token('deadbeef1234567890deadbeef987654321')
+      #  client.delete_app_token('deadbeef1234567890deadbeef987654321')
       def delete_app_token(access_token, options = {})
         options[:access_token] = access_token
 


### PR DESCRIPTION
Documentation for method name in oauth_applications.rb is wrong [here ](https://github.com/octokit/octokit.rb/blob/dcbfa148ea1b41d83aac7bd4a39265ef90aab417/lib/octokit/client/oauth_applications.rb#L68) fixed it.