### PR TITLE
Update the "debugging" sample code in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ traffic:
 
 ```ruby
 stack = Faraday::RackBuilder.new do |builder|
-  builder.use Faraday::Retry::Middleware, exceptions: Faraday::Request::Retry::DEFAULT_EXCEPTIONS + [Octokit::ServerError] # or Faraday::Request::Retry for Faraday < 2.0
+  builder.use Faraday::Retry::Middleware, exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [Octokit::ServerError] # or Faraday::Request::Retry for Faraday < 2.0
   builder.use Octokit::Middleware::FollowRedirects
   builder.use Octokit::Response::RaiseError
   builder.use Octokit::Response::FeedParser


### PR DESCRIPTION
Update the sample code for enabling HTTP debugging in Faraday to work with newer versions of Faraday.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* In testing using ruby 3.2.3, faraday 2.12.0 and faraday-retry 2.2.1, I found that the included sample code failed with this error:

```
uninitialized constant Faraday::Retry (NameError)

  builder.use Faraday::Retry::Middleware, exceptions: Faraday::Request::Retry::DEFAULT_EXCEPTIONS + [Octokit::ServerError] # or Faraday::Request::Retry for Faraday < 2.0
                            ^^^^^^^^^^^^
	from /Users/$USER/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/faraday-2.12.0/lib/faraday/rack_builder.rb:74:in `build'
	from /Users/$USER/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/faraday-2.12.0/lib/faraday/rack_builder.rb:63:in `initialize'
```

### After the change?

* After making the proposed to point to this constant: https://github.com/lostisland/faraday-retry/blob/main/lib/faraday/retry/middleware.rb#L18 the example debugging code works successfully.


### Does this introduce a breaking change?
no

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

