### PR TITLE
Drop runtime dependency on base64

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :test do
   install_if -> { RUBY_VERSION >= '2.8' } do
     gem 'rexml', '>= 3.2.4'
   end
+  gem 'base64'
   gem 'json', '>= 2.3.0'
   gem 'jwt', '~> 2.2', '>= 2.2.1'
   gem 'mime-types', '~> 3.3', '>= 3.3.1'

--- a/lib/octokit/client/code_scanning.rb
+++ b/lib/octokit/client/code_scanning.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'base64'
 require 'tempfile'
 require 'zlib'
 
@@ -45,7 +44,7 @@ module Octokit
           Zlib::GzipWriter.open(tempfile) do |gz_file|
             gz_file.write File.binread(file)
           end
-          Base64.strict_encode64(tempfile.read)
+          [tempfile.read].pack('m0') # Base64.strict_encode64
         end
       end
     end

--- a/lib/octokit/client/contents.rb
+++ b/lib/octokit/client/contents.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'base64'
-
 module Octokit
   class Client
     # Methods for the Repo Contents API
@@ -80,7 +78,7 @@ module Octokit
         end
         raise ArgumentError, 'content or :file option required' if content.nil?
 
-        options[:content] = Base64.strict_encode64(content)
+        options[:content] = [content].pack('m0') # Base64.strict_encode64
         options[:message] = message
         url = "#{Repository.path repo}/contents/#{path}"
         put url, options

--- a/octokit.gemspec
+++ b/octokit.gemspec
@@ -5,7 +5,6 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'octokit/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'base64'
   spec.add_dependency 'faraday', '>= 1', '< 3'
   spec.add_dependency 'sawyer', '~> 0.9'
   spec.authors = ['Wynn Netherland', 'Erik Michaels-Ober', 'Clint Shryock']

--- a/spec/octokit/client/licenses_spec.rb
+++ b/spec/octokit/client/licenses_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'base64'
+
 describe Octokit::Client::Licenses do
   describe '.licenses', :vcr do
     it 'returns all licenses' do


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
#1658 added base64 as a dependency in order to supress a warning/error on Ruby 3.3/3.4.

There are two places here where it is used, and these can instead be replaced by the `pack` method which the base64 gem just wraps around.

I've instead added it as a development dependency so that tests can continue to make use of it.

Other gems have taken a similar approach:
* https://github.com/rubocop/rubocop/pull/12313
* https://github.com/rack/rack/pull/2110
* https://github.com/elastic/elasticsearch-ruby/pull/2295
* https://github.com/socketry/protocol-http/pull/51
* etc.

----

### Before the change?
`base64` is part of the depenency tree.

### After the change?
`base64` is removed.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

