### PR TITLE
Fix string validation errors

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -191,6 +191,7 @@ module Octokit
       return nil unless data.is_a?(Hash) && !Array(data[:errors]).empty?
 
       summary = +"\nError summary:\n"
+      return summary << data[:errors] if data[:errors].is_a?(String)
       summary << data[:errors].map do |error|
         if error.is_a? Hash
           error.map { |k, v| "  #{k}: #{v}" }

--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -192,6 +192,7 @@ module Octokit
 
       summary = +"\nError summary:\n"
       return summary << data[:errors] if data[:errors].is_a?(String)
+
       summary << data[:errors].map do |error|
         if error.is_a? Hash
           error.map { |k, v| "  #{k}: #{v}" }

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -839,6 +839,25 @@ describe Octokit::Client do
       end
     end
 
+    it 'exposes errors string' do
+      stub_get('/boom')
+        .to_return \
+          status: 422,
+          headers: {
+            content_type: 'application/json'
+          },
+          body: {
+            message: 'Validation Failed',
+            errors: 'Issue'
+          }.to_json
+      begin
+        Octokit.get('/boom')
+      rescue Octokit::UnprocessableEntity => e
+        expect(e.message).to include('GET https://api.github.com/boom: 422 - Validation Failed')
+        expect(e.message).to include('Issue')
+      end
+    end
+
     it 'knows the difference between different kinds of forbidden' do
       stub_get('/some/admin/stuffs').to_return(status: 403)
       expect { Octokit.get('/some/admin/stuffs') }.to raise_error Octokit::Forbidden

--- a/spec/octokit/client_spec.rb
+++ b/spec/octokit/client_spec.rb
@@ -950,7 +950,13 @@ describe Octokit::Client do
         expect(e.message).to include('Error summary:')
         expect(e.message).to include('field: some field')
         expect(e.message).to include('issue: some issue')
-        expect(e.message).to include('details: {:subfield=>"value"}')
+        # Ruby, depending on the version, may format the hash differently
+        # either with a ligature (=>) or a colon (:)
+        # '{:subfield => "value"}' or '{subfield: "value"}'
+        # so we use a regex to match either for the test assertion
+        expect(e.message).to match(
+          /details: \{(?::subfield\s*=>\s*"value"|subfield:\s*"value")\}/
+        )
       end
     end
 


### PR DESCRIPTION
Just came across this in the wild

https://github.com/openSUSE/open-build-service/issues/17535

Apparently sometimes the validation json is formated like that.

----

### Before the change?

* `Octokit::Error.response_error_summary` crashes

### After the change?

* `Octokit::Error.response_error_summary` succeeds 

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

----

