### PR TITLE
Remove outdated version constraint from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Install via Rubygems
 
 ... or add to your Gemfile
 
-    gem "octokit", "~> 5.0"
+    gem "octokit"
 
 Access the library in Ruby:
 


### PR DESCRIPTION
The current release is v8 so this was very out of date. I think it's better just to remove than to keep updating.