### PR TITLE
Paginate deployments

### DIFF
--- a/lib/octokit/client/deployments.rb
+++ b/lib/octokit/client/deployments.rb
@@ -22,7 +22,7 @@ module Octokit
       # @return [Array<Sawyer::Resource>] A list of deployments
       # @see https://developer.github.com/v3/repos/deployments/#list-deployments
       def deployments(repo, options = {})
-        get("#{Repository.path repo}/deployments", options)
+        paginate("#{Repository.path repo}/deployments", options)
       end
       alias list_deployments deployments
 
@@ -60,7 +60,7 @@ module Octokit
       # @see https://developer.github.com/v3/repos/deployments/#list-deployment-statuses
       def deployment_statuses(deployment_url, options = {})
         deployment = get(deployment_url, accept: options[:accept])
-        get(deployment.rels[:statuses].href, options)
+        paginate(deployment.rels[:statuses].href, options)
       end
       alias list_deployment_statuses deployment_statuses
 


### PR DESCRIPTION
### Before the change?

* It was not possible to paginate automatically this two endpoints.

### After the change?

* It is possible to paginate the result for `deployments` and `deployment_statuses`.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

I followed https://github.com/octokit/octokit.rb/pull/1032/files and doesn't seems it is required here?

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

