### PR TITLE
Boolean from response should include all successful 2XX response codes

### DIFF
--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -9,7 +9,7 @@ module Octokit
 
     # Header keys that can be passed in options hash to {#get},{#head}
     CONVENIENCE_HEADERS = Set.new(%i[accept content_type])
-    SUCCESSFUL_RESPONSES = [200, 201, 202, 204].freeze
+    SUCCESSFUL_RESPONSES = (200..299)
 
     # Make a HTTP GET request
     #
@@ -168,7 +168,7 @@ module Octokit
     # @return [Boolean] True on success, false otherwise
     def boolean_from_response(method, path, options = {})
       request(method, path, options)
-      SUCCESSFUL_RESPONSES.include? @last_response.status
+      SUCCESSFUL_RESPONSES.cover? @last_response.status
     rescue Octokit::NotFound
       false
     end

--- a/lib/octokit/connection.rb
+++ b/lib/octokit/connection.rb
@@ -9,6 +9,7 @@ module Octokit
 
     # Header keys that can be passed in options hash to {#get},{#head}
     CONVENIENCE_HEADERS = Set.new(%i[accept content_type])
+    SUCCESSFUL_RESPONSES = [200, 201, 202, 204].freeze
 
     # Make a HTTP GET request
     #
@@ -167,7 +168,7 @@ module Octokit
     # @return [Boolean] True on success, false otherwise
     def boolean_from_response(method, path, options = {})
       request(method, path, options)
-      [201, 202, 204].include? @last_response.status
+      SUCCESSFUL_RESPONSES.include? @last_response.status
     rescue Octokit::NotFound
       false
     end

--- a/spec/octokit/client/actions_workflow_runs_spec.rb
+++ b/spec/octokit/client/actions_workflow_runs_spec.rb
@@ -104,7 +104,7 @@ describe Octokit::Client::ActionsWorkflowRuns, :vcr do
     end
 
     it 'returns false if request returns unexpected status' do
-      request = stub_post("repos/#{@test_repo}/actions/runs/#{@run_id}/rerun").to_return(status: 205)
+      request = stub_post("repos/#{@test_repo}/actions/runs/#{@run_id}/rerun").to_return(status: 300)
 
       response = @client.rerun_workflow_run(@test_repo, @run_id)
 
@@ -124,7 +124,7 @@ describe Octokit::Client::ActionsWorkflowRuns, :vcr do
     end
 
     it 'returns false if the request returns unexpected status' do
-      request = stub_post("repos/#{@test_repo}/actions/runs/#{@run_id}/cancel").to_return(status: 205)
+      request = stub_post("repos/#{@test_repo}/actions/runs/#{@run_id}/cancel").to_return(status: 300)
 
       response = @client.cancel_workflow_run(@test_repo, @run_id)
 


### PR DESCRIPTION
Resolves #1790

----

### Before the change?
* Workflow dispatch events started returning 200 rather than 204. boolean_from_response does not consider the entire successful response http code range.


### After the change?
* boolean_from_response now considers any 2XX response code as valid


### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
* I do not believe this introduces a breaking change. The output type of the method does not change.

----

