### PR TITLE
fix: Remove the Faraday multipart warning and tweak the error message raised at runtime when Faraday Multipart is not installed

### DIFF
--- a/lib/octokit/default.rb
+++ b/lib/octokit/default.rb
@@ -12,11 +12,6 @@ if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
   rescue LoadError
     Octokit::Warnable.octokit_warn 'To use retry middleware with Faraday v2.0+, install `faraday-retry` gem'
   end
-  begin
-    require 'faraday/multipart'
-  rescue LoadError
-    Octokit::Warnable.octokit_warn 'To use multipart middleware with Faraday v2.0+, install `faraday-multipart` gem; note: this is used by the ManageGHES client for uploading licenses'
-  end
 end
 
 module Octokit

--- a/lib/octokit/enterprise_management_console_client/management_console.rb
+++ b/lib/octokit/enterprise_management_console_client/management_console.rb
@@ -171,7 +171,14 @@ module Octokit
     def faraday_configuration
       @faraday_configuration ||= Faraday.new(url: @management_console_endpoint) do |http|
         http.headers[:user_agent] = user_agent
-        http.request :multipart
+        begin
+          http.request :multipart
+        rescue Faraday::Error
+          raise Faraday::Error, <<~ERROR
+            The `faraday-multipart` gem is required to upload a license.
+            Please add `gem "faraday-multipart"` to your Gemfile.
+          ERROR
+        end
         http.request :url_encoded
 
         # Disabling SSL is essential for certain self-hosted Enterprise instances

--- a/lib/octokit/manage_ghes_client/manage_ghes.rb
+++ b/lib/octokit/manage_ghes_client/manage_ghes.rb
@@ -36,7 +36,14 @@ module Octokit
     # @return [nil]
     def upload_license(license)
       conn = authenticated_client
-      conn.request :multipart
+      begin
+        conn.request :multipart
+      rescue Faraday::Error
+        raise Faraday::Error, <<~ERROR
+          The `faraday-multipart` gem is required to upload a license.
+          Please add `gem "faraday-multipart"` to your Gemfile.
+        ERROR
+      end
       params = {}
       params[:license] = Faraday::FilePart.new(license, 'binary')
       params[:password] = @manage_ghes_password

--- a/spec/octokit/enterprise_management_console_client/management_console_spec.rb
+++ b/spec/octokit/enterprise_management_console_client/management_console_spec.rb
@@ -14,6 +14,15 @@ describe Octokit::EnterpriseManagementConsoleClient::ManagementConsole do
       expect(@enterprise_management_console_client.last_response.status).to eq(202)
       assert_requested :post, github_management_console_url('setup/api/start')
     end
+
+    it 'raises an error if the faraday-multipart gem is not installed' do
+      middleware_key = :multipart
+      middleware = Faraday::Request.unregister_middleware(middleware_key)
+
+      expect { @enterprise_management_console_client.upload_license(@license) }.to raise_error Faraday::Error
+    ensure
+      Faraday::Request.register_middleware(middleware_key => middleware) if middleware
+    end
   end # .upload_license
 
   describe '.start_configuration', :vcr do

--- a/spec/octokit/ghes_manage_client/ghes_manage_spec.rb
+++ b/spec/octokit/ghes_manage_client/ghes_manage_spec.rb
@@ -38,6 +38,15 @@ describe Octokit::ManageGHESClient::ManageAPI do
       expect(@manage_ghes.last_response.status).to eq(202)
       assert_requested :post, github_manage_ghes_url('/manage/v1/config/init')
     end
+
+    it 'raises an error if the faraday-multipart gem is not installed' do
+      middleware_key = :multipart
+      middleware = Faraday::Request.unregister_middleware(middleware_key)
+
+      expect { @manage_ghes.upload_license(@license) }.to raise_error Faraday::Error
+    ensure
+      Faraday::Request.register_middleware(middleware_key => middleware) if middleware
+    end
   end # .upload_license
 
   describe '.start_configuration', :vcr do


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1701

----

### Before the change?


* A warning message related to the Faraday Multipart middleware is always printed at boot time.
At runtime, a Faraday error is raised and the message of what happened is not clear.

### After the change?


* The warning message is not printed at boot time. A better error and message is raised at runtime.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

