### PR TITLE
Adds support for the Custom Properties API.

### DIFF
--- a/lib/octokit/client.rb
+++ b/lib/octokit/client.rb
@@ -26,6 +26,7 @@ require 'octokit/client/commit_pulls'
 require 'octokit/client/commit_branches'
 require 'octokit/client/community_profile'
 require 'octokit/client/contents'
+require 'octokit/client/custom_properties'
 require 'octokit/client/downloads'
 require 'octokit/client/dependabot_secrets'
 require 'octokit/client/deployments'
@@ -89,6 +90,7 @@ module Octokit
     include Octokit::Client::CommitBranches
     include Octokit::Client::CommunityProfile
     include Octokit::Client::Contents
+    include Octokit::Client::CustomProperties
     include Octokit::Client::DependabotSecrets
     include Octokit::Client::Deployments
     include Octokit::Client::Downloads

--- a/lib/octokit/client/custom_properties.rb
+++ b/lib/octokit/client/custom_properties.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Octokit
+  class Client
+    # Methods for the Repository Custom Properties API
+    #
+    # @see https://docs.github.com/en/rest/repos/custom-properties
+    module CustomProperties
+      # Get all custom property values for a repository
+      #
+      # @param repo [Integer, String, Repository, Hash] A GitHub repository
+      # @return [Array<Sawyer::Resource>] List of custom property values
+      # @see https://docs.github.com/en/rest/repos/custom-properties#get-all-custom-property-values-for-a-repository
+      def get_repo_custom_properties(repo, options = {})
+        get("#{Repository.path repo}/properties/values", options)
+      end
+
+      # Create or update custom property values for a repository
+      #
+      # @param repo [Integer, String, Repository, Hash] A GitHub repository
+      # @param properties [Array<Hash>] List of custom property names and associated values
+      # @option properties [String] :property_name The name of the property
+      # @option properties [String, Array<String>, nil] :value The value of the property
+      # @return [Boolean] True on success
+      # @see https://docs.github.com/en/rest/repos/custom-properties#create-or-update-custom-property-values-for-a-repository
+      def update_repo_custom_properties(repo, properties, options = {})
+        options[:properties] = properties
+        patch("#{Repository.path repo}/properties/values", options)
+      end
+    end
+  end
+end

--- a/spec/octokit/client/custom_properties_spec.rb
+++ b/spec/octokit/client/custom_properties_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+describe Octokit::Client::CustomProperties do
+  before do
+    Octokit.reset!
+    @client = oauth_client
+  end
+
+  after do
+    Octokit.reset!
+  end
+
+  describe '.get_repo_custom_properties' do
+    before do
+      VCR.turn_off!
+      stub_request(:get, github_url("/repos/#{@test_repo}/properties/values"))
+        .to_return(
+          status: 200,
+          body: [{ property_name: 'environment', value: 'production' }].to_json,
+          headers: { content_type: 'application/json' }
+        )
+    end
+
+    after do
+      VCR.turn_on!
+    end
+
+    it 'returns custom property values for a repository' do
+      properties = @client.get_repo_custom_properties(@test_repo)
+      expect(properties).to be_kind_of Array
+      assert_requested :get, github_url("/repos/#{@test_repo}/properties/values")
+    end
+  end # .get_repo_custom_properties
+
+  describe '.update_repo_custom_properties' do
+    before do
+      VCR.turn_off!
+      stub_request(:patch, github_url("/repos/#{@test_repo}/properties/values"))
+        .to_return(status: 204, body: nil)
+    end
+
+    after do
+      VCR.turn_on!
+    end
+
+    it 'updates custom property values for a repository' do
+      properties = [{ property_name: 'environment', value: 'production' }]
+      @client.update_repo_custom_properties(@test_repo, properties)
+      assert_requested :patch, github_url("/repos/#{@test_repo}/properties/values")
+    end
+  end # .update_repo_custom_properties
+end


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1726

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
* Octokit.rb had no client methods for the Repository Custom Properties REST API, so callers could not get or update custom property values on a repository.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
* Adds `Octokit::Client::CustomProperties` with:
  * `#get_repo_custom_properties(repo)` — get all custom property values for a repository
  * `#update_repo_custom_properties(repo, properties)` — create or update custom property values for a repository
* Wires the module into `Octokit::Client` and adds specs for the new methods.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->
Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!
- [ ] Yes
- [x] No

----