### PR TITLE
fix: Check for empty spaces and illegal characters in JSON body of error responses

### DIFF
--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -162,12 +162,12 @@ module Octokit
 
     def data
       @data ||=
-        if (body = @response[:body]) && !body.empty?
+        if (body = @response[:body]) && !body.strip.empty? && body.start_with?("{")
           if body.is_a?(String) &&
              @response[:response_headers] &&
              @response[:response_headers][:content_type] =~ /json/
 
-            Sawyer::Agent.serializer.decode(body.strip)
+            Sawyer::Agent.serializer.decode(body)
           else
             body
           end

--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -162,16 +162,22 @@ module Octokit
 
     def data
       @data ||=
-        if (body = @response[:body]) && !body.strip.empty? && body.start_with?("{")
-          if body.is_a?(String) &&
-             @response[:response_headers] &&
-             @response[:response_headers][:content_type] =~ /json/
+        if (body = @response[:body]) && !body.empty?
+          if valid_json_body?(body)
 
             Sawyer::Agent.serializer.decode(body)
           else
             body
           end
         end
+    end
+
+    def valid_json_body?(body)
+      body.is_a?(String) &&
+        @response[:response_headers] &&
+        @response[:response_headers][:content_type] =~ /json/ &&
+        !body.strip.empty? &&
+        body.start_with?("{")
     end
 
     def response_message

--- a/lib/octokit/error.rb
+++ b/lib/octokit/error.rb
@@ -167,7 +167,7 @@ module Octokit
              @response[:response_headers] &&
              @response[:response_headers][:content_type] =~ /json/
 
-            Sawyer::Agent.serializer.decode(body)
+            Sawyer::Agent.serializer.decode(body.strip)
           else
             body
           end


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1777

I noticed that sometimes GitHub returns `" "` string (string with one empty space) or `"<illegal-character>{}"` in error responses, which leads to `Json::ParseError` exceptions.
If we `#strip` the body and check that it starts with `{`, we will avoid errors down the road.
WDYT?

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

*  We pass the whole error response body to [Sawyer::Agent.serializer#decode](https://github.com/Lokideos/octokit.rb/blob/main/lib/octokit/error.rb#L170C13-L170C19), which leads to errors when the body looks like `" "`.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* We strip body of empty spaces before passing it to [Sawyer::Agent.serializer#decode](https://github.com/Lokideos/octokit.rb/blob/main/lib/octokit/error.rb#L170C13-L170C19) to avoid `Json::ParseError` exceptions.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->
No

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

