### PR TITLE
Add method to get a webhook delivery:

### DIFF
--- a/lib/octokit/client/apps.rb
+++ b/lib/octokit/client/apps.rb
@@ -231,6 +231,18 @@ module Octokit
         end
       end
 
+      # Returns a delivery for the webhook configured for a GitHub App.
+      #
+      # @param delivery_id [String] The id of a GitHub App Hook Delivery
+      # @param options [Hash] A customizable set of options
+      #
+      # @see https://docs.github.com/en/rest/apps/webhooks#get-a-delivery-for-an-app-webhook
+      #
+      # @return [<Sawyer::Resource>] The webhook delivery
+      def app_hook_delivery(delivery_id, options = {})
+        get "/app/hook/deliveries/#{delivery_id}", options
+      end
+
       # Redeliver a delivery for the webhook configured for a GitHub App.
       #
       # @param delivery_id [Integer] The id of a GitHub App Hook Delivery

--- a/spec/cassettes/Octokit_Client_Apps/_app_hook_delivery/returns_a_webhook_delivery.json
+++ b/spec/cassettes/Octokit_Client_Apps/_app_hook_delivery/returns_a_webhook_delivery.json
@@ -1,0 +1,100 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.github.com/app/hook/deliveries/73209766136",
+        "body": {
+          "encoding": "US-ASCII",
+          "base64_string": ""
+        },
+        "headers": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "User-Agent": [
+            "Octokit Ruby Gem 8.1.0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Authorization": [
+            "Bearer <JWT_BEARER_TOKEN>"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Server": [
+            "GitHub.com"
+          ],
+          "Date": [
+            "Tue, 27 Feb 2024 02:56:35 GMT"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Cache-Control": [
+            "public, max-age=60, s-maxage=60"
+          ],
+          "Vary": [
+            "Accept",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "Etag": [
+            "W/\"e85846baba41945fbf4cee323e9b038cad19af962ef5fc394fa0fd9d862703c1\""
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Api-Version-Selected": [
+            "2022-11-28"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Xss-Protection": [
+            "0"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "X-Github-Request-Id": [
+            "CB30:60868:67ECACE:6933B01:65DD4F63"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "base64_string": "ewogICJpZCI6IDczMjA5NzY2MTM2LAogICJndWlkIjogIjczMWI4MzI4LWQ0\nZGQtMTFlZS05OWYyLTFkNzU4MjlhMTBlNyIsCiAgImRlbGl2ZXJlZF9hdCI6\nICIyMDI0LTAyLTI2VDE5OjMwOjA4WiIsCiAgInJlZGVsaXZlcnkiOiBmYWxz\nZSwKICAiZHVyYXRpb24iOiAwLjIzLAogICJzdGF0dXMiOiAiT0siLAogICJz\ndGF0dXNfY29kZSI6IDIwMCwKICAiZXZlbnQiOiAicHVzaCIsCiAgImFjdGlv\nbiI6IG51bGwsCiAgImluc3RhbGxhdGlvbl9pZCI6IDQ1ODAwNTE3LAogICJy\nZXBvc2l0b3J5X2lkIjogNDM5Mzg2OTA5LAogICJ1cmwiOiAiaHR0cHM6Ly9l\neGFtcGxlLmNvbS9naXRodWIvaG9va3MiLAogICJyZXF1ZXN0IjogewogICAg\nImhlYWRlcnMiOiB7CiAgICAgICJBY2NlcHQiOiAiKi8qIiwKICAgICAgIkNv\nbnRlbnQtVHlwZSI6ICJhcHBsaWNhdGlvbi9qc29uIiwKICAgICAgIlVzZXIt\nQWdlbnQiOiAiR2l0SHViLUhvb2tzaG90L2Q1NDIwOWEiLAogICAgICAiWC1H\naXRIdWItRGVsaXZlcnkiOiAiNzMxYjgzMjgtZDRkZC0xMWVlLTk5ZjItMWQ3\nNTgyOWExMGU3IiwKICAgICAgIlgtR2l0SHViLUV2ZW50IjogInB1c2giLAog\nICAgICAiWC1HaXRIdWItSG9vay1JRCI6ICIzNzI4ODAwMjAiLAogICAgICAi\nWC1HaXRIdWItSG9vay1JbnN0YWxsYXRpb24tVGFyZ2V0LUlEIjogIjxHSVRI\nVUJfVEVTVF9JTlRFR1JBVElPTj4iLAogICAgICAiWC1HaXRIdWItSG9vay1J\nbnN0YWxsYXRpb24tVGFyZ2V0LVR5cGUiOiAiaW50ZWdyYXRpb24iLAogICAg\nICAiWC1IdWItU2lnbmF0dXJlIjogInNoYTE9N2M0MTk2OTc2YTQyNzQyZTdm\nYTg0ZTNhMGEwMGYwN2I0NGVlNTZhMiIsCiAgICAgICJYLUh1Yi1TaWduYXR1\ncmUtMjU2IjogInNoYTI1Nj0yNTM0MWZmMmVmYzNjMGIxNDI0MjQ0NTczNmE5\nNjEzM2FhZDc0ZTVkNzIyNmQ1ZDgwYzNlMmI3NGJiNmZlNTA0IgogICAgfSwK\nICAgICJwYXlsb2FkIjogewogICAgICAicmVmIjogInJlZnMvaGVhZHMvYnJh\nbmNoLW5hbWUiLAogICAgICAiYmVmb3JlIjogIjRmMzg5NjBlNWE4ZDdlYWM5\nN2I2YzdiZDlkZGQ2OGMxZjljN2Q2ODEiLAogICAgICAiYWZ0ZXIiOiAiMDAw\nMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMCIsCiAgICAg\nICJyZXBvc2l0b3J5IjogewogICAgICAgICJpZCI6IDQzOTM4NjkwOSwKICAg\nICAgICAibm9kZV9pZCI6ICJSX2tnRE9HakNESFEiLAogICAgICAgICJuYW1l\nIjogImNhbmFyeS1yZW5hbWVkIiwKICAgICAgICAiZnVsbF9uYW1lIjogIkJv\nYi9jYW5hcnktcmVuYW1lZCIsCiAgICAgICAgInByaXZhdGUiOiB0cnVlLAog\nICAgICAgICJvd25lciI6IHsKICAgICAgICAgICJuYW1lIjogIkJvYiIsCiAg\nICAgICAgICAiZW1haWwiOiAiYm9iQGV4YW1wbGUuY29tIiwKICAgICAgICAg\nICJsb2dpbiI6ICJCb2IiLAogICAgICAgICAgImlkIjogNTQsCiAgICAgICAg\nICAibm9kZV9pZCI6ICJNRFE2VlhObGNqZ3hNakl5TkRZPSIsCiAgICAgICAg\nICAiYXZhdGFyX3VybCI6ICJodHRwczovL2F2YXRhcnMuZ2l0aHVidXNlcmNv\nbnRlbnQuY29tL3UvODEyMjI0Nj92PTQiLAogICAgICAgICAgImdyYXZhdGFy\nX2lkIjogIiIsCiAgICAgICAgICAidXJsIjogImh0dHBzOi8vYXBpLmdpdGh1\nYi5jb20vdXNlcnMvQm9iIiwKICAgICAgICAgICJodG1sX3VybCI6ICJodHRw\nczovL2dpdGh1Yi5jb20vQm9iIiwKICAgICAgICAgICJmb2xsb3dlcnNfdXJs\nIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvQm9iL2ZvbGxvd2Vy\ncyIsCiAgICAgICAgICAiZm9sbG93aW5nX3VybCI6ICJodHRwczovL2FwaS5n\naXRodWIuY29tL3VzZXJzL0JvYi9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwK\nICAgICAgICAgICJnaXN0c191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0aHViLmNv\nbS91c2Vycy9Cb2IvZ2lzdHN7L2dpc3RfaWR9IiwKICAgICAgICAgICJzdGFy\ncmVkX3VybCI6ICJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL0JvYi9z\ndGFycmVkey9vd25lcn17L3JlcG99IiwKICAgICAgICAgICJzdWJzY3JpcHRp\nb25zX3VybCI6ICJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL0JvYi9z\ndWJzY3JpcHRpb25zIiwKICAgICAgICAgICJvcmdhbml6YXRpb25zX3VybCI6\nICJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL0JvYi9vcmdzIiwKICAg\nICAgICAgICJyZXBvc191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy9Cb2IvcmVwb3MiLAogICAgICAgICAgImV2ZW50c191cmwiOiAiaHR0\ncHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9Cb2IvZXZlbnRzey9wcml2YWN5\nfSIsCiAgICAgICAgICAicmVjZWl2ZWRfZXZlbnRzX3VybCI6ICJodHRwczov\nL2FwaS5naXRodWIuY29tL3VzZXJzL0JvYi9yZWNlaXZlZF9ldmVudHMiLAog\nICAgICAgICAgInR5cGUiOiAiVXNlciIsCiAgICAgICAgICAic2l0ZV9hZG1p\nbiI6IGZhbHNlCiAgICAgICAgfSwKICAgICAgICAiaHRtbF91cmwiOiAiaHR0\ncHM6Ly9naXRodWIuY29tL0JvYi9jYW5hcnktcmVuYW1lZCIsCiAgICAgICAg\nImRlc2NyaXB0aW9uIjogIkNhbmFyeSBhcHAiLAogICAgICAgICJmb3JrIjog\nZmFsc2UsCiAgICAgICAgInVybCI6ICJodHRwczovL2dpdGh1Yi5jb20vQm9i\nL2NhbmFyeS1yZW5hbWVkIiwKICAgICAgICAiZm9ya3NfdXJsIjogImh0dHBz\nOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvQm9iL2NhbmFyeS1yZW5hbWVkL2Zv\ncmtzIiwKICAgICAgICAia2V5c191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy9Cb2IvY2FuYXJ5LXJlbmFtZWQva2V5c3sva2V5X2lkfSIs\nCiAgICAgICAgImNvbGxhYm9yYXRvcnNfdXJsIjogImh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vcmVwb3MvQm9iL2NhbmFyeS1yZW5hbWVkL2NvbGxhYm9yYXRv\ncnN7L2NvbGxhYm9yYXRvcn0iLAogICAgICAgICJ0ZWFtc191cmwiOiAiaHR0\ncHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9Cb2IvY2FuYXJ5LXJlbmFtZWQv\ndGVhbXMiLAogICAgICAgICJob29rc191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9Cb2IvY2FuYXJ5LXJlbmFtZWQvaG9va3MiLAogICAg\nICAgICJpc3N1ZV9ldmVudHNfdXJsIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vcmVwb3MvQm9iL2NhbmFyeS1yZW5hbWVkL2lzc3Vlcy9ldmVudHN7L251\nbWJlcn0iLAogICAgICAgICJldmVudHNfdXJsIjogImh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vcmVwb3MvQm9iL2NhbmFyeS1yZW5hbWVkL2V2ZW50cyIsCiAg\nICAgICAgImFzc2lnbmVlc191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0aHViLmNv\nbS9yZXBvcy9Cb2IvY2FuYXJ5LXJlbmFtZWQvYXNzaWduZWVzey91c2VyfSIs\nCiAgICAgICAgImJyYW5jaGVzX3VybCI6ICJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zL0JvYi9jYW5hcnktcmVuYW1lZC9icmFuY2hlc3svYnJhbmNo\nfSIsCiAgICAgICAgInRhZ3NfdXJsIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5j\nb20vcmVwb3MvQm9iL2NhbmFyeS1yZW5hbWVkL3RhZ3MiLAogICAgICAgICJi\nbG9ic191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9Cb2Iv\nY2FuYXJ5LXJlbmFtZWQvZ2l0L2Jsb2Jzey9zaGF9IiwKICAgICAgICAiZ2l0\nX3RhZ3NfdXJsIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvQm9i\nL2NhbmFyeS1yZW5hbWVkL2dpdC90YWdzey9zaGF9IiwKICAgICAgICAiZ2l0\nX3JlZnNfdXJsIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvQm9i\nL2NhbmFyeS1yZW5hbWVkL2dpdC9yZWZzey9zaGF9IiwKICAgICAgICAidHJl\nZXNfdXJsIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvQm9iL2Nh\nbmFyeS1yZW5hbWVkL2dpdC90cmVlc3svc2hhfSIsCiAgICAgICAgInN0YXR1\nc2VzX3VybCI6ICJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL0JvYi9j\nYW5hcnktcmVuYW1lZC9zdGF0dXNlcy97c2hhfSIsCiAgICAgICAgImxhbmd1\nYWdlc191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9Cb2Iv\nY2FuYXJ5LXJlbmFtZWQvbGFuZ3VhZ2VzIiwKICAgICAgICAic3RhcmdhemVy\nc191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9Cb2IvY2Fu\nYXJ5LXJlbmFtZWQvc3RhcmdhemVycyIsCiAgICAgICAgImNvbnRyaWJ1dG9y\nc191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9Cb2IvY2Fu\nYXJ5LXJlbmFtZWQvY29udHJpYnV0b3JzIiwKICAgICAgICAic3Vic2NyaWJl\ncnNfdXJsIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvQm9iL2Nh\nbmFyeS1yZW5hbWVkL3N1YnNjcmliZXJzIiwKICAgICAgICAic3Vic2NyaXB0\naW9uX3VybCI6ICJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL0JvYi9j\nYW5hcnktcmVuYW1lZC9zdWJzY3JpcHRpb24iLAogICAgICAgICJjb21taXRz\nX3VybCI6ICJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL0JvYi9jYW5h\ncnktcmVuYW1lZC9jb21taXRzey9zaGF9IiwKICAgICAgICAiZ2l0X2NvbW1p\ndHNfdXJsIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvQm9iL2Nh\nbmFyeS1yZW5hbWVkL2dpdC9jb21taXRzey9zaGF9IiwKICAgICAgICAiY29t\nbWVudHNfdXJsIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvQm9i\nL2NhbmFyeS1yZW5hbWVkL2NvbW1lbnRzey9udW1iZXJ9IiwKICAgICAgICAi\naXNzdWVfY29tbWVudF91cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9y\nZXBvcy9Cb2IvY2FuYXJ5LXJlbmFtZWQvaXNzdWVzL2NvbW1lbnRzey9udW1i\nZXJ9IiwKICAgICAgICAiY29udGVudHNfdXJsIjogImh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vcmVwb3MvQm9iL2NhbmFyeS1yZW5hbWVkL2NvbnRlbnRzL3sr\ncGF0aH0iLAogICAgICAgICJjb21wYXJlX3VybCI6ICJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL0JvYi9jYW5hcnktcmVuYW1lZC9jb21wYXJlL3ti\nYXNlfS4uLntoZWFkfSIsCiAgICAgICAgIm1lcmdlc191cmwiOiAiaHR0cHM6\nLy9hcGkuZ2l0aHViLmNvbS9yZXBvcy9Cb2IvY2FuYXJ5LXJlbmFtZWQvbWVy\nZ2VzIiwKICAgICAgICAiYXJjaGl2ZV91cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9Cb2IvY2FuYXJ5LXJlbmFtZWQve2FyY2hpdmVfZm9y\nbWF0fXsvcmVmfSIsCiAgICAgICAgImRvd25sb2Fkc191cmwiOiAiaHR0cHM6\nLy9hcGkuZ2l0aHViLmNvbS9yZXBvcy9Cb2IvY2FuYXJ5LXJlbmFtZWQvZG93\nbmxvYWRzIiwKICAgICAgICAiaXNzdWVzX3VybCI6ICJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL0JvYi9jYW5hcnktcmVuYW1lZC9pc3N1ZXN7L251\nbWJlcn0iLAogICAgICAgICJwdWxsc191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy9Cb2IvY2FuYXJ5LXJlbmFtZWQvcHVsbHN7L251bWJl\ncn0iLAogICAgICAgICJtaWxlc3RvbmVzX3VybCI6ICJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zL0JvYi9jYW5hcnktcmVuYW1lZC9taWxlc3RvbmVz\ney9udW1iZXJ9IiwKICAgICAgICAibm90aWZpY2F0aW9uc191cmwiOiAiaHR0\ncHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy9Cb2IvY2FuYXJ5LXJlbmFtZWQv\nbm90aWZpY2F0aW9uc3s/c2luY2UsYWxsLHBhcnRpY2lwYXRpbmd9IiwKICAg\nICAgICAibGFiZWxzX3VybCI6ICJodHRwczovL2FwaS5naXRodWIuY29tL3Jl\ncG9zL0JvYi9jYW5hcnktcmVuYW1lZC9sYWJlbHN7L25hbWV9IiwKICAgICAg\nICAicmVsZWFzZXNfdXJsIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVw\nb3MvQm9iL2NhbmFyeS1yZW5hbWVkL3JlbGVhc2Vzey9pZH0iLAogICAgICAg\nICJkZXBsb3ltZW50c191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9y\nZXBvcy9Cb2IvY2FuYXJ5LXJlbmFtZWQvZGVwbG95bWVudHMiLAogICAgICAg\nICJjcmVhdGVkX2F0IjogMTYzOTc1Njg5OCwKICAgICAgICAidXBkYXRlZF9h\ndCI6ICIyMDI0LTAyLTI2VDE5OjI3OjI3WiIsCiAgICAgICAgInB1c2hlZF9h\ndCI6IDE3MDg5NzU4MDcsCiAgICAgICAgImdpdF91cmwiOiAiZ2l0Oi8vZ2l0\naHViLmNvbS9Cb2IvY2FuYXJ5LXJlbmFtZWQuZ2l0IiwKICAgICAgICAic3No\nX3VybCI6ICJnaXRAZ2l0aHViLmNvbTpCb2IvY2FuYXJ5LXJlbmFtZWQuZ2l0\nIiwKICAgICAgICAiY2xvbmVfdXJsIjogImh0dHBzOi8vZ2l0aHViLmNvbS9C\nb2IvY2FuYXJ5LXJlbmFtZWQuZ2l0IiwKICAgICAgICAic3ZuX3VybCI6ICJo\ndHRwczovL2dpdGh1Yi5jb20vQm9iL2NhbmFyeS1yZW5hbWVkIiwKICAgICAg\nICAiaG9tZXBhZ2UiOiBudWxsLAogICAgICAgICJzaXplIjogMjAyLAogICAg\nICAgICJzdGFyZ2F6ZXJzX2NvdW50IjogMCwKICAgICAgICAid2F0Y2hlcnNf\nY291bnQiOiAwLAogICAgICAgICJsYW5ndWFnZSI6ICJSdWJ5IiwKICAgICAg\nICAiaGFzX2lzc3VlcyI6IHRydWUsCiAgICAgICAgImhhc19wcm9qZWN0cyI6\nIHRydWUsCiAgICAgICAgImhhc19kb3dubG9hZHMiOiB0cnVlLAogICAgICAg\nICJoYXNfd2lraSI6IHRydWUsCiAgICAgICAgImhhc19wYWdlcyI6IGZhbHNl\nLAogICAgICAgICJoYXNfZGlzY3Vzc2lvbnMiOiBmYWxzZSwKICAgICAgICAi\nZm9ya3NfY291bnQiOiAwLAogICAgICAgICJtaXJyb3JfdXJsIjogbnVsbCwK\nICAgICAgICAiYXJjaGl2ZWQiOiBmYWxzZSwKICAgICAgICAiZGlzYWJsZWQi\nOiBmYWxzZSwKICAgICAgICAib3Blbl9pc3N1ZXNfY291bnQiOiAyNywKICAg\nICAgICAibGljZW5zZSI6IG51bGwsCiAgICAgICAgImFsbG93X2Zvcmtpbmci\nOiB0cnVlLAogICAgICAgICJpc190ZW1wbGF0ZSI6IGZhbHNlLAogICAgICAg\nICJ3ZWJfY29tbWl0X3NpZ25vZmZfcmVxdWlyZWQiOiBmYWxzZSwKICAgICAg\nICAidG9waWNzIjogW10sCiAgICAgICAgInZpc2liaWxpdHkiOiAicHJpdmF0\nZSIsCiAgICAgICAgImZvcmtzIjogMCwKICAgICAgICAib3Blbl9pc3N1ZXMi\nOiAyNywKICAgICAgICAid2F0Y2hlcnMiOiAwLAogICAgICAgICJkZWZhdWx0\nX2JyYW5jaCI6ICJtYWluIiwKICAgICAgICAic3RhcmdhemVycyI6IDAsCiAg\nICAgICAgIm1hc3Rlcl9icmFuY2giOiAibWFpbiIKICAgICAgfSwKICAgICAg\nInB1c2hlciI6IHsKICAgICAgICAibmFtZSI6ICJCb2IiLAogICAgICAgICJl\nbWFpbCI6ICJib2JAZXhhbXBsZS5jb20iCiAgICAgIH0sCiAgICAgICJzZW5k\nZXIiOiB7CiAgICAgICAgImxvZ2luIjogIkJvYiIsCiAgICAgICAgImlkIjog\nNTQsCiAgICAgICAgIm5vZGVfaWQiOiAiTURRNlZYTmxjamd4TWpJeU5EWT0i\nLAogICAgICAgICJhdmF0YXJfdXJsIjogImh0dHBzOi8vYXZhdGFycy5naXRo\ndWJ1c2VyY29udGVudC5jb20vdS84MTIyMjQ2P3Y9NCIsCiAgICAgICAgImdy\nYXZhdGFyX2lkIjogIiIsCiAgICAgICAgInVybCI6ICJodHRwczovL2FwaS5n\naXRodWIuY29tL3VzZXJzL0JvYiIsCiAgICAgICAgImh0bWxfdXJsIjogImh0\ndHBzOi8vZ2l0aHViLmNvbS9Cb2IiLAogICAgICAgICJmb2xsb3dlcnNfdXJs\nIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvQm9iL2ZvbGxvd2Vy\ncyIsCiAgICAgICAgImZvbGxvd2luZ191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS91c2Vycy9Cb2IvZm9sbG93aW5ney9vdGhlcl91c2VyfSIsCiAg\nICAgICAgImdpc3RzX3VybCI6ICJodHRwczovL2FwaS5naXRodWIuY29tL3Vz\nZXJzL0JvYi9naXN0c3svZ2lzdF9pZH0iLAogICAgICAgICJzdGFycmVkX3Vy\nbCI6ICJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL0JvYi9zdGFycmVk\ney9vd25lcn17L3JlcG99IiwKICAgICAgICAic3Vic2NyaXB0aW9uc191cmwi\nOiAiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9Cb2Ivc3Vic2NyaXB0\naW9ucyIsCiAgICAgICAgIm9yZ2FuaXphdGlvbnNfdXJsIjogImh0dHBzOi8v\nYXBpLmdpdGh1Yi5jb20vdXNlcnMvQm9iL29yZ3MiLAogICAgICAgICJyZXBv\nc191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9Cb2IvcmVw\nb3MiLAogICAgICAgICJldmVudHNfdXJsIjogImh0dHBzOi8vYXBpLmdpdGh1\nYi5jb20vdXNlcnMvQm9iL2V2ZW50c3svcHJpdmFjeX0iLAogICAgICAgICJy\nZWNlaXZlZF9ldmVudHNfdXJsIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ndXNlcnMvQm9iL3JlY2VpdmVkX2V2ZW50cyIsCiAgICAgICAgInR5cGUiOiAi\nVXNlciIsCiAgICAgICAgInNpdGVfYWRtaW4iOiBmYWxzZQogICAgICB9LAog\nICAgICAiaW5zdGFsbGF0aW9uIjogewogICAgICAgICJpZCI6IDQ1ODAwNTE3\nLAogICAgICAgICJub2RlX2lkIjogIk1ESXpPa2x1ZEdWbmNtRjBhVzl1U1c1\nemRHRnNiR0YwYVc5dU5EVTRNREExTVRjPSIKICAgICAgfSwKICAgICAgImNy\nZWF0ZWQiOiBmYWxzZSwKICAgICAgImRlbGV0ZWQiOiB0cnVlLAogICAgICAi\nZm9yY2VkIjogZmFsc2UsCiAgICAgICJiYXNlX3JlZiI6IG51bGwsCiAgICAg\nICJjb21wYXJlIjogImh0dHBzOi8vZ2l0aHViLmNvbS9Cb2IvY2FuYXJ5LXJl\nbmFtZWQvY29tcGFyZS80ZjM4OTYwZTVhOGQuLi4wMDAwMDAwMDAwMDAiLAog\nICAgICAiY29tbWl0cyI6IFtdLAogICAgICAiaGVhZF9jb21taXQiOiBudWxs\nCiAgICB9CiAgfSwKICAicmVzcG9uc2UiOiB7CiAgICAiaGVhZGVycyI6IHsK\nICAgICAgIkNhY2hlLUNvbnRyb2wiOiAibm8tY2FjaGUiLAogICAgICAiQ29u\ndGVudC1MZW5ndGgiOiAiMCIsCiAgICAgICJDb250ZW50LVR5cGUiOiAidGV4\ndC9odG1sIiwKICAgICAgIkRhdGUiOiAiTW9uLCAyNiBGZWIgMjAyNCAxOToz\nMDowOCBHTVQiLAogICAgICAiUmVmZXJyZXItUG9saWN5IjogInN0cmljdC1v\ncmlnaW4td2hlbi1jcm9zcy1vcmlnaW4iLAogICAgICAiWC1Db250ZW50LVR5\ncGUtT3B0aW9ucyI6ICJub3NuaWZmIiwKICAgICAgIlgtRnJhbWUtT3B0aW9u\ncyI6ICJTQU1FT1JJR0lOIiwKICAgICAgIlgtUGVybWl0dGVkLUNyb3NzLURv\nbWFpbi1Qb2xpY2llcyI6ICJub25lIiwKICAgICAgIlgtUmVxdWVzdC1JZCI6\nICJlNmFhZGRjNC1hMWVkLTRkYzgtOTkwOC04MzU2NGRkOTdlMjMiLAogICAg\nICAiWC1SdW50aW1lIjogIjAuMDQwODA0IiwKICAgICAgIlgtWHNzLVByb3Rl\nY3Rpb24iOiAiMCIKICAgIH0sCiAgICAicGF5bG9hZCI6ICIiCiAgfQp9Cg==\n"
+        }
+      },
+      "recorded_at": "Tue, 27 Feb 2024 02:56:35 GMT"
+    }
+  ],
+  "recorded_with": "VCR 6.1.0"
+}

--- a/spec/octokit/client/apps_spec.rb
+++ b/spec/octokit/client/apps_spec.rb
@@ -198,6 +198,14 @@ describe Octokit::Client::Apps do
     end
   end # .list_app_hook_deliveries
 
+  describe '.app_hook_delivery', :vcr do
+    let(:delivery_id) { 73_209_766_136 }
+    it 'returns a webhook delivery' do
+      response = @jwt_client.app_hook_delivery(delivery_id)
+      expect(response.id).to eq(73_209_766_136)
+    end
+  end # .app_hook_delivery
+
   describe '.deliver_app_hook', :vcr do
     let(:delivery_id) { 55_148_726_666 }
     it 'schedules a webhook for redelivery' do


### PR DESCRIPTION
- Added a new `app_hook_delivery` to retrieve one webhook delivery for an app.

  Ref https://docs.github.com/en/rest/apps/webhooks#get-a-delivery-for-an-app-webhook

----

### Before the change?
No method is implemented to get a specific webhook delivery for an app. 


### After the change?

User can now call `client.app_hook_delivery('delivery-123')` to get the webhook delivery resource.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----

