### PR TITLE
Add return_run_details parameter support for workflow dispatch

### DIFF
--- a/lib/octokit/client/actions_workflows.rb
+++ b/lib/octokit/client/actions_workflows.rb
@@ -36,7 +36,7 @@ module Octokit
       # @param id [Integer, String] Id or file name of the workflow
       # @param ref [String] A SHA, branch name, or tag name
       # @param options [Hash] Optional parameters
-      # @option options [Boolean] :return_run_details Fetch run details (needs API 2022-11-28)
+      # @option options [Boolean] :return_run_details Fetch run details
       #
       # @return [Boolean, Sawyer::Resource] Boolean success or run details
       # @see https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event

--- a/lib/octokit/client/actions_workflows.rb
+++ b/lib/octokit/client/actions_workflows.rb
@@ -43,7 +43,7 @@ module Octokit
       def workflow_dispatch(repo, id, ref, options = {})
         merged_params = options.merge({ ref: ref })
         endpoint_path = "#{Repository.path repo}/actions/workflows/#{id}/dispatches"
-        
+
         wants_details = merged_params[:return_run_details]
         wants_details ? post(endpoint_path, merged_params) : boolean_from_response(:post, endpoint_path, merged_params)
       end

--- a/lib/octokit/client/actions_workflows.rb
+++ b/lib/octokit/client/actions_workflows.rb
@@ -35,11 +35,17 @@ module Octokit
       # @param repo [Integer, String, Repository, Hash] A GitHub repository
       # @param id [Integer, String] Id or file name of the workflow
       # @param ref [String] A SHA, branch name, or tag name
+      # @param options [Hash] Optional parameters
+      # @option options [Boolean] :return_run_details Fetch run details (needs API 2022-11-28)
       #
-      # @return [Boolean] True if event was dispatched, false otherwise
+      # @return [Boolean, Sawyer::Resource] Boolean success or run details
       # @see https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event
       def workflow_dispatch(repo, id, ref, options = {})
-        boolean_from_response :post, "#{Repository.path repo}/actions/workflows/#{id}/dispatches", options.merge({ ref: ref })
+        merged_params = options.merge({ ref: ref })
+        endpoint_path = "#{Repository.path repo}/actions/workflows/#{id}/dispatches"
+        
+        wants_details = merged_params[:return_run_details]
+        wants_details ? post(endpoint_path, merged_params) : boolean_from_response(:post, endpoint_path, merged_params)
       end
 
       # Enable a workflow

--- a/spec/octokit/client/actions_workflows_spec.rb
+++ b/spec/octokit/client/actions_workflows_spec.rb
@@ -55,8 +55,8 @@ describe Octokit::Client::ActionsWorkflows do
       assert_requested request
     end
 
-    context 'with return_run_details option explicitly false' do
-      it 'returns a boolean' do
+    context 'with return_run_details option' do
+      it 'returns a boolean when set to false' do
         wf_file = 'simple_workflow.yml'
         http_stub = stub_post("/repos/#{@test_repo}/actions/workflows/#{wf_file}/dispatches")
 
@@ -65,9 +65,7 @@ describe Octokit::Client::ActionsWorkflows do
         expect(output).to be(true).or be(false)
         assert_requested http_stub
       end
-    end
 
-    context 'with return_run_details option' do
       it 'gets run details from API response' do
         wf_file = 'simple_workflow.yml'
         # rubocop:disable Style/NumericLiterals

--- a/spec/octokit/client/actions_workflows_spec.rb
+++ b/spec/octokit/client/actions_workflows_spec.rb
@@ -54,6 +54,27 @@ describe Octokit::Client::ActionsWorkflows do
       @client.workflow_dispatch(@test_repo, workflow_file_name, 'main')
       assert_requested request
     end
