### PR TITLE
feat: add missing method `delete_issue_comment_reaction()`

### DIFF
--- a/lib/octokit/client/reactions.rb
+++ b/lib/octokit/client/reactions.rb
@@ -102,6 +102,22 @@ module Octokit
         post "#{Repository.path repo}/issues/comments/#{id}/reactions", options
       end
 
+      # Delete a reaction from an issue comment
+      #
+      # @param repo [Integer, String, Hash, Repository] A GitHub repository
+      # @param comment_id [Integer] The Issue comment id
+      # @param reaction_id [Integer] The Reaction id
+      #
+      # @see https://docs.github.com/en/rest/reactions/reactions#delete-an-issue-comment-reaction
+      #
+      # @example
+      #   @client.delete_issue_comment_reaction("octokit/octokit.rb", 1, 2)
+      #
+      # @return [Boolean] Return true if reaction was deleted, false otherwise.
+      def delete_issue_comment_reaction(repo, comment_id, reaction_id, options = {})
+        boolean_from_response :delete, "#{Repository.path repo}/issues/comments/#{comment_id}/reactions/#{reaction_id}", options
+      end
+
       # List reactions for a pull request review comment
       #
       # @param repo [Integer, String, Hash, Repository] A GitHub repository

--- a/spec/cassettes/Octokit_Client_Reactions/with_repository/with_issue/with_issue_comment/_delete_issue_comment_reaction/deletes_the_reaction.json
+++ b/spec/cassettes/Octokit_Client_Reactions/with_repository/with_issue/with_issue_comment/_delete_issue_comment_reaction/deletes_the_reaction.json
@@ -1,0 +1,654 @@
+{
+    "http_interactions": [
+        {
+            "request": {
+                "method": "post",
+                "uri": "https://api.github.com/user/repos",
+                "body": {
+                    "encoding": "UTF-8",
+                    "base64_string": "eyJhdXRvX2luaXQiOnRydWUsIm5hbWUiOiJhbi1yZXBvIn0=\n"
+                },
+                "headers": {
+                    "Accept": [
+                        "application/vnd.github.v3+json"
+                    ],
+                    "User-Agent": [
+                        "Octokit Ruby Gem 4.3.0"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "Authorization": [
+                        "token <<ACCESS_TOKEN>>"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 201,
+                    "message": "Created"
+                },
+                "headers": {
+                    "Server": [
+                        "GitHub.com"
+                    ],
+                    "Date": [
+                        "Fri, 13 May 2016 13:57:48 GMT"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "Content-Length": [
+                        "5480"
+                    ],
+                    "Status": [
+                        "201 Created"
+                    ],
+                    "X-Ratelimit-Limit": [
+                        "5000"
+                    ],
+                    "X-Ratelimit-Remaining": [
+                        "4709"
+                    ],
+                    "X-Ratelimit-Reset": [
+                        "1463149720"
+                    ],
+                    "Cache-Control": [
+                        "private, max-age=60, s-maxage=60"
+                    ],
+                    "Vary": [
+                        "Accept, Authorization, Cookie, X-GitHub-OTP",
+                        "Accept-Encoding"
+                    ],
+                    "Etag": [
+                        "\"00d3a2fc997a1b125c8835b676eedc23\""
+                    ],
+                    "X-Oauth-Scopes": [
+                        "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user"
+                    ],
+                    "X-Accepted-Oauth-Scopes": [
+                        "public_repo, repo"
+                    ],
+                    "Location": [
+                        "https://api.github.com/repos/<GITHUB_LOGIN>/an-repo"
+                    ],
+                    "X-Github-Media-Type": [
+                        "github.v3; format=json"
+                    ],
+                    "Access-Control-Expose-Headers": [
+                        "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ],
+                    "Content-Security-Policy": [
+                        "default-src 'none'"
+                    ],
+                    "Strict-Transport-Security": [
+                        "max-age=31536000; includeSubdomains; preload"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "X-Frame-Options": [
+                        "deny"
+                    ],
+                    "X-Xss-Protection": [
+                        "1; mode=block"
+                    ],
+                    "X-Served-By": [
+                        "a241e1a8264a6ace03db946c85b92db3"
+                    ],
+                    "X-Github-Request-Id": [
+                        "4B765081:B214:1290082:5735DD5B"
+                    ]
+                },
+                "body": {
+                    "encoding": "UTF-8",
+                    "base64_string": "eyJpZCI6NTg3NDQ4ODgsIm5hbWUiOiJhbi1yZXBvIiwiZnVsbF9uYW1lIjoi\nPEdJVEhVQl9MT0dJTj4vYW4tcmVwbyIsIm93bmVyIjp7ImxvZ2luIjoiPEdJ\nVEhVQl9MT0dJTj4iLCJpZCI6MTI0MzUzMjksImF2YXRhcl91cmwiOiJodHRw\nczovL2F2YXRhcnMuZ2l0aHVidXNlcmNvbnRlbnQuY29tL3UvMTI0MzUzMjk/\ndj0zIiwiZ3JhdmF0YXJfaWQiOiIiLCJ1cmwiOiJodHRwczovL2FwaS5naXRo\ndWIuY29tL3VzZXJzLzxHSVRIVUJfTE9HSU4+IiwiaHRtbF91cmwiOiJodHRw\nczovL2dpdGh1Yi5jb20vPEdJVEhVQl9MT0dJTj4iLCJmb2xsb3dlcnNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy88R0lUSFVCX0xPR0lO\nPi9mb2xsb3dlcnMiLCJmb2xsb3dpbmdfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS91c2Vycy88R0lUSFVCX0xPR0lOPi9mb2xsb3dpbmd7L290aGVy\nX3VzZXJ9IiwiZ2lzdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy88R0lUSFVCX0xPR0lOPi9naXN0c3svZ2lzdF9pZH0iLCJzdGFycmVk\nX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvPEdJVEhVQl9M\nT0dJTj4vc3RhcnJlZHsvb3duZXJ9ey9yZXBvfSIsInN1YnNjcmlwdGlvbnNf\ndXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy88R0lUSFVCX0xP\nR0lOPi9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3VzZXJzLzxHSVRIVUJfTE9HSU4+L29yZ3Mi\nLCJyZXBvc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzLzxH\nSVRIVUJfTE9HSU4+L3JlcG9zIiwiZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBp\nLmdpdGh1Yi5jb20vdXNlcnMvPEdJVEhVQl9MT0dJTj4vZXZlbnRzey9wcml2\nYWN5fSIsInJlY2VpdmVkX2V2ZW50c191cmwiOiJodHRwczovL2FwaS5naXRo\ndWIuY29tL3VzZXJzLzxHSVRIVUJfTE9HSU4+L3JlY2VpdmVkX2V2ZW50cyIs\nInR5cGUiOiJVc2VyIiwic2l0ZV9hZG1pbiI6ZmFsc2V9LCJwcml2YXRlIjpm\nYWxzZSwiaHRtbF91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vPEdJVEhVQl9M\nT0dJTj4vYW4tcmVwbyIsImRlc2NyaXB0aW9uIjpudWxsLCJmb3JrIjpmYWxz\nZSwidXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy88R0lUSFVC\nX0xPR0lOPi9hbi1yZXBvIiwiZm9ya3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy88R0lUSFVCX0xPR0lOPi9hbi1yZXBvL2ZvcmtzIiwi\na2V5c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zLzxHSVRI\nVUJfTE9HSU4+L2FuLXJlcG8va2V5c3sva2V5X2lkfSIsImNvbGxhYm9yYXRv\ncnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy88R0lUSFVC\nX0xPR0lOPi9hbi1yZXBvL2NvbGxhYm9yYXRvcnN7L2NvbGxhYm9yYXRvcn0i\nLCJ0ZWFtc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zLzxH\nSVRIVUJfTE9HSU4+L2FuLXJlcG8vdGVhbXMiLCJob29rc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zLzxHSVRIVUJfTE9HSU4+L2FuLXJl\ncG8vaG9va3MiLCJpc3N1ZV9ldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy88R0lUSFVCX0xPR0lOPi9hbi1yZXBvL2lzc3Vlcy9l\ndmVudHN7L251bWJlcn0iLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy88R0lUSFVCX0xPR0lOPi9hbi1yZXBvL2V2ZW50cyIs\nImFzc2lnbmVlc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9z\nLzxHSVRIVUJfTE9HSU4+L2FuLXJlcG8vYXNzaWduZWVzey91c2VyfSIsImJy\nYW5jaGVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvPEdJ\nVEhVQl9MT0dJTj4vYW4tcmVwby9icmFuY2hlc3svYnJhbmNofSIsInRhZ3Nf\ndXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy88R0lUSFVCX0xP\nR0lOPi9hbi1yZXBvL3RhZ3MiLCJibG9ic191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zLzxHSVRIVUJfTE9HSU4+L2FuLXJlcG8vZ2l0L2Js\nb2Jzey9zaGF9IiwiZ2l0X3RhZ3NfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy88R0lUSFVCX0xPR0lOPi9hbi1yZXBvL2dpdC90YWdzey9z\naGF9IiwiZ2l0X3JlZnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9y\nZXBvcy88R0lUSFVCX0xPR0lOPi9hbi1yZXBvL2dpdC9yZWZzey9zaGF9Iiwi\ndHJlZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy88R0lU\nSFVCX0xPR0lOPi9hbi1yZXBvL2dpdC90cmVlc3svc2hhfSIsInN0YXR1c2Vz\nX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvPEdJVEhVQl9M\nT0dJTj4vYW4tcmVwby9zdGF0dXNlcy97c2hhfSIsImxhbmd1YWdlc191cmwi\nOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zLzxHSVRIVUJfTE9HSU4+\nL2FuLXJlcG8vbGFuZ3VhZ2VzIiwic3RhcmdhemVyc191cmwiOiJodHRwczov\nL2FwaS5naXRodWIuY29tL3JlcG9zLzxHSVRIVUJfTE9HSU4+L2FuLXJlcG8v\nc3RhcmdhemVycyIsImNvbnRyaWJ1dG9yc191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3JlcG9zLzxHSVRIVUJfTE9HSU4+L2FuLXJlcG8vY29udHJp\nYnV0b3JzIiwic3Vic2NyaWJlcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHVi\nLmNvbS9yZXBvcy88R0lUSFVCX0xPR0lOPi9hbi1yZXBvL3N1YnNjcmliZXJz\nIiwic3Vic2NyaXB0aW9uX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvPEdJVEhVQl9MT0dJTj4vYW4tcmVwby9zdWJzY3JpcHRpb24iLCJj\nb21taXRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvPEdJ\nVEhVQl9MT0dJTj4vYW4tcmVwby9jb21taXRzey9zaGF9IiwiZ2l0X2NvbW1p\ndHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy88R0lUSFVC\nX0xPR0lOPi9hbi1yZXBvL2dpdC9jb21taXRzey9zaGF9IiwiY29tbWVudHNf\ndXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy88R0lUSFVCX0xP\nR0lOPi9hbi1yZXBvL2NvbW1lbnRzey9udW1iZXJ9IiwiaXNzdWVfY29tbWVu\ndF91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zLzxHSVRIVUJf\nTE9HSU4+L2FuLXJlcG8vaXNzdWVzL2NvbW1lbnRzey9udW1iZXJ9IiwiY29u\ndGVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9yZXBvcy88R0lU\nSFVCX0xPR0lOPi9hbi1yZXBvL2NvbnRlbnRzL3srcGF0aH0iLCJjb21wYXJl\nX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvPEdJVEhVQl9M\nT0dJTj4vYW4tcmVwby9jb21wYXJlL3tiYXNlfS4uLntoZWFkfSIsIm1lcmdl\nc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zLzxHSVRIVUJf\nTE9HSU4+L2FuLXJlcG8vbWVyZ2VzIiwiYXJjaGl2ZV91cmwiOiJodHRwczov\nL2FwaS5naXRodWIuY29tL3JlcG9zLzxHSVRIVUJfTE9HSU4+L2FuLXJlcG8v\ne2FyY2hpdmVfZm9ybWF0fXsvcmVmfSIsImRvd25sb2Fkc191cmwiOiJodHRw\nczovL2FwaS5naXRodWIuY29tL3JlcG9zLzxHSVRIVUJfTE9HSU4+L2FuLXJl\ncG8vZG93bmxvYWRzIiwiaXNzdWVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1\nYi5jb20vcmVwb3MvPEdJVEhVQl9MT0dJTj4vYW4tcmVwby9pc3N1ZXN7L251\nbWJlcn0iLCJwdWxsc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Jl\ncG9zLzxHSVRIVUJfTE9HSU4+L2FuLXJlcG8vcHVsbHN7L251bWJlcn0iLCJt\naWxlc3RvbmVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3Mv\nPEdJVEhVQl9MT0dJTj4vYW4tcmVwby9taWxlc3RvbmVzey9udW1iZXJ9Iiwi\nbm90aWZpY2F0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Jl\ncG9zLzxHSVRIVUJfTE9HSU4+L2FuLXJlcG8vbm90aWZpY2F0aW9uc3s/c2lu\nY2UsYWxsLHBhcnRpY2lwYXRpbmd9IiwibGFiZWxzX3VybCI6Imh0dHBzOi8v\nYXBpLmdpdGh1Yi5jb20vcmVwb3MvPEdJVEhVQl9MT0dJTj4vYW4tcmVwby9s\nYWJlbHN7L25hbWV9IiwicmVsZWFzZXNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0\naHViLmNvbS9yZXBvcy88R0lUSFVCX0xPR0lOPi9hbi1yZXBvL3JlbGVhc2Vz\ney9pZH0iLCJkZXBsb3ltZW50c191cmwiOiJodHRwczovL2FwaS5naXRodWIu\nY29tL3JlcG9zLzxHSVRIVUJfTE9HSU4+L2FuLXJlcG8vZGVwbG95bWVudHMi\nLCJjcmVhdGVkX2F0IjoiMjAxNi0wNS0xM1QxMzo1Nzo0N1oiLCJ1cGRhdGVk\nX2F0IjoiMjAxNi0wNS0xM1QxMzo1Nzo0N1oiLCJwdXNoZWRfYXQiOiIyMDE2\nLTA1LTEzVDEzOjU3OjQ4WiIsImdpdF91cmwiOiJnaXQ6Ly9naXRodWIuY29t\nLzxHSVRIVUJfTE9HSU4+L2FuLXJlcG8uZ2l0Iiwic3NoX3VybCI6ImdpdEBn\naXRodWIuY29tOjxHSVRIVUJfTE9HSU4+L2FuLXJlcG8uZ2l0IiwiY2xvbmVf\ndXJsIjoiaHR0cHM6Ly9naXRodWIuY29tLzxHSVRIVUJfTE9HSU4+L2FuLXJl\ncG8uZ2l0Iiwic3ZuX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS88R0lUSFVC\nX0xPR0lOPi9hbi1yZXBvIiwiaG9tZXBhZ2UiOm51bGwsInNpemUiOjAsInN0\nYXJnYXplcnNfY291bnQiOjAsIndhdGNoZXJzX2NvdW50IjowLCJsYW5ndWFn\nZSI6bnVsbCwiaGFzX2lzc3VlcyI6dHJ1ZSwiaGFzX2Rvd25sb2FkcyI6dHJ1\nZSwiaGFzX3dpa2kiOnRydWUsImhhc19wYWdlcyI6ZmFsc2UsImZvcmtzX2Nv\ndW50IjowLCJtaXJyb3JfdXJsIjpudWxsLCJvcGVuX2lzc3Vlc19jb3VudCI6\nMCwiZm9ya3MiOjAsIm9wZW5faXNzdWVzIjowLCJ3YXRjaGVycyI6MCwiZGVm\nYXVsdF9icmFuY2giOiJtYXN0ZXIiLCJwZXJtaXNzaW9ucyI6eyJhZG1pbiI6\ndHJ1ZSwicHVzaCI6dHJ1ZSwicHVsbCI6dHJ1ZX0sIm5ldHdvcmtfY291bnQi\nOjAsInN1YnNjcmliZXJzX2NvdW50IjoxfQ==\n"
+                },
+                "http_version": null
+            },
+            "recorded_at": "Fri, 13 May 2016 13:57:48 GMT"
+        },
+        {
+            "request": {
+                "method": "post",
+                "uri": "https://api.github.com/repos/<GITHUB_LOGIN>/an-repo/issues",
+                "body": {
+                    "encoding": "UTF-8",
+                    "base64_string": "eyJsYWJlbHMiOltdLCJ0aXRsZSI6Ik1pZ3JhdGUgaXNzdWVzIHRvIHYzIiwi\nYm9keSI6Ik1vdmUgYWxsIElzc3VlcyBjYWxscyB0byB2MyBvZiB0aGUgQVBJ\nIn0=\n"
+                },
+                "headers": {
+                    "Accept": [
+                        "application/vnd.github.v3+json"
+                    ],
+                    "User-Agent": [
+                        "Octokit Ruby Gem 4.3.0"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "Authorization": [
+                        "token <<ACCESS_TOKEN>>"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 201,
+                    "message": "Created"
+                },
+                "headers": {
+                    "Server": [
+                        "GitHub.com"
+                    ],
+                    "Date": [
+                        "Fri, 13 May 2016 13:57:48 GMT"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "Content-Length": [
+                        "1898"
+                    ],
+                    "Status": [
+                        "201 Created"
+                    ],
+                    "X-Ratelimit-Limit": [
+                        "5000"
+                    ],
+                    "X-Ratelimit-Remaining": [
+                        "4708"
+                    ],
+                    "X-Ratelimit-Reset": [
+                        "1463149720"
+                    ],
+                    "Cache-Control": [
+                        "private, max-age=60, s-maxage=60"
+                    ],
+                    "Vary": [
+                        "Accept, Authorization, Cookie, X-GitHub-OTP",
+                        "Accept-Encoding"
+                    ],
+                    "Etag": [
+                        "\"14ad3596b66cf9dfdc0a475b36c51981\""
+                    ],
+                    "X-Oauth-Scopes": [
+                        "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user"
+                    ],
+                    "X-Accepted-Oauth-Scopes": [
+                        ""
+                    ],
+                    "Location": [
+                        "https://api.github.com/repos/<GITHUB_LOGIN>/an-repo/issues/1"
+                    ],
+                    "X-Github-Media-Type": [
+                        "github.v3; format=json"
+                    ],
+                    "Access-Control-Expose-Headers": [
+                        "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ],
+                    "Content-Security-Policy": [
+                        "default-src 'none'"
+                    ],
+                    "Strict-Transport-Security": [
+                        "max-age=31536000; includeSubdomains; preload"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "X-Frame-Options": [
+                        "deny"
+                    ],
+                    "X-Xss-Protection": [
+                        "1; mode=block"
+                    ],
+                    "X-Served-By": [
+                        "139317cebd6caf9cd03889139437f00b"
+                    ],
+                    "X-Github-Request-Id": [
+                        "4B765081:B215:15E96D1:5735DD5C"
+                    ]
+                },
+                "body": {
+                    "encoding": "UTF-8",
+                    "base64_string": "eyJ1cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zLzxHSVRIVUJf\nTE9HSU4+L2FuLXJlcG8vaXNzdWVzLzEiLCJyZXBvc2l0b3J5X3VybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvPEdJVEhVQl9MT0dJTj4vYW4t\ncmVwbyIsImxhYmVsc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Jl\ncG9zLzxHSVRIVUJfTE9HSU4+L2FuLXJlcG8vaXNzdWVzLzEvbGFiZWxzey9u\nYW1lfSIsImNvbW1lbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20v\ncmVwb3MvPEdJVEhVQl9MT0dJTj4vYW4tcmVwby9pc3N1ZXMvMS9jb21tZW50\ncyIsImV2ZW50c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9z\nLzxHSVRIVUJfTE9HSU4+L2FuLXJlcG8vaXNzdWVzLzEvZXZlbnRzIiwiaHRt\nbF91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vPEdJVEhVQl9MT0dJTj4vYW4t\ncmVwby9pc3N1ZXMvMSIsImlkIjoxNTQ3MTc4MjksIm51bWJlciI6MSwidGl0\nbGUiOiJNaWdyYXRlIGlzc3VlcyB0byB2MyIsInVzZXIiOnsibG9naW4iOiI8\nR0lUSFVCX0xPR0lOPiIsImlkIjoxMjQzNTMyOSwiYXZhdGFyX3VybCI6Imh0\ndHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5jb20vdS8xMjQzNTMy\nOT92PTMiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vdXNlcnMvPEdJVEhVQl9MT0dJTj4iLCJodG1sX3VybCI6Imh0\ndHBzOi8vZ2l0aHViLmNvbS88R0lUSFVCX0xPR0lOPiIsImZvbGxvd2Vyc191\ncmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzLzxHSVRIVUJfTE9H\nSU4+L2ZvbGxvd2VycyIsImZvbGxvd2luZ191cmwiOiJodHRwczovL2FwaS5n\naXRodWIuY29tL3VzZXJzLzxHSVRIVUJfTE9HSU4+L2ZvbGxvd2luZ3svb3Ro\nZXJfdXNlcn0iLCJnaXN0c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29t\nL3VzZXJzLzxHSVRIVUJfTE9HSU4+L2dpc3Rzey9naXN0X2lkfSIsInN0YXJy\nZWRfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy88R0lUSFVC\nX0xPR0lOPi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwic3Vic2NyaXB0aW9u\nc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzLzxHSVRIVUJf\nTE9HSU4+L3N1YnNjcmlwdGlvbnMiLCJvcmdhbml6YXRpb25zX3VybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvPEdJVEhVQl9MT0dJTj4vb3Jn\ncyIsInJlcG9zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMv\nPEdJVEhVQl9MT0dJTj4vcmVwb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9h\ncGkuZ2l0aHViLmNvbS91c2Vycy88R0lUSFVCX0xPR0lOPi9ldmVudHN7L3By\naXZhY3l9IiwicmVjZWl2ZWRfZXZlbnRzX3VybCI6Imh0dHBzOi8vYXBpLmdp\ndGh1Yi5jb20vdXNlcnMvPEdJVEhVQl9MT0dJTj4vcmVjZWl2ZWRfZXZlbnRz\nIiwidHlwZSI6IlVzZXIiLCJzaXRlX2FkbWluIjpmYWxzZX0sImxhYmVscyI6\nW10sInN0YXRlIjoib3BlbiIsImxvY2tlZCI6ZmFsc2UsImFzc2lnbmVlIjpu\ndWxsLCJtaWxlc3RvbmUiOm51bGwsImNvbW1lbnRzIjowLCJjcmVhdGVkX2F0\nIjoiMjAxNi0wNS0xM1QxMzo1Nzo0OFoiLCJ1cGRhdGVkX2F0IjoiMjAxNi0w\nNS0xM1QxMzo1Nzo0OFoiLCJjbG9zZWRfYXQiOm51bGwsImJvZHkiOiJNb3Zl\nIGFsbCBJc3N1ZXMgY2FsbHMgdG8gdjMgb2YgdGhlIEFQSSIsImNsb3NlZF9i\neSI6bnVsbH0=\n"
+                },
+                "http_version": null
+            },
+            "recorded_at": "Fri, 13 May 2016 13:57:48 GMT"
+        },
+        {
+            "request": {
+                "method": "post",
+                "uri": "https://api.github.com/repos/<GITHUB_LOGIN>/an-repo/issues/1/comments",
+                "body": {
+                    "encoding": "UTF-8",
+                    "base64_string": "eyJib2R5IjoiQW5vdGhlciB0ZXN0IGNvbW1lbnQifQ==\n"
+                },
+                "headers": {
+                    "Accept": [
+                        "application/vnd.github.v3+json"
+                    ],
+                    "User-Agent": [
+                        "Octokit Ruby Gem 4.3.0"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "Authorization": [
+                        "token <<ACCESS_TOKEN>>"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 201,
+                    "message": "Created"
+                },
+                "headers": {
+                    "Server": [
+                        "GitHub.com"
+                    ],
+                    "Date": [
+                        "Fri, 13 May 2016 13:57:49 GMT"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "Content-Length": [
+                        "1470"
+                    ],
+                    "Status": [
+                        "201 Created"
+                    ],
+                    "X-Ratelimit-Limit": [
+                        "5000"
+                    ],
+                    "X-Ratelimit-Remaining": [
+                        "4707"
+                    ],
+                    "X-Ratelimit-Reset": [
+                        "1463149720"
+                    ],
+                    "Cache-Control": [
+                        "private, max-age=60, s-maxage=60"
+                    ],
+                    "Vary": [
+                        "Accept, Authorization, Cookie, X-GitHub-OTP",
+                        "Accept-Encoding"
+                    ],
+                    "Etag": [
+                        "\"8e6e6412c7cec8a8ea8edf55cae601b3\""
+                    ],
+                    "X-Oauth-Scopes": [
+                        "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user"
+                    ],
+                    "X-Accepted-Oauth-Scopes": [
+                        ""
+                    ],
+                    "Location": [
+                        "https://api.github.com/repos/<GITHUB_LOGIN>/an-repo/issues/comments/219050296"
+                    ],
+                    "X-Github-Media-Type": [
+                        "github.v3; format=json"
+                    ],
+                    "Access-Control-Expose-Headers": [
+                        "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ],
+                    "Content-Security-Policy": [
+                        "default-src 'none'"
+                    ],
+                    "Strict-Transport-Security": [
+                        "max-age=31536000; includeSubdomains; preload"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "X-Frame-Options": [
+                        "deny"
+                    ],
+                    "X-Xss-Protection": [
+                        "1; mode=block"
+                    ],
+                    "X-Served-By": [
+                        "593010132f82159af0ded24b4932e109"
+                    ],
+                    "X-Github-Request-Id": [
+                        "4B765081:B214:12902E3:5735DD5C"
+                    ]
+                },
+                "body": {
+                    "encoding": "UTF-8",
+                    "base64_string": "eyJ1cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zLzxHSVRIVUJf\nTE9HSU4+L2FuLXJlcG8vaXNzdWVzL2NvbW1lbnRzLzIxOTA1MDI5NiIsImh0\nbWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tLzxHSVRIVUJfTE9HSU4+L2Fu\nLXJlcG8vaXNzdWVzLzEjaXNzdWVjb21tZW50LTIxOTA1MDI5NiIsImlzc3Vl\nX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvPEdJVEhVQl9M\nT0dJTj4vYW4tcmVwby9pc3N1ZXMvMSIsImlkIjoyMTkwNTAyOTYsInVzZXIi\nOnsibG9naW4iOiI8R0lUSFVCX0xPR0lOPiIsImlkIjoxMjQzNTMyOSwiYXZh\ndGFyX3VybCI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5j\nb20vdS8xMjQzNTMyOT92PTMiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvPEdJVEhVQl9MT0dJTj4iLCJo\ndG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS88R0lUSFVCX0xPR0lOPiIs\nImZvbGxvd2Vyc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJz\nLzxHSVRIVUJfTE9HSU4+L2ZvbGxvd2VycyIsImZvbGxvd2luZ191cmwiOiJo\ndHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzLzxHSVRIVUJfTE9HSU4+L2Zv\nbGxvd2luZ3svb3RoZXJfdXNlcn0iLCJnaXN0c191cmwiOiJodHRwczovL2Fw\naS5naXRodWIuY29tL3VzZXJzLzxHSVRIVUJfTE9HSU4+L2dpc3Rzey9naXN0\nX2lkfSIsInN0YXJyZWRfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91\nc2Vycy88R0lUSFVCX0xPR0lOPi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwi\nc3Vic2NyaXB0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3Vz\nZXJzLzxHSVRIVUJfTE9HSU4+L3N1YnNjcmlwdGlvbnMiLCJvcmdhbml6YXRp\nb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvPEdJVEhV\nQl9MT0dJTj4vb3JncyIsInJlcG9zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1\nYi5jb20vdXNlcnMvPEdJVEhVQl9MT0dJTj4vcmVwb3MiLCJldmVudHNfdXJs\nIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy88R0lUSFVCX0xPR0lO\nPi9ldmVudHN7L3ByaXZhY3l9IiwicmVjZWl2ZWRfZXZlbnRzX3VybCI6Imh0\ndHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvPEdJVEhVQl9MT0dJTj4vcmVj\nZWl2ZWRfZXZlbnRzIiwidHlwZSI6IlVzZXIiLCJzaXRlX2FkbWluIjpmYWxz\nZX0sImNyZWF0ZWRfYXQiOiIyMDE2LTA1LTEzVDEzOjU3OjQ5WiIsInVwZGF0\nZWRfYXQiOiIyMDE2LTA1LTEzVDEzOjU3OjQ5WiIsImJvZHkiOiJBbm90aGVy\nIHRlc3QgY29tbWVudCJ9\n"
+                },
+                "http_version": null
+            },
+            "recorded_at": "Fri, 13 May 2016 13:57:49 GMT"
+        },
+        {
+            "request": {
+                "method": "post",
+                "uri": "https://api.github.com/repos/<GITHUB_LOGIN>/an-repo/issues/comments/219050296/reactions",
+                "body": {
+                    "encoding": "UTF-8",
+                    "base64_string": "eyJjb250ZW50IjoiKzEifQ==\n"
+                },
+                "headers": {
+                    "Accept": [
+                        "application/vnd.github.squirrel-girl-preview"
+                    ],
+                    "User-Agent": [
+                        "Octokit Ruby Gem 4.3.0"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "Authorization": [
+                        "token <<ACCESS_TOKEN>>"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 201,
+                    "message": "Created"
+                },
+                "headers": {
+                    "Server": [
+                        "GitHub.com"
+                    ],
+                    "Date": [
+                        "Fri, 13 May 2016 13:57:49 GMT"
+                    ],
+                    "Content-Type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "Content-Length": [
+                        "47"
+                    ],
+                    "Status": [
+                        "201 Created"
+                    ],
+                    "X-Ratelimit-Limit": [
+                        "5000"
+                    ],
+                    "X-Ratelimit-Remaining": [
+                        "4706"
+                    ],
+                    "X-Ratelimit-Reset": [
+                        "1463149720"
+                    ],
+                    "Cache-Control": [
+                        "private, max-age=60, s-maxage=60"
+                    ],
+                    "Vary": [
+                        "Accept, Authorization, Cookie, X-GitHub-OTP",
+                        "Accept-Encoding"
+                    ],
+                    "Etag": [
+                        "\"e91775fa51e3030171d5a5589f949c57\""
+                    ],
+                    "X-Oauth-Scopes": [
+                        "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user"
+                    ],
+                    "X-Accepted-Oauth-Scopes": [
+                        ""
+                    ],
+                    "X-Github-Media-Type": [
+                        "github.squirrel-girl-preview"
+                    ],
+                    "Access-Control-Expose-Headers": [
+                        "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ],
+                    "Content-Security-Policy": [
+                        "default-src 'none'"
+                    ],
+                    "Strict-Transport-Security": [
+                        "max-age=31536000; includeSubdomains; preload"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "X-Frame-Options": [
+                        "deny"
+                    ],
+                    "X-Xss-Protection": [
+                        "1; mode=block"
+                    ],
+                    "X-Served-By": [
+                        "e724c57ebb9961c772a91e2dd7421c8d"
+                    ],
+                    "X-Github-Request-Id": [
+                        "4B765081:B215:15E97DA:5735DD5D"
+                    ]
+                },
+                "body": {
+                    "encoding": "UTF-8",
+                    "base64_string": "eyJpZCI6OTg0ODE1LCJ1c2VyX2lkIjoxMjQzNTMyOSwiY29udGVudCI6Iisx\nIn0=\n"
+                },
+                "http_version": null
+            },
+            "recorded_at": "Fri, 13 May 2016 13:57:49 GMT"
+        },
+        {
+            "request": {
+              "method": "delete",
+              "uri": "https://api.github.com/repos/<GITHUB_LOGIN>/an-repo/issues/comments/219050296/reactions/984815",
+              "body": {
+                "encoding": "UTF-8",
+                "base64_string": "e30=\n"
+              },
+              "headers": {
+                "Accept": [
+                  "application/vnd.github.squirrel-girl-preview"
+                ],
+                "User-Agent": [
+                  "Octokit Ruby Gem 4.3.0"
+                ],
+                "Content-Type": [
+                  "application/json"
+                ],
+                "Authorization": [
+                  "token <<ACCESS_TOKEN>>"
+                ],
+                "Accept-Encoding": [
+                  "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+                ]
+              }
+            },
+            "response": {
+              "status": {
+                "code": 204,
+                "message": "No Content"
+              },
+              "headers": {
+                "Server": [
+                  "GitHub.com"
+                ],
+                "Date": [
+                  "Fri, 13 May 2016 13:57:45 GMT"
+                ],
+                "Status": [
+                  "204 No Content"
+                ],
+                "X-Ratelimit-Limit": [
+                  "5000"
+                ],
+                "X-Ratelimit-Remaining": [
+                  "4716"
+                ],
+                "X-Ratelimit-Reset": [
+                  "1463149720"
+                ],
+                "X-Oauth-Scopes": [
+                  "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user"
+                ],
+                "X-Accepted-Oauth-Scopes": [
+                  "repo"
+                ],
+                "X-Github-Media-Type": [
+                  "github.squirrel-girl-preview"
+                ],
+                "Access-Control-Expose-Headers": [
+                  "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval"
+                ],
+                "Access-Control-Allow-Origin": [
+                  "*"
+                ],
+                "Content-Security-Policy": [
+                  "default-src 'none'"
+                ],
+                "Strict-Transport-Security": [
+                  "max-age=31536000; includeSubdomains; preload"
+                ],
+                "X-Content-Type-Options": [
+                  "nosniff"
+                ],
+                "X-Frame-Options": [
+                  "deny"
+                ],
+                "X-Xss-Protection": [
+                  "1; mode=block"
+                ],
+                "Vary": [
+                  "Accept-Encoding"
+                ],
+                "X-Served-By": [
+                  "b0ef53392caa42315c6206737946d931"
+                ],
+                "X-Github-Request-Id": [
+                  "4B765081:B214:128FBF1:5735DD58"
+                ]
+              },
+              "body": {
+                "encoding": "UTF-8",
+                "base64_string": ""
+              },
+              "http_version": null
+            },
+            "recorded_at": "Fri, 13 May 2016 13:57:45 GMT"
+          },
+        {
+            "request": {
+                "method": "delete",
+                "uri": "https://api.github.com/repos/<GITHUB_LOGIN>/an-repo",
+                "body": {
+                    "encoding": "UTF-8",
+                    "base64_string": "e30=\n"
+                },
+                "headers": {
+                    "Accept": [
+                        "application/vnd.github.v3+json"
+                    ],
+                    "User-Agent": [
+                        "Octokit Ruby Gem 4.3.0"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "Authorization": [
+                        "token <<ACCESS_TOKEN>>"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 204,
+                    "message": "No Content"
+                },
+                "headers": {
+                    "Server": [
+                        "GitHub.com"
+                    ],
+                    "Date": [
+                        "Fri, 13 May 2016 13:57:49 GMT"
+                    ],
+                    "Status": [
+                        "204 No Content"
+                    ],
+                    "X-Ratelimit-Limit": [
+                        "5000"
+                    ],
+                    "X-Ratelimit-Remaining": [
+                        "4705"
+                    ],
+                    "X-Ratelimit-Reset": [
+                        "1463149720"
+                    ],
+                    "X-Oauth-Scopes": [
+                        "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user"
+                    ],
+                    "X-Accepted-Oauth-Scopes": [
+                        "delete_repo"
+                    ],
+                    "X-Github-Media-Type": [
+                        "github.v3; format=json"
+                    ],
+                    "Access-Control-Expose-Headers": [
+                        "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ],
+                    "Content-Security-Policy": [
+                        "default-src 'none'"
+                    ],
+                    "Strict-Transport-Security": [
+                        "max-age=31536000; includeSubdomains; preload"
+                    ],
+                    "X-Content-Type-Options": [
+                        "nosniff"
+                    ],
+                    "X-Frame-Options": [
+                        "deny"
+                    ],
+                    "X-Xss-Protection": [
+                        "1; mode=block"
+                    ],
+                    "Vary": [
+                        "Accept-Encoding"
+                    ],
+                    "X-Served-By": [
+                        "e724c57ebb9961c772a91e2dd7421c8d"
+                    ],
+                    "X-Github-Request-Id": [
+                        "4B765081:B214:12903A5:5735DD5D"
+                    ]
+                },
+                "body": {
+                    "encoding": "UTF-8",
+                    "base64_string": ""
+                },
+                "http_version": null
+            },
+            "recorded_at": "Fri, 13 May 2016 13:57:49 GMT"
+        }
+    ],
+    "recorded_with": "VCR 2.9.3"
+}

--- a/spec/octokit/client/reactions_spec.rb
+++ b/spec/octokit/client/reactions_spec.rb
@@ -83,6 +83,15 @@ describe Octokit::Client::Reactions do
             assert_requested :post, github_url("/repos/#{@repo.full_name}/issues/comments/#{@issue_comment.id}/reactions")
           end
         end # .create_issue_comment_reaction
+
+        describe '.delete_issue_comment_reaction' do
+          it 'deletes the reaction' do
+            reaction = @client.create_issue_comment_reaction(@repo.full_name, @issue_comment.id, '-1')
+            result = @client.delete_issue_comment_reaction(@repo.full_name, @issue_comment.id, reaction.id)
+            expect(result).to be_truthy
+            assert_requested :delete, github_url("/repos/#{@repo.full_name}/issues/comments/#{@issue_comment.id}/reactions/#{reaction.id}")
+          end
+        end # .delete_issue_comment_reaction
       end # with issue comment
 
       context 'with reaction' do


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Octokit.rb was missing the `delete_issue_comment_reaction()` method.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* This method has been implemented so that users can call `.delete_issue_comment_reaction()` to delete a reaction from a given issue comment.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

I used the documentation found [here](https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/bf6cc4c0237abd467c1a6125f675db1ea4f7eaab/docs/reactions/deleteForIssueComment.md) to construct this method.

---

related: https://github.com/octokit/octokit.rb/pull/1637
