### PR TITLE
fix: Use auto pagination when retrieving environments

### DIFF
--- a/lib/octokit/client/environments.rb
+++ b/lib/octokit/client/environments.rb
@@ -24,7 +24,10 @@ module Octokit
       # @return [Sawyer::Resource] Total count of environments and list of environments
       # @see https://docs.github.com/en/rest/deployments/environments#list-environments
       def environments(repo, options = {})
-        get("#{Repository.path repo}/environments", options)
+        paginate("#{Repository.path repo}/environments", options) do |data, last_response|
+          data.environments.concat last_response.data.environments
+          data.total_count += last_response.data.total_count
+        end
       end
       alias list_environments environments
 


### PR DESCRIPTION
### Before the change?
* Listing environments would only fetch the first page if `auto_paginate` is set to `true`.

### After the change?
* Listing environments will fetch all the pages if `auto_paginate` is set to `true`.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
No