+
+    context 'with return_run_details option' do
+      it 'gets run details from API response' do
+        wf_file = 'simple_workflow.yml'
+        api_response_body = { id: 123, status: 'queued' }.to_json
+        
+        http_stub = stub_post("/repos/#{@test_repo}/actions/workflows/#{wf_file}/dispatches")
+          .to_return(
+            status: 200,
+            body: api_response_body,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        output = @client.workflow_dispatch(@test_repo, wf_file, 'main', return_run_details: true)
+        
+        expect(output.class.name).to eq('Sawyer::Resource')
+        expect(output.id).to be(123)
+        expect(output.status).to match('queued')
+        assert_requested http_stub
+      end
+    end
   end # .workflow_dispatch
 
   describe '.workflow_enable' do

--- a/spec/octokit/client/actions_workflows_spec.rb
+++ b/spec/octokit/client/actions_workflows_spec.rb
@@ -58,11 +58,13 @@ describe Octokit::Client::ActionsWorkflows do
     context 'with return_run_details option' do
       it 'gets run details from API response' do
         wf_file = 'simple_workflow.yml'
+        # rubocop:disable Style/NumericLiterals
         api_response_body = {
-          workflow_run_id: 22_103_568_458,
+          workflow_run_id: 22103568458,
           run_url: "https://api.github.com/repos/#{@test_repo}/actions/runs/22103568458",
           html_url: "https://github.com/#{@test_repo}/actions/runs/22103568458"
         }.to_json
+        # rubocop:enable Style/NumericLiterals
 
         http_stub = stub_post("/repos/#{@test_repo}/actions/workflows/#{wf_file}/dispatches")
                     .to_return(
@@ -74,7 +76,7 @@ describe Octokit::Client::ActionsWorkflows do
         output = @client.workflow_dispatch(@test_repo, wf_file, 'main', return_run_details: true)
 
         expect(output.class.name).to eq('Sawyer::Resource')
-        expect(output.workflow_run_id).to be(22_103_568_458)
+        expect(output.workflow_run_id).to be(22103568458) # rubocop:disable Style/NumericLiterals
         expect(output.run_url).to match('actions/runs/22103568458')
         expect(output.html_url).to match("github.com/#{@test_repo}/actions/runs/22103568458")
         assert_requested http_stub

--- a/spec/octokit/client/actions_workflows_spec.rb
+++ b/spec/octokit/client/actions_workflows_spec.rb
@@ -59,16 +59,16 @@ describe Octokit::Client::ActionsWorkflows do
       it 'gets run details from API response' do
         wf_file = 'simple_workflow.yml'
         api_response_body = { id: 123, status: 'queued' }.to_json
-        
+
         http_stub = stub_post("/repos/#{@test_repo}/actions/workflows/#{wf_file}/dispatches")
-          .to_return(
-            status: 200,
-            body: api_response_body,
-            headers: { 'Content-Type' => 'application/json' }
-          )
+                    .to_return(
+                      status: 200,
+                      body: api_response_body,
+                      headers: { 'Content-Type' => 'application/json' }
+                    )
 
         output = @client.workflow_dispatch(@test_repo, wf_file, 'main', return_run_details: true)
-        
+
         expect(output.class.name).to eq('Sawyer::Resource')
         expect(output.id).to be(123)
         expect(output.status).to match('queued')

--- a/spec/octokit/client/actions_workflows_spec.rb
+++ b/spec/octokit/client/actions_workflows_spec.rb
@@ -55,6 +55,18 @@ describe Octokit::Client::ActionsWorkflows do
       assert_requested request
     end
 
+    context 'with return_run_details option explicitly false' do
+      it 'returns a boolean' do
+        wf_file = 'simple_workflow.yml'
+        http_stub = stub_post("/repos/#{@test_repo}/actions/workflows/#{wf_file}/dispatches")
+
+        output = @client.workflow_dispatch(@test_repo, wf_file, 'main', return_run_details: false)
+
+        expect(output).to be(true).or be(false)
+        assert_requested http_stub
+      end
+    end
+
     context 'with return_run_details option' do
       it 'gets run details from API response' do
         wf_file = 'simple_workflow.yml'

--- a/spec/octokit/client/actions_workflows_spec.rb
+++ b/spec/octokit/client/actions_workflows_spec.rb
@@ -58,7 +58,11 @@ describe Octokit::Client::ActionsWorkflows do
     context 'with return_run_details option' do
       it 'gets run details from API response' do
         wf_file = 'simple_workflow.yml'
-        api_response_body = { id: 123, status: 'queued' }.to_json
+        api_response_body = {
+          workflow_run_id: 22_103_568_458,
+          run_url: "https://api.github.com/repos/#{@test_repo}/actions/runs/22103568458",
+          html_url: "https://github.com/#{@test_repo}/actions/runs/22103568458"
+        }.to_json
 
         http_stub = stub_post("/repos/#{@test_repo}/actions/workflows/#{wf_file}/dispatches")
                     .to_return(
@@ -70,8 +74,9 @@ describe Octokit::Client::ActionsWorkflows do
         output = @client.workflow_dispatch(@test_repo, wf_file, 'main', return_run_details: true)
 
         expect(output.class.name).to eq('Sawyer::Resource')
-        expect(output.id).to be(123)
-        expect(output.status).to match('queued')
+        expect(output.workflow_run_id).to be(22_103_568_458)
+        expect(output.run_url).to match('actions/runs/22103568458')
+        expect(output.html_url).to match("github.com/#{@test_repo}/actions/runs/22103568458")
         assert_requested http_stub
       end
     end


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/octokit/octokit.rb/issues/1799

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
* Users who try to add the newly introduced return_run_details request parameter for the create workflow dispatch endpoint will receive an error from the ruby function even though they did successfully dispatch a workflow. Also, they wouldn't be able to consume the new response body 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
* Users can pass in the return_run_details parameter as true and begin using the run details in their ruby code.

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

