### PR TITLE
feat: Renew access token with refresh access token

### DIFF
--- a/lib/octokit/client/users.rb
+++ b/lib/octokit/client/users.rb
@@ -57,6 +57,33 @@ module Octokit
         post "#{web_endpoint}login/oauth/access_token", options
       end
 
+      # Refresh a user's access token with a refresh token.
+      #
+      # Applications can refresh an access token without requiring a user to re-authorize using refresh access token.
+      #
+      # @param code [String] 40 character GitHub OAuth refresh access token
+      #
+      # @return [Sawyer::Resource]
+      # @see https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens#refreshing-a-user-access-token-with-a-refresh-token
+      #
+      # @example
+      #  client = Octokit::Client.new(:client_id => 'abcdefg12345', :client_secret => 'secret')
+      #  client.refresh_access_token('40-character-refresh-token')
+      def refresh_access_token(code, app_id = client_id, app_secret = client_secret, options = {})
+        options = options.merge({
+                                  refresh_token: code,
+                                  client_id: app_id,
+                                  client_secret: app_secret,
+                                  grant_type: 'refresh_token',
+                                  headers: {
+                                    content_type: 'application/json',
+                                    accept: 'application/json'
+                                  }
+                                })
+
+        post "#{web_endpoint}login/oauth/access_token", options
+      end
+
       # Validate user username and password
       #
       # @param options [Hash] User credentials

--- a/spec/fixtures/renew_access_token.json
+++ b/spec/fixtures/renew_access_token.json
@@ -1,0 +1,8 @@
+{
+  "scope": "",
+  "expires_in": 28800,
+  "token_type": "bearer",
+  "access_token": "new_access_token",
+  "refresh_token": "new_refresh_token",
+  "refresh_token_expires_in": 15811200
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #I1652

----

### Before the change?

* Missing functionality to renew an access token when github app is authenticated.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Expired access tokens can be renewed using refresh access token.
* Method added in **lib/octokit/client/users.rb**

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] No

----

