### PR TITLE
maint: Added base64 gem explicitly dependency

### DIFF
--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -5,6 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'octokit/version'
 
 Gem::Specification.new do |spec|
+  spec.add_dependency 'base64'
   spec.add_dependency 'faraday', '>= 1', '< 3'
   spec.add_dependency 'sawyer', '~> 0.9'
   spec.authors = ['Wynn Netherland', 'Erik Michaels-Ober', 'Clint Shryock']


### PR DESCRIPTION
### Before the change?

octokit.rb warns the following message With Ruby 3.3.0.

```
/Users/hsbt/.local/share/gem/gems/octokit-8.0.0/lib/octokit/client/code_scanning.rb:3: warning: base64 was loaded from the standard library, but is not part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of octokit-8.0.0 to add base64 into its gemspec.
```

This means octokit.rb is not working after Ruby 3.4 release. We should add `base64` as dependency.

### After the change?

Above warning is suppressed.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

