### PR TITLE
Bump major version to v10.0.0

### DIFF
--- a/lib/octokit/version.rb
+++ b/lib/octokit/version.rb
@@ -3,11 +3,11 @@
 module Octokit
   # Current major release.
   # @return [Integer]
-  MAJOR = 9
+  MAJOR = 10
 
   # Current minor release.
   # @return [Integer]
-  MINOR = 2
+  MINOR = 0
 
   # Current patch level.
   # @return [Integer]


### PR DESCRIPTION
When merging #1740 and going to release, I didn't realize that #1720 had been merged but not released yet and the major version hadn't been updated. This change updates the major version so I can release [v10.0.0](https://github.com/octokit/octokit.rb/releases/tag/v10.0.0) to RubyGems using [script/release](https://github.com/octokit/octokit.rb/blob/main/script/release). 